### PR TITLE
ci: limit Dependabot Django updates to LTS releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Only follow Django LTS releases (the x.2 series: 5.2, 6.2, ...).
+      # Extend these ranges when a new major series approaches.
+      - dependency-name: "django"
+        versions: [">=6.0,<6.2", ">=7.0,<7.2"]
+      - dependency-name: "django-stubs"
+        versions: [">=6.0,<6.2", ">=7.0,<7.2"]
+      - dependency-name: "django-stubs-ext"
+        versions: [">=6.0,<6.2", ">=7.0,<7.2"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Adds Dependabot `ignore` rules so `django`, `django-stubs`, and `django-stubs-ext` are only bumped to LTS series (x.2: 5.2, 6.2, ...). Non-LTS series 6.0/6.1 and 7.0/7.1 are ignored; extend the ranges when a new major series approaches.

Follow-up to declining the Django 6.0 bump in #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)