### PR TITLE
fix: validate webhook signatures before rate limiting, logging, and storage

### DIFF
--- a/app/plugins/sources/base.py
+++ b/app/plugins/sources/base.py
@@ -17,7 +17,9 @@ from plugins.base import BasePlugin, PluginMetadata
 logger = logging.getLogger(__name__)
 
 # Webhook signature headers whose values must never be logged.
-# Mirrors the masking policy of WebhookStorageService._extract_safe_headers.
+# Follows the same mask-as-[PRESENT] policy as
+# WebhookStorageService._extract_safe_headers, but covers a broader set
+# (e.g. the legacy X-Chargify-Webhook-Signature header).
 _SENSITIVE_HEADERS: frozenset[str] = frozenset(
     {
         "stripe-signature",

--- a/app/plugins/sources/base.py
+++ b/app/plugins/sources/base.py
@@ -6,6 +6,7 @@ external services, validating signatures and parsing event data.
 
 import logging
 from abc import abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -14,6 +15,42 @@ from django.http import HttpRequest
 from plugins.base import BasePlugin, PluginMetadata
 
 logger = logging.getLogger(__name__)
+
+# Webhook signature headers whose values must never be logged.
+# Mirrors the masking policy of WebhookStorageService._extract_safe_headers.
+_SENSITIVE_HEADERS: frozenset[str] = frozenset(
+    {
+        "stripe-signature",
+        "x-chargify-webhook-signature",
+        "x-chargify-webhook-signature-hmac-sha-256",
+    }
+)
+_SENSITIVE_HEADER_PREFIXES: tuple[str, ...] = ("x-shopify-hmac",)
+
+
+def mask_sensitive_headers(headers: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a copy of request headers with signature values masked.
+
+    Signature headers (Stripe-Signature, X-Chargify-Webhook-Signature*,
+    X-Shopify-Hmac-*) are replaced with "[PRESENT]" so their values never
+    leak into log sinks.
+
+    Args:
+        headers: Request headers mapping (e.g. ``request.headers``).
+
+    Returns:
+        Dictionary of headers safe for logging.
+    """
+    masked: dict[str, Any] = {}
+    for name, value in headers.items():
+        lowered = name.lower()
+        if lowered in _SENSITIVE_HEADERS or lowered.startswith(
+            _SENSITIVE_HEADER_PREFIXES
+        ):
+            masked[name] = "[PRESENT]"
+        else:
+            masked[name] = value
+    return masked
 
 
 # Exceptions for source plugins

--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -19,6 +19,7 @@ from plugins.sources.base import (
     BaseSourcePlugin,
     CustomerNotFoundError,
     InvalidDataError,
+    mask_sensitive_headers,
 )
 
 logger = logging.getLogger(__name__)
@@ -195,23 +196,15 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         Returns:
             True if webhook is valid, False otherwise.
         """
-        from django.conf import settings as django_settings
-
         try:
-            # For development/testing ONLY: allow bypassing validation when
-            # webhook secret is empty. This MUST NOT work in production.
+            # Never bypass validation: an empty webhook secret means we
+            # cannot verify the signature, so reject (even with DEBUG=True).
             if not self.webhook_secret:
-                if not django_settings.DEBUG:
-                    logger.error(
-                        "SECURITY: Webhook secret not configured in production! "
-                        "Rejecting webhook to prevent unauthorized access."
-                    )
-                    return False
-                logger.warning(
-                    "Webhook secret not configured - bypassing validation for "
-                    "development. This would be rejected in production."
+                logger.error(
+                    "SECURITY: Webhook secret not configured! "
+                    "Rejecting webhook to prevent unauthorized access."
                 )
-                return True
+                return False
 
             # Validate timestamp first
             if not self._validate_webhook_timestamp(request):
@@ -234,7 +227,7 @@ class ChargifySourcePlugin(BaseSourcePlugin):
                     "has_signature": bool(signature),
                     "signature_type": "sha256" if use_sha256 else "md5",
                     "content_type": request.content_type,
-                    "headers": dict(request.headers),
+                    "headers": mask_sensitive_headers(request.headers),
                 },
             )
 
@@ -268,7 +261,7 @@ class ChargifySourcePlugin(BaseSourcePlugin):
                     hashlib.md5,
                 ).hexdigest()
 
-            # Log raw data for debugging
+            # Log validation context for debugging (never signature values)
             logger.debug(
                 "Webhook signature details",
                 extra={
@@ -276,8 +269,6 @@ class ChargifySourcePlugin(BaseSourcePlugin):
                     "body_length": len(body),
                     "secret_length": len(self.webhook_secret),
                     "signature_type": "sha256" if use_sha256 else "md5",
-                    "expected_signature": expected_signature,
-                    "received_signature": signature,
                 },
             )
 
@@ -290,8 +281,6 @@ class ChargifySourcePlugin(BaseSourcePlugin):
                     extra={
                         "webhook_id": webhook_id,
                         "signature_type": "sha256" if use_sha256 else "md5",
-                        "expected_signature": expected_signature,
-                        "received_signature": signature,
                     },
                 )
 
