### PR TITLE
fix: add missing event types to VALID_EVENT_TYPES

### DIFF
--- a/app/webhooks/services/event_processor.py
+++ b/app/webhooks/services/event_processor.py
@@ -40,6 +40,8 @@ class EventProcessor:
         "payment_failure",
         "refund_issued",
         "invoice_paid",
+        "payment_action_required",
+        "checkout_completed",
         # Subscription events
         "subscription_created",
         "subscription_updated",


### PR DESCRIPTION
## Summary

- Adds `payment_action_required` and `checkout_completed` to `EventProcessor.VALID_EVENT_TYPES`
- Fixes production Sentry error: `ValueError: Invalid event type: payment_action_required`
- Both types are already mapped by the Stripe source plugin and used across 6+ places in the codebase — they were simply omitted from the validation gate

## Test plan

- [x] `uv run pytest tests/test_event_processing.py` — 79 tests pass
- [x] `uv run pytest tests/test_stripe_billing.py` — pass
- [x] `uv run pytest tests/test_event_consolidation.py` — pass
- [x] `uv run ruff check` and `uv run ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)