@@ -660,7 +649,7 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             extra={
                 "content_type": request.content_type,
                 "form_data": (request.POST.dict() if request.POST else None),
-                "headers": dict(request.headers),
+                "headers": mask_sensitive_headers(request.headers),
             },
         )
 

--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -98,12 +98,13 @@ class StripeSourcePlugin(BaseSourcePlugin):
         if settings.DISABLE_BILLING:
             return False
 
-        logger.info(
+        # Pre-validation: log only minimal, non-attacker-controlled fields
+        # so unauthenticated callers cannot flood logs with payload content.
+        logger.debug(
             "Validate Stripe webhook data",
             extra={
                 "content_type": request.content_type,
-                "form_data": (request.POST.dict() if request.POST else None),
-                "headers": mask_sensitive_headers(request.headers),
+                "content_length": request.headers.get("Content-Length"),
             },
         )
 

--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -13,7 +13,11 @@ from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpRequest
 from plugins.base import PluginCapability, PluginMetadata, PluginType
-from plugins.sources.base import BaseSourcePlugin, InvalidDataError
+from plugins.sources.base import (
+    BaseSourcePlugin,
+    InvalidDataError,
+    mask_sensitive_headers,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +103,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
             extra={
                 "content_type": request.content_type,
                 "form_data": (request.POST.dict() if request.POST else None),
-                "headers": dict(request.headers),
+                "headers": mask_sensitive_headers(request.headers),
             },
         )
 
@@ -811,7 +815,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
             extra={
                 "content_type": request.content_type,
                 "form_data": (request.POST.dict() if request.POST else None),
-                "headers": dict(request.headers),
+                "headers": mask_sensitive_headers(request.headers),
             },
         )
 

--- a/app/webhooks/webhook_router.py
+++ b/app/webhooks/webhook_router.py
@@ -410,19 +410,20 @@ def _process_webhook(
         if not provider.validate_webhook(request):
             raise WebhookSignatureError()
 
-        # Log/store raw webhook payload only after signature validation
-        _log_webhook_payload(
-            request,
-            log_provider_name or provider_name,
-            str(workspace.uuid) if workspace else None,
-        )
-
         # Enforce workspace rate limits on authenticated requests only.
         # A single enforce_rate_limit call increments usage once and
         # returns the info reused for response headers.
         rate_limit_response, rate_limit_info = _handle_rate_limiting(workspace)
         if rate_limit_response:
             return rate_limit_response
+
+        # Log/store raw webhook payload only for authenticated,
+        # non-rate-limited requests
+        _log_webhook_payload(
+            request,
+            log_provider_name or provider_name,
+            str(workspace.uuid) if workspace else None,
+        )
 
         # Parse webhook (returns None for test webhooks)
         event_data = cast("Dict[str, Any] | None", provider.parse_webhook(request))

--- a/app/webhooks/webhook_router.py
+++ b/app/webhooks/webhook_router.py
@@ -131,7 +131,7 @@ def create_error_response(error: Exception, status_code: int = 500) -> dict:
 
 
 def _handle_rate_limiting(
-    workspace: Workspace,
+    workspace: Optional[Workspace],
 ) -> tuple[Optional[JsonResponse], Optional[Dict[str, Any]]]:
     """
     Handle rate limiting for workspace.
@@ -391,7 +391,7 @@ def _process_webhook(
     request: HttpRequest,
     provider: Any,
     provider_name: str,
-    workspace: Workspace = None,
+    workspace: Workspace | None = None,
     integration: Integration | None = None,
     log_provider_name: str | None = None,
 ) -> JsonResponse:

--- a/app/webhooks/webhook_router.py
+++ b/app/webhooks/webhook_router.py
@@ -130,13 +130,19 @@ def create_error_response(error: Exception, status_code: int = 500) -> dict:
     }
 
 
-def _handle_rate_limiting(workspace: Workspace) -> Optional[JsonResponse]:
+def _handle_rate_limiting(
+    workspace: Workspace,
+) -> tuple[Optional[JsonResponse], Optional[Dict[str, Any]]]:
     """
     Handle rate limiting for workspace.
-    Returns response if rate limited, None otherwise.
+
+    Returns a tuple of (error_response, rate_limit_info). error_response
+    is a 429 JsonResponse if the workspace is rate limited, None otherwise.
+    rate_limit_info is returned when the request is allowed so callers can
+    reuse it for response headers without consuming additional quota.
     """
     if not workspace:
-        return None
+        return None, None
 
     try:
         rate_limit_info = rate_limiter.enforce_rate_limit(workspace)
@@ -144,7 +150,7 @@ def _handle_rate_limiting(workspace: Workspace) -> Optional[JsonResponse]:
             f"Rate limit check passed for workspace {workspace.uuid}: "
             f"{rate_limit_info['current_usage']}/{rate_limit_info['limit']}"
         )
-        return None  # No rate limiting
+        return None, rate_limit_info  # No rate limiting
     except RateLimitException as e:
         logger.warning(f"Rate limit exceeded for workspace {workspace.uuid}: {str(e)}")
         error_response = create_error_response(e, 429)
@@ -163,18 +169,7 @@ def _handle_rate_limiting(workspace: Workspace) -> Optional[JsonResponse]:
         for header_name, header_value in rate_limit_headers.items():
             response[header_name] = header_value
 
-        return response
-
-
-def _validate_and_parse_webhook(
-    request: HttpRequest, provider: Any
-) -> Optional[Dict[str, Any]]:
-    """Validate and parse webhook. Returns None for test webhooks."""
-    if not provider.validate_webhook(request):
-        raise WebhookSignatureError()
-
-    event_data = provider.parse_webhook(request)
-    return cast("Dict[str, Any] | None", event_data)
+        return response, None
 
 
 def _add_rate_limit_headers(
@@ -398,26 +393,39 @@ def _process_webhook(
     provider_name: str,
     workspace: Workspace = None,
     integration: Integration | None = None,
+    log_provider_name: str | None = None,
 ) -> JsonResponse:
     """
     Common webhook processing logic with standardized error handling
     and rate limiting.
 
+    Validates the webhook signature FIRST - before rate limiting, payload
+    logging, and storage - so unauthenticated requests cannot consume
+    workspace quota or persist attacker-controlled data.
+
     Uses workspace-specific Slack integration for notifications.
     """
     try:
-        # Handle rate limiting
-        rate_limit_response = _handle_rate_limiting(workspace)
+        # Validate webhook signature before any side effects
+        if not provider.validate_webhook(request):
+            raise WebhookSignatureError()
+
+        # Log/store raw webhook payload only after signature validation
+        _log_webhook_payload(
+            request,
+            log_provider_name or provider_name,
+            str(workspace.uuid) if workspace else None,
+        )
+
+        # Enforce workspace rate limits on authenticated requests only.
+        # A single enforce_rate_limit call increments usage once and
+        # returns the info reused for response headers.
+        rate_limit_response, rate_limit_info = _handle_rate_limiting(workspace)
         if rate_limit_response:
             return rate_limit_response
 
-        # Get rate limit info for headers
-        rate_limit_info = None
-        if workspace:
-            rate_limit_info = rate_limiter.enforce_rate_limit(workspace)
-
-        # Validate and parse webhook
-        event_data = _validate_and_parse_webhook(request, provider)
+        # Parse webhook (returns None for test webhooks)
+        event_data = cast("Dict[str, Any] | None", provider.parse_webhook(request))
 
         # Stamp first successful webhook verification
         if integration is not None and integration.webhook_verified_at is None:
@@ -467,9 +475,6 @@ def customer_shopify_webhook(
     request: HttpRequest, organization_uuid: str
 ) -> JsonResponse:
     """Handle customer-specific Shopify webhook requests with rate limiting"""
-    # Log raw webhook payload before any processing
-    _log_webhook_payload(request, "shopify", organization_uuid)
-
     logger.info(
         f"Processing customer Shopify webhook for workspace {organization_uuid}",
         extra={
@@ -495,7 +500,12 @@ def customer_shopify_webhook(
         provider = ShopifySourcePlugin(webhook_secret=integration.webhook_secret)
 
         return _process_webhook(
-            request, provider, "customer_shopify", workspace, integration
+            request,
+            provider,
+            "customer_shopify",
+            workspace,
+            integration,
+            log_provider_name="shopify",
         )
 
     except Exception as e:
@@ -510,9 +520,6 @@ def customer_chargify_webhook(
     request: HttpRequest, organization_uuid: str
 ) -> JsonResponse:
     """Handle customer-specific Chargify/Maxio webhook requests with rate limiting"""
-    # Log raw webhook payload before any processing
-    _log_webhook_payload(request, "chargify", organization_uuid)
-
     logger.info(
         f"Processing customer Chargify/Maxio webhook for workspace {organization_uuid}",
         extra={
@@ -535,7 +542,12 @@ def customer_chargify_webhook(
         provider = ChargifySourcePlugin(webhook_secret=integration.webhook_secret)
 
         return _process_webhook(
-            request, provider, "customer_chargify", workspace, integration
+            request,
+            provider,
+            "customer_chargify",
+            workspace,
+            integration,
+            log_provider_name="chargify",
         )
 
     except Exception as e:
@@ -552,9 +564,6 @@ def customer_stripe_webhook(
     request: HttpRequest, organization_uuid: str
 ) -> JsonResponse:
     """Handle customer-specific Stripe webhook requests with rate limiting"""
-    # Log raw webhook payload before any processing
-    _log_webhook_payload(request, "stripe", organization_uuid)
-
     logger.info(
         f"Processing customer Stripe webhook for workspace {organization_uuid}",
         extra={
@@ -580,7 +589,12 @@ def customer_stripe_webhook(
         provider = StripeSourcePlugin(webhook_secret=integration.webhook_secret)
 
         return _process_webhook(
-            request, provider, "customer_stripe", workspace, integration
+            request,
+            provider,
+            "customer_stripe",
+            workspace,
+            integration,
+            log_provider_name="stripe",
         )
 
     except Exception as e:
@@ -596,9 +610,6 @@ def customer_stripe_webhook(
 @require_http_methods(["POST"])
 def billing_stripe_webhook(request: HttpRequest) -> JsonResponse:
     """Handle global Stripe billing webhooks for Notipus revenue"""
-    # Log raw webhook payload before any processing
-    _log_webhook_payload(request, "stripe_billing")
-
     logger.info(
         "Processing global billing Stripe webhook",
         extra={"content_type": request.content_type},
@@ -626,7 +637,9 @@ def billing_stripe_webhook(request: HttpRequest) -> JsonResponse:
 
         provider = StripeSourcePlugin(webhook_secret=billing_integration.webhook_secret)
 
-        return _process_webhook(request, provider, "billing_stripe")
+        return _process_webhook(
+            request, provider, "billing_stripe", log_provider_name="stripe_billing"
+        )
 
     except Exception as e:
         logger.error(f"Error in billing Stripe webhook: {str(e)}", exc_info=True)

--- a/tests/test_chargify_webhooks_comprehensive.py
+++ b/tests/test_chargify_webhooks_comprehensive.py
@@ -95,10 +95,14 @@ class TestChargifyWebhookValidation:
         with patch("hmac.compare_digest", return_value=False):
             assert provider.validate_webhook(request) is False
 
-    def test_no_secret_configured_bypasses_validation_in_debug(
+    def test_no_secret_configured_rejects_even_in_debug(
         self, request_factory, settings
     ):
-        """Test that missing webhook secret bypasses validation in DEBUG mode only"""
+        """Test that missing webhook secret rejects even in DEBUG mode.
+
+        There is no development bypass: an empty secret means the signature
+        cannot be verified, so the webhook must be rejected.
+        """
         provider = ChargifySourcePlugin(webhook_secret="")
 
         request = request_factory.post(
@@ -107,9 +111,9 @@ class TestChargifyWebhookValidation:
             content_type="application/x-www-form-urlencoded",
         )
 
-        # In DEBUG mode, empty secret should bypass validation
+        # Even in DEBUG mode, empty secret must reject
         settings.DEBUG = True
-        assert provider.validate_webhook(request) is True
+        assert provider.validate_webhook(request) is False
 
     def test_no_secret_configured_rejects_in_production(
         self, request_factory, settings

--- a/tests/webhooks/test_webhook_auth_ordering.py
+++ b/tests/webhooks/test_webhook_auth_ordering.py
@@ -1,0 +1,154 @@
+"""Tests for webhook authentication ordering (issue #75).
+
+Signature validation must run before any side effects: rate limiting
+(quota billing), payload logging, and Redis storage. Unauthenticated
+requests must not consume workspace quota, must not persist payloads,
+and must never leak signature values into logs.
+"""
+
+import json
+import logging
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from core.models import Integration, Workspace
+from django.test import Client
+from webhooks.services.rate_limiter import rate_limiter
+from webhooks.services.webhook_storage import webhook_storage_service
+
+
+@pytest.fixture
+def workspace(db: Any) -> Workspace:
+    """Create a test workspace."""
+    return Workspace.objects.create(
+        name="Test Workspace",
+        shop_domain="test.myshopify.com",
+    )
+
+
+@pytest.fixture
+def stripe_integration(workspace: Workspace) -> Integration:
+    """Create a Stripe customer integration."""
+    return Integration.objects.create(
+        workspace=workspace,
+        integration_type="stripe_customer",
+        webhook_secret="whsec_test_secret_123",
+        is_active=True,
+    )
+
+
+def _all_captured_log_text(caplog: pytest.LogCaptureFixture) -> str:
+    """Collect all captured log output including extra record attributes."""
+    parts = [caplog.text]
+    parts.extend(str(vars(record)) for record in caplog.records)
+    return "\n".join(parts)
+
+
+@pytest.mark.django_db
+class TestWebhookAuthOrdering:
+    """Signature validation must precede rate limiting, logging, storage."""
+
+    def test_unsigned_webhook_does_not_consume_quota_or_store(
+        self,
+        client: Client,
+        workspace: Workspace,
+        stripe_integration: Integration,
+        settings: Any,
+    ) -> None:
+        """An empty, unsigned POST must not bill quota or persist a payload."""
+        settings.LOG_WEBHOOKS = True
+
+        url = f"/webhook/customer/{workspace.uuid}/stripe/"
+        with (
+            patch.object(rate_limiter, "enforce_rate_limit") as mock_enforce,
+            patch.object(rate_limiter, "increment_usage") as mock_increment,
+            patch.object(webhook_storage_service, "store_webhook") as mock_store,
+        ):
+            response = client.post(url, data="", content_type="application/json")
+
+        assert response.status_code == 400
+        mock_enforce.assert_not_called()
+        mock_increment.assert_not_called()
+        mock_store.assert_not_called()
+
+    def test_invalid_stripe_signature_value_not_logged(
+        self,
+        client: Client,
+        workspace: Workspace,
+        stripe_integration: Integration,
+        settings: Any,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An invalid Stripe-Signature value must never appear in logs."""
+        settings.LOG_WEBHOOKS = True
+        settings.DISABLE_BILLING = False
+
+        signature_canary = "t=1234567890,v1=SIGLEAKCANARYDEADBEEF"
+        url = f"/webhook/customer/{workspace.uuid}/stripe/"
+        with caplog.at_level(logging.DEBUG):
+            response = client.post(
+                url,
+                data=json.dumps({"type": "invoice.paid"}),
+                content_type="application/json",
+                HTTP_STRIPE_SIGNATURE=signature_canary,
+            )
+
+        assert response.status_code == 400
+        assert "SIGLEAKCANARYDEADBEEF" not in _all_captured_log_text(caplog)
+
+    @patch("plugins.sources.stripe.StripeSourcePlugin")
+    def test_valid_webhook_consumes_exactly_one_quota_unit(
+        self,
+        mock_provider_class: Any,
+        client: Client,
+        workspace: Workspace,
+        stripe_integration: Integration,
+    ) -> None:
+        """An accepted webhook must increment rate-limit usage exactly once."""
+        mock_provider = mock_provider_class.return_value
+        mock_provider.validate_webhook.return_value = True
+        mock_provider.parse_webhook.return_value = None  # Test webhook
+
+        url = f"/webhook/customer/{workspace.uuid}/stripe/"
+        with patch.object(
+            rate_limiter, "increment_usage", return_value=1
+        ) as mock_increment:
+            response = client.post(
+                url,
+                data=json.dumps({"type": "test"}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        mock_increment.assert_called_once()
+
+    @patch("plugins.sources.stripe.StripeSourcePlugin")
+    def test_valid_webhook_is_stored_after_validation(
+        self,
+        mock_provider_class: Any,
+        client: Client,
+        workspace: Workspace,
+        stripe_integration: Integration,
+        settings: Any,
+    ) -> None:
+        """A validated webhook is still logged/stored when LOG_WEBHOOKS=True."""
+        settings.LOG_WEBHOOKS = True
+
+        mock_provider = mock_provider_class.return_value
+        mock_provider.validate_webhook.return_value = True
+        mock_provider.parse_webhook.return_value = None  # Test webhook
+
+        url = f"/webhook/customer/{workspace.uuid}/stripe/"
+        with patch.object(webhook_storage_service, "store_webhook") as mock_store:
+            response = client.post(
+                url,
+                data=json.dumps({"type": "test"}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        mock_store.assert_called_once()
+        store_args = mock_store.call_args[0]
+        assert store_args[1] == "stripe"
+        assert store_args[2] == str(workspace.uuid)

--- a/tests/webhooks/test_webhook_auth_ordering.py
+++ b/tests/webhooks/test_webhook_auth_ordering.py
@@ -8,13 +8,14 @@ and must never leak signature values into logs.
 
 import json
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from core.models import Integration, Workspace
 from django.test import Client
-from webhooks.services.rate_limiter import rate_limiter
+from webhooks.services.rate_limiter import RateLimitException, rate_limiter
 from webhooks.services.webhook_storage import webhook_storage_service
 
 
@@ -122,6 +123,45 @@ class TestWebhookAuthOrdering:
 
         assert response.status_code == 200
         mock_increment.assert_called_once()
+
+    @patch("plugins.sources.stripe.StripeSourcePlugin")
+    def test_rate_limited_webhook_is_not_logged_or_stored(
+        self,
+        mock_provider_class: Any,
+        client: Client,
+        workspace: Workspace,
+        stripe_integration: Integration,
+        settings: Any,
+    ) -> None:
+        """An authenticated but over-quota request must not be logged/stored."""
+        settings.LOG_WEBHOOKS = True
+
+        mock_provider = mock_provider_class.return_value
+        mock_provider.validate_webhook.return_value = True
+        mock_provider.parse_webhook.return_value = None  # Test webhook
+
+        url = f"/webhook/customer/{workspace.uuid}/stripe/"
+        with (
+            patch.object(
+                rate_limiter,
+                "enforce_rate_limit",
+                side_effect=RateLimitException(
+                    "Rate limit exceeded",
+                    limit=100,
+                    current_usage=100,
+                    reset_time=datetime.now(timezone.utc) + timedelta(hours=1),
+                ),
+            ),
+            patch.object(webhook_storage_service, "store_webhook") as mock_store,
+        ):
+            response = client.post(
+                url,
+                data=json.dumps({"type": "test"}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 429
+        mock_store.assert_not_called()
 
     @patch("plugins.sources.stripe.StripeSourcePlugin")
     def test_valid_webhook_is_stored_after_validation(


### PR DESCRIPTION
Fixes #75 — all five security-ordering findings from the webhook-pipeline audit (Group 1).

## Changes

1. **Signature validation now runs first.** `_process_webhook` validates the provider signature before any side effects. Rate limiting, payload logging, and Redis webhook storage only run for authenticated requests. Workspace/integration lookup stays before validation (it supplies the `webhook_secret`).
2. **Rate-limit quota no longer double-counted.** `_handle_rate_limiting` returns `(error_response, rate_limit_info)` so the second `enforce_rate_limit` call (which made every accepted webhook consume 2 quota units and doubled `X-RateLimit-Used`) is gone.
3. **`_log_webhook_payload` / `store_webhook` moved after validation** — unauthenticated payloads can no longer flood logs/Redis or plant attacker-controlled content in the debugging view.
4. **Signature values no longer logged.** New `mask_sensitive_headers()` helper in `plugins/sources/base.py` (masks `Stripe-Signature`, `X-Chargify-Webhook-Signature*`, `X-Shopify-Hmac-*` as `[PRESENT]`), used by the Stripe and Chargify plugins' log sites. Also stopped logging expected/received HMAC values in Chargify debug logs.
5. **Chargify DEBUG bypass removed.** Empty `webhook_secret` now always rejects, even with `settings.DEBUG=True`.

## Tests

New `tests/webhooks/test_webhook_auth_ordering.py`:
- unsigned empty POST → 400, no quota increment, no webhook storage record (with `LOG_WEBHOOKS=True`)
- invalid `Stripe-Signature` canary never appears in captured logs (`caplog`)
- accepted webhook increments quota exactly once and is stored post-validation

Updated `tests/test_chargify_webhooks_comprehensive.py` to assert empty-secret rejection under `DEBUG=True`.

`uv run pytest`: 793 passed. `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)