### PR TITLE
fix: stop silently dropping webhooks on dedup, dispatch, and billing failures

### DIFF
--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -8,8 +8,6 @@ import hashlib
 import hmac
 import logging
 import re
-import time
-from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Any, ClassVar, cast
 
@@ -29,8 +27,10 @@ class ChargifySourcePlugin(BaseSourcePlugin):
     """Chargify (Maxio Advanced Billing) source plugin implementation.
 
     Handles webhook validation using HMAC signatures (SHA-256 preferred,
-    with MD5 fallback), deduplication, and parsing of various subscription
-    and payment events.
+    with MD5 fallback) and parsing of various subscription and payment
+    events. Deduplication is handled at the router level via the
+    event consolidation service, keyed on the ``X-Chargify-Webhook-Id``
+    header surfaced as ``event_id`` in the parsed event data.
 
     Attributes:
         EVENT_TYPE_MAPPING: Maps Chargify event names to internal types.
@@ -69,8 +69,6 @@ class ChargifySourcePlugin(BaseSourcePlugin):
     }
 
     # Class-level constants
-    _CACHE_MAX_SIZE: ClassVar[int] = 1000
-    _DEDUP_WINDOW_SECONDS: ClassVar[int] = 300  # 5 minutes
     _TIMESTAMP_TOLERANCE_SECONDS: ClassVar[int] = 300  # 5 minutes tolerance
 
     @classmethod
@@ -101,48 +99,6 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         """
         super().__init__(webhook_secret)
         self._current_webhook_data: dict[str, Any] | None = None
-        # Instance-level cache for recently processed webhook IDs.
-        # Note: This cache is per-instance, meaning deduplication only works
-        # within a single request lifecycle. For cross-request deduplication
-        # in production, consider using Redis or another persistent store.
-        # The instance-level cache is intentional to ensure test isolation.
-        self._webhook_cache: OrderedDict[str, float] = OrderedDict()
-
-    def _check_webhook_duplicate(self, webhook_id: str) -> bool:
-        """Check if a webhook ID has been processed recently.
-
-        Implements proper idempotency by tracking recently processed
-        webhook IDs with a time-based cleanup.
-
-        Args:
-            webhook_id: The webhook identifier to check.
-
-        Returns:
-            True if this is a duplicate webhook, False otherwise.
-        """
-        if not webhook_id:
-            logger.warning("No webhook ID provided for deduplication check")
-            return False
-
-        now = time.time()
-
-        # Clean up old entries
-        cutoff = now - self._DEDUP_WINDOW_SECONDS
-        expired_keys = [k for k, v in self._webhook_cache.items() if v <= cutoff]
-        for key in expired_keys:
-            del self._webhook_cache[key]
-
-        # Check if webhook ID has been processed
-        if webhook_id in self._webhook_cache:
-            logger.info(f"Duplicate webhook detected: {webhook_id}")
-            return True
-
-        # Add to cache
-        self._webhook_cache[webhook_id] = now
-        if len(self._webhook_cache) > self._CACHE_MAX_SIZE:
-            self._webhook_cache.popitem(last=False)  # Remove oldest
-
-        return False
 
     def _validate_webhook_timestamp(self, request: HttpRequest) -> bool:
         """Validate webhook timestamp to prevent replay attacks.
@@ -585,24 +541,23 @@ class ChargifySourcePlugin(BaseSourcePlugin):
     def _handle_chargify_event(
         self, event_type: str, customer_id: str, data: dict[str, Any], webhook_id: str
     ) -> dict[str, Any]:
-        """Route webhook event to appropriate handler with deduplication.
+        """Route webhook event to appropriate handler.
+
+        Deduplication happens at the router level (event consolidation
+        service), keyed on the webhook id surfaced via ``event_id``.
 
         Args:
             event_type: The webhook event type.
             customer_id: Customer identifier.
             data: Form data dictionary.
-            webhook_id: Webhook identifier for deduplication.
+            webhook_id: Webhook identifier (used for logging).
 
         Returns:
             Parsed event data dictionary.
 
         Raises:
-            InvalidDataError: If webhook is duplicate or event type unsupported.
+            InvalidDataError: If event type is unsupported.
         """
-        # Check for duplicates using webhook ID (proper idempotency)
-        if self._check_webhook_duplicate(webhook_id):
-            raise InvalidDataError(f"Duplicate webhook: {webhook_id}")
-
         if event_type == "payment_success":
             return self._parse_payment_success(data)
         elif event_type == "payment_failure":
@@ -642,7 +597,8 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             Parsed event data dictionary.
 
         Raises:
-            InvalidDataError: If webhook data is invalid.
+            InvalidDataError: If webhook data is invalid or the
+                ``X-Chargify-Webhook-Id`` header is missing.
         """
         logger.info(
             "Parsing Chargify webhook data",
@@ -662,9 +618,18 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         # Get event info
         event_type, customer_id = self._get_chargify_event_info(data)
 
-        # Handle the event
+        # The webhook id is required: it is the deduplication key, so a
+        # missing id must be a validation failure (400) rather than a
+        # webhook that bypasses dedup on every retry.
         webhook_id = request.headers.get("X-Chargify-Webhook-Id", "")
-        return self._handle_chargify_event(event_type, customer_id, data, webhook_id)
+        if not webhook_id:
+            raise InvalidDataError("Missing X-Chargify-Webhook-Id header")
+
+        event = self._handle_chargify_event(event_type, customer_id, data, webhook_id)
+
+        # Surface the webhook id so the router can deduplicate retries
+        event["event_id"] = webhook_id
+        return event
 
     def _parse_shopify_order_ref(self, memo: str) -> str | None:
         """Extract Shopify order reference from transaction memo.

--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -402,6 +402,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
         data: dict[str, Any],
         amount: float,
         idempotency_key: str | None = None,
+        event_id: str | None = None,
     ) -> dict[str, Any]:
         """Build Stripe event data structure.
 
@@ -411,6 +412,10 @@ class StripeSourcePlugin(BaseSourcePlugin):
             data: Raw event data.
             amount: Payment amount in dollars.
             idempotency_key: Stripe request idempotency key for deduplication.
+            event_id: Stripe event id (``evt_...``) from the outer event
+                envelope, used for exact deduplication. Distinct from
+                ``external_id``, which is the underlying object id
+                (e.g. ``sub_...`` or ``in_...``).
 
         Returns:
             Standardized event data dictionary.
@@ -420,6 +425,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
             "customer_id": customer_id,
             "provider": self.PROVIDER_NAME,
             "external_id": data.get("id", ""),
+            "event_id": event_id,
             "status": data.get("status"),
             "created_at": data.get("created"),
             "currency": str(data.get("currency", "USD")).upper(),
@@ -840,6 +846,11 @@ class StripeSourcePlugin(BaseSourcePlugin):
         # All events triggered by the same Stripe API request share this key
         idempotency_key = self._extract_idempotency_key(event)
 
+        # Extract the Stripe event id (evt_...) from the outer envelope for
+        # exact deduplication. The object id alone would make distinct events
+        # for the same object (e.g. created + updated) collide.
+        event_id = cast("str | None", getattr(event, "id", None))
+
         # Extract event info using Stripe event object
         event_type, data = self._extract_stripe_event_info(event)
 
@@ -886,7 +897,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
 
             # Build and return event data
             return self._build_stripe_event_data(
-                event_type, customer_id, data_dict, amount, idempotency_key
+                event_type, customer_id, data_dict, amount, idempotency_key, event_id
             )
 
         except (KeyError, ValueError, AttributeError) as e:

--- a/app/webhooks/services/billing.py
+++ b/app/webhooks/services/billing.py
@@ -2,12 +2,18 @@
 
 This module processes billing-related webhook events from Stripe
 and updates workspace subscription status accordingly.
+
+Handlers distinguish expected no-ops (missing customer id, no matching
+workspace) from unexpected errors: expected no-ops are logged and return
+normally, while unexpected errors (e.g. database failures) propagate so
+the webhook view returns 5xx and Stripe redelivers the event.
 """
 
 import logging
 from datetime import datetime, timezone
 from typing import Any, cast
 
+import stripe
 from core.models import Workspace
 from core.services.stripe import StripeAPI
 
@@ -98,55 +104,58 @@ class BillingService:
 
         Returns:
             True if sync was successful, False otherwise.
+
+        Raises:
+            Exception: Unexpected errors (e.g. database failures) propagate
+                so webhook callers return 5xx and Stripe retries. Only
+                Stripe API errors are swallowed (the sync is best-effort
+                refinement after the primary update already succeeded).
         """
+        workspace = Workspace.objects.filter(stripe_customer_id=customer_id).first()
+
+        if not workspace:
+            logger.warning(f"No workspace found for customer {customer_id} during sync")
+            return False
+
         try:
-            workspace = Workspace.objects.filter(stripe_customer_id=customer_id).first()
-
-            if not workspace:
-                logger.warning(
-                    f"No workspace found for customer {customer_id} during sync"
-                )
-                return False
-
             stripe_api = StripeAPI()
             subscriptions = stripe_api.get_customer_subscriptions(
                 customer_id, status="all"
             )
-
-            if not subscriptions:
-                logger.info(f"No subscriptions found for customer {customer_id}")
-                return True
-
-            active_sub = BillingService._get_active_subscription(subscriptions)
-            stripe_status = active_sub.get("status", "active")
-            internal_status = STRIPE_STATUS_MAPPING.get(stripe_status, "active")
-            plan_name = BillingService._extract_plan_name_from_subscription(active_sub)
-
-            # Build update data
-            update_data: dict[str, Any] = {"subscription_status": internal_status}
-
-            if plan_name:
-                update_data["subscription_plan"] = plan_name
-
-            if active_sub.get("current_period_end"):
-                update_data["billing_cycle_anchor"] = active_sub["current_period_end"]
-
-            if stripe_status == "trialing" and active_sub.get("current_period_end"):
-                update_data["trial_end_date"] = datetime.fromtimestamp(
-                    active_sub["current_period_end"], tz=timezone.utc
-                )
-
-            Workspace.objects.filter(id=workspace.id).update(**update_data)
-
-            logger.info(
-                f"Synced workspace {workspace.name} from Stripe: "
-                f"status={internal_status}, plan={plan_name}"
-            )
-            return True
-
-        except Exception as e:
+        except stripe.StripeError as e:
             logger.error(f"Error syncing workspace from Stripe: {e!s}")
             return False
+
+        if not subscriptions:
+            logger.info(f"No subscriptions found for customer {customer_id}")
+            return True
+
+        active_sub = BillingService._get_active_subscription(subscriptions)
+        stripe_status = active_sub.get("status", "active")
+        internal_status = STRIPE_STATUS_MAPPING.get(stripe_status, "active")
+        plan_name = BillingService._extract_plan_name_from_subscription(active_sub)
+
+        # Build update data
+        update_data: dict[str, Any] = {"subscription_status": internal_status}
+
+        if plan_name:
+            update_data["subscription_plan"] = plan_name
+
+        if active_sub.get("current_period_end"):
+            update_data["billing_cycle_anchor"] = active_sub["current_period_end"]
+
+        if stripe_status == "trialing" and active_sub.get("current_period_end"):
+            update_data["trial_end_date"] = datetime.fromtimestamp(
+                active_sub["current_period_end"], tz=timezone.utc
+            )
+
+        Workspace.objects.filter(id=workspace.id).update(**update_data)
+
+        logger.info(
+            f"Synced workspace {workspace.name} from Stripe: "
+            f"status={internal_status}, plan={plan_name}"
+        )
+        return True
 
     @staticmethod
     def _get_customer_id(data: dict[str, Any], data_type: str) -> str | None:
@@ -172,32 +181,24 @@ class BillingService:
         Args:
             subscription: Subscription data from Stripe webhook.
         """
-        try:
-            customer_id = BillingService._get_customer_id(subscription, "subscription")
-            if not customer_id:
-                return
+        customer_id = BillingService._get_customer_id(subscription, "subscription")
+        if not customer_id:
+            return
 
-            # Don't set subscription_plan here - sync_workspace_from_stripe will
-            # properly extract and normalize the plan name from the Product.
-            # Previously this was setting plan_id (a Price ID) which is wrong.
-            updated_count = Workspace.objects.filter(
-                stripe_customer_id=customer_id
-            ).update(
-                subscription_status="active",
-                billing_cycle_anchor=subscription.get("current_period_start"),
-            )
+        # Don't set subscription_plan here - sync_workspace_from_stripe will
+        # properly extract and normalize the plan name from the Product.
+        # Previously this was setting plan_id (a Price ID) which is wrong.
+        updated_count = Workspace.objects.filter(stripe_customer_id=customer_id).update(
+            subscription_status="active",
+            billing_cycle_anchor=subscription.get("current_period_start"),
+        )
 
-            if updated_count > 0:
-                logger.info(
-                    f"Subscription created for customer {customer_id}, syncing..."
-                )
-                # Sync full state from Stripe (properly extracts plan name)
-                BillingService.sync_workspace_from_stripe(customer_id)
-            else:
-                logger.warning(f"No workspace found for customer {customer_id}")
-
-        except Exception as e:
-            logger.error(f"Error handling subscription created: {e!s}")
+        if updated_count > 0:
+            logger.info(f"Subscription created for customer {customer_id}, syncing...")
+            # Sync full state from Stripe (properly extracts plan name)
+            BillingService.sync_workspace_from_stripe(customer_id)
+        else:
+            logger.warning(f"No workspace found for customer {customer_id}")
 
     @staticmethod
     def handle_subscription_updated(subscription: dict[str, Any]) -> None:
@@ -206,44 +207,38 @@ class BillingService:
         Args:
             subscription: Subscription data from Stripe webhook.
         """
-        try:
-            customer_id = BillingService._get_customer_id(subscription, "subscription")
-            if not customer_id:
-                return
+        customer_id = BillingService._get_customer_id(subscription, "subscription")
+        if not customer_id:
+            return
 
-            # Extract subscription status
-            status = subscription.get("status", "active")
+        # Extract subscription status
+        status = subscription.get("status", "active")
 
-            # Map Stripe statuses to our internal statuses
-            internal_status = STRIPE_STATUS_MAPPING.get(status, "active")
+        # Map Stripe statuses to our internal statuses
+        internal_status = STRIPE_STATUS_MAPPING.get(status, "active")
 
-            # Don't set subscription_plan here - sync_workspace_from_stripe will
-            # properly extract and normalize the plan name from the Product.
-            # Previously this was setting plan_id (a Price ID) which is wrong.
-            update_data: dict[str, Any] = {"subscription_status": internal_status}
+        # Don't set subscription_plan here - sync_workspace_from_stripe will
+        # properly extract and normalize the plan name from the Product.
+        # Previously this was setting plan_id (a Price ID) which is wrong.
+        update_data: dict[str, Any] = {"subscription_status": internal_status}
 
-            # Update billing cycle anchor if present
-            if subscription.get("current_period_end"):
-                update_data["billing_cycle_anchor"] = subscription.get(
-                    "current_period_end"
-                )
+        # Update billing cycle anchor if present
+        if subscription.get("current_period_end"):
+            update_data["billing_cycle_anchor"] = subscription.get("current_period_end")
 
-            updated_count = Workspace.objects.filter(
-                stripe_customer_id=customer_id
-            ).update(**update_data)
+        updated_count = Workspace.objects.filter(stripe_customer_id=customer_id).update(
+            **update_data
+        )
 
-            if updated_count > 0:
-                logger.info(
-                    f"Updated subscription status to {internal_status} "
-                    f"for customer {customer_id}, syncing..."
-                )
-                # Sync full state from Stripe (properly extracts plan name)
-                BillingService.sync_workspace_from_stripe(customer_id)
-            else:
-                logger.warning(f"No workspace found for customer {customer_id}")
-
-        except Exception as e:
-            logger.error(f"Error handling subscription updated: {e!s}")
+        if updated_count > 0:
+            logger.info(
+                f"Updated subscription status to {internal_status} "
+                f"for customer {customer_id}, syncing..."
+            )
+            # Sync full state from Stripe (properly extracts plan name)
+            BillingService.sync_workspace_from_stripe(customer_id)
+        else:
+            logger.warning(f"No workspace found for customer {customer_id}")
 
     @staticmethod
     def handle_subscription_deleted(subscription: dict[str, Any]) -> None:
@@ -252,24 +247,18 @@ class BillingService:
         Args:
             subscription: Subscription data from Stripe webhook.
         """
-        try:
-            customer_id = BillingService._get_customer_id(subscription, "subscription")
-            if not customer_id:
-                return
+        customer_id = BillingService._get_customer_id(subscription, "subscription")
+        if not customer_id:
+            return
 
-            updated_count = Workspace.objects.filter(
-                stripe_customer_id=customer_id
-            ).update(subscription_status="cancelled")
+        updated_count = Workspace.objects.filter(stripe_customer_id=customer_id).update(
+            subscription_status="cancelled"
+        )
 
-            if updated_count > 0:
-                logger.info(
-                    f"Marked subscription as cancelled for customer {customer_id}"
-                )
-            else:
-                logger.warning(f"No workspace found for customer {customer_id}")
-
-        except Exception as e:
-            logger.error(f"Error handling subscription deleted: {e!s}")
+        if updated_count > 0:
+            logger.info(f"Marked subscription as cancelled for customer {customer_id}")
+        else:
+            logger.warning(f"No workspace found for customer {customer_id}")
 
     @staticmethod
     def handle_payment_success(invoice: dict[str, Any]) -> None:
@@ -278,32 +267,26 @@ class BillingService:
         Args:
             invoice: Invoice data from Stripe webhook.
         """
-        try:
-            customer_id = invoice.get("customer")
-            if not customer_id:
-                logger.error("Missing customer ID in invoice data")
-                return
+        customer_id = invoice.get("customer")
+        if not customer_id:
+            logger.error("Missing customer ID in invoice data")
+            return
 
-            period_end = invoice.get("period_end")
+        period_end = invoice.get("period_end")
 
-            # Prepare update data
-            update_data: dict[str, Any] = {"subscription_status": "active"}
-            if period_end:
-                update_data["billing_cycle_anchor"] = period_end
+        # Prepare update data
+        update_data: dict[str, Any] = {"subscription_status": "active"}
+        if period_end:
+            update_data["billing_cycle_anchor"] = period_end
 
-            updated_count = Workspace.objects.filter(
-                stripe_customer_id=customer_id
-            ).update(**update_data)
+        updated_count = Workspace.objects.filter(stripe_customer_id=customer_id).update(
+            **update_data
+        )
 
-            if updated_count > 0:
-                logger.info(
-                    f"Updated payment status to active for customer {customer_id}"
-                )
-            else:
-                logger.warning(f"No workspace found for customer {customer_id}")
-
-        except Exception as e:
-            logger.error(f"Error handling payment success: {e!s}")
+        if updated_count > 0:
+            logger.info(f"Updated payment status to active for customer {customer_id}")
+        else:
+            logger.warning(f"No workspace found for customer {customer_id}")
 
     @staticmethod
     def handle_payment_failed(invoice: dict[str, Any]) -> None:
@@ -312,25 +295,21 @@ class BillingService:
         Args:
             invoice: Invoice data from Stripe webhook.
         """
-        try:
-            customer_id = invoice.get("customer")
-            if not customer_id:
-                logger.error("Missing customer ID in invoice data")
-                return
+        customer_id = invoice.get("customer")
+        if not customer_id:
+            logger.error("Missing customer ID in invoice data")
+            return
 
-            updated_count = Workspace.objects.filter(
-                stripe_customer_id=customer_id
-            ).update(subscription_status="past_due")
+        updated_count = Workspace.objects.filter(stripe_customer_id=customer_id).update(
+            subscription_status="past_due"
+        )
 
-            if updated_count > 0:
-                logger.warning(
-                    f"Updated payment status to past_due for customer {customer_id}"
-                )
-            else:
-                logger.warning(f"No workspace found for customer {customer_id}")
-
-        except Exception as e:
-            logger.error(f"Error handling payment failure: {e!s}")
+        if updated_count > 0:
+            logger.warning(
+                f"Updated payment status to past_due for customer {customer_id}"
+            )
+        else:
+            logger.warning(f"No workspace found for customer {customer_id}")
 
     @staticmethod
     def handle_checkout_completed(session: dict[str, Any]) -> None:
@@ -342,55 +321,49 @@ class BillingService:
         Args:
             session: Checkout session data from Stripe webhook.
         """
-        try:
-            customer_id = session.get("customer")
-            if not customer_id:
-                logger.error("Missing customer ID in checkout session")
-                return
+        customer_id = session.get("customer")
+        if not customer_id:
+            logger.error("Missing customer ID in checkout session")
+            return
 
-            # Extract metadata with workspace and plan info
-            metadata = session.get("metadata", {})
-            workspace_id = metadata.get("workspace_id") or metadata.get(
-                "organization_id"
+        # Extract metadata with workspace and plan info
+        metadata = session.get("metadata", {})
+        workspace_id = metadata.get("workspace_id") or metadata.get("organization_id")
+        plan_name = metadata.get("plan_name")
+
+        subscription_id = session.get("subscription")
+
+        # Update workspace with new subscription status
+        update_data: dict[str, Any] = {
+            "subscription_status": "active",
+            "payment_method_added": True,
+        }
+
+        if plan_name:
+            update_data["subscription_plan"] = plan_name
+
+        # Find workspace by customer ID or workspace ID from metadata
+        if workspace_id:
+            updated_count = Workspace.objects.filter(id=workspace_id).update(
+                **update_data
             )
-            plan_name = metadata.get("plan_name")
+        else:
+            updated_count = Workspace.objects.filter(
+                stripe_customer_id=customer_id
+            ).update(**update_data)
 
-            subscription_id = session.get("subscription")
-
-            # Update workspace with new subscription status
-            update_data: dict[str, Any] = {
-                "subscription_status": "active",
-                "payment_method_added": True,
-            }
-
-            if plan_name:
-                update_data["subscription_plan"] = plan_name
-
-            # Find workspace by customer ID or workspace ID from metadata
-            if workspace_id:
-                updated_count = Workspace.objects.filter(id=workspace_id).update(
-                    **update_data
-                )
-            else:
-                updated_count = Workspace.objects.filter(
-                    stripe_customer_id=customer_id
-                ).update(**update_data)
-
-            if updated_count > 0:
-                logger.info(
-                    f"Checkout completed for customer {customer_id}, "
-                    f"subscription: {subscription_id}, plan: {plan_name}"
-                )
-                # Verify/sync full state from Stripe (catches any drift)
-                BillingService.sync_workspace_from_stripe(customer_id)
-            else:
-                logger.warning(
-                    f"No workspace found for checkout session. "
-                    f"Customer: {customer_id}, Workspace ID: {workspace_id}"
-                )
-
-        except Exception as e:
-            logger.error(f"Error handling checkout completed: {e!s}")
+        if updated_count > 0:
+            logger.info(
+                f"Checkout completed for customer {customer_id}, "
+                f"subscription: {subscription_id}, plan: {plan_name}"
+            )
+            # Verify/sync full state from Stripe (catches any drift)
+            BillingService.sync_workspace_from_stripe(customer_id)
+        else:
+            logger.warning(
+                f"No workspace found for checkout session. "
+                f"Customer: {customer_id}, Workspace ID: {workspace_id}"
+            )
 
     @staticmethod
     def handle_trial_ending(subscription: dict[str, Any]) -> None:
@@ -402,28 +375,24 @@ class BillingService:
         Args:
             subscription: Subscription data from Stripe webhook.
         """
-        try:
-            customer_id = BillingService._get_customer_id(subscription, "trial ending")
-            if not customer_id:
-                return
+        customer_id = BillingService._get_customer_id(subscription, "trial ending")
+        if not customer_id:
+            return
 
-            trial_end = subscription.get("trial_end")
+        trial_end = subscription.get("trial_end")
 
-            # Find workspace and log the event
-            ws = Workspace.objects.filter(stripe_customer_id=customer_id).first()
+        # Find workspace and log the event
+        ws = Workspace.objects.filter(stripe_customer_id=customer_id).first()
 
-            if ws:
-                logger.info(
-                    f"Trial ending soon for workspace {ws.name} "
-                    f"(customer: {customer_id}), trial_end: {trial_end}"
-                )
-                # TODO: Send notification email to workspace admins
-                # TODO: Trigger Slack notification if configured
-            else:
-                logger.warning(f"Trial ending for unknown customer {customer_id}")
-
-        except Exception as e:
-            logger.error(f"Error handling trial ending: {e!s}")
+        if ws:
+            logger.info(
+                f"Trial ending soon for workspace {ws.name} "
+                f"(customer: {customer_id}), trial_end: {trial_end}"
+            )
+            # TODO: Send notification email to workspace admins
+            # TODO: Trigger Slack notification if configured
+        else:
+            logger.warning(f"Trial ending for unknown customer {customer_id}")
 
     @staticmethod
     def handle_invoice_paid(invoice: dict[str, Any]) -> None:
@@ -435,34 +404,30 @@ class BillingService:
         Args:
             invoice: Invoice data from Stripe webhook.
         """
-        try:
-            customer_id = invoice.get("customer")
-            if not customer_id:
-                logger.error("Missing customer ID in paid invoice")
-                return
+        customer_id = invoice.get("customer")
+        if not customer_id:
+            logger.error("Missing customer ID in paid invoice")
+            return
 
-            # Mark organization as active with payment method confirmed
-            update_data: dict[str, Any] = {
-                "subscription_status": "active",
-                "payment_method_added": True,
-            }
+        # Mark organization as active with payment method confirmed
+        update_data: dict[str, Any] = {
+            "subscription_status": "active",
+            "payment_method_added": True,
+        }
 
-            # Update billing cycle anchor if period_end is present
-            period_end = invoice.get("period_end")
-            if period_end:
-                update_data["billing_cycle_anchor"] = period_end
+        # Update billing cycle anchor if period_end is present
+        period_end = invoice.get("period_end")
+        if period_end:
+            update_data["billing_cycle_anchor"] = period_end
 
-            updated_count = Workspace.objects.filter(
-                stripe_customer_id=customer_id
-            ).update(**update_data)
+        updated_count = Workspace.objects.filter(stripe_customer_id=customer_id).update(
+            **update_data
+        )
 
-            if updated_count > 0:
-                logger.info(f"Invoice paid for customer {customer_id}")
-            else:
-                logger.warning(f"No workspace found for paid invoice: {customer_id}")
-
-        except Exception as e:
-            logger.error(f"Error handling invoice paid: {e!s}")
+        if updated_count > 0:
+            logger.info(f"Invoice paid for customer {customer_id}")
+        else:
+            logger.warning(f"No workspace found for paid invoice: {customer_id}")
 
     @staticmethod
     def handle_payment_action_required(invoice: dict[str, Any]) -> None:
@@ -474,28 +439,24 @@ class BillingService:
         Args:
             invoice: Invoice data from Stripe webhook.
         """
-        try:
-            customer_id = invoice.get("customer")
-            if not customer_id:
-                logger.error("Missing customer ID in action required invoice")
-                return
+        customer_id = invoice.get("customer")
+        if not customer_id:
+            logger.error("Missing customer ID in action required invoice")
+            return
 
-            hosted_invoice_url = invoice.get("hosted_invoice_url")
+        hosted_invoice_url = invoice.get("hosted_invoice_url")
 
-            # Find workspace and log the event
-            ws = Workspace.objects.filter(stripe_customer_id=customer_id).first()
+        # Find workspace and log the event
+        ws = Workspace.objects.filter(stripe_customer_id=customer_id).first()
 
-            if ws:
-                logger.warning(
-                    f"Payment action required for workspace {ws.name} "
-                    f"(customer: {customer_id}). Invoice URL: {hosted_invoice_url}"
-                )
-                # TODO: Send notification email to workspace admins
-                # with link to complete payment
-            else:
-                logger.warning(
-                    f"Payment action required for unknown customer: {customer_id}"
-                )
-
-        except Exception as e:
-            logger.error(f"Error handling payment action required: {e!s}")
+        if ws:
+            logger.warning(
+                f"Payment action required for workspace {ws.name} "
+                f"(customer: {customer_id}). Invoice URL: {hosted_invoice_url}"
+            )
+            # TODO: Send notification email to workspace admins
+            # with link to complete payment
+        else:
+            logger.warning(
+                f"Payment action required for unknown customer: {customer_id}"
+            )

--- a/app/webhooks/webhook_router.py
+++ b/app/webhooks/webhook_router.py
@@ -205,6 +205,36 @@ def _get_slack_webhook_url(workspace: Optional[Workspace]) -> Optional[str]:
         return None
 
 
+def _get_dedup_key(event_data: Dict[str, Any]) -> str:
+    """Build the deduplication key for a parsed webhook event.
+
+    Prefers the provider's unique event id (e.g. Stripe's ``evt_...`` or
+    Chargify's webhook id). Falls back to a composite of event type and
+    object id so distinct events for the same object (e.g.
+    subscription.created and subscription.updated for one subscription)
+    don't collide.
+    """
+    event_id = event_data.get("event_id")
+    if event_id:
+        return str(event_id)
+    external_id = event_data.get("external_id", "")
+    if external_id:
+        return f"{event_data.get('type', '')}:{external_id}"
+    return ""
+
+
+def _record_dedup_marker(
+    event_data: Dict[str, Any], workspace_id: str, dedup_key: str
+) -> None:
+    """Record the dedup marker for a successfully queued/dispatched event."""
+    event_consolidation_service.record_event(
+        event_type=event_data.get("type", ""),
+        customer_id=event_data.get("customer_id", ""),
+        workspace_id=workspace_id,
+        external_id=dedup_key,
+    )
+
+
 def _process_webhook_data(
     event_data: Dict[str, Any],
     provider: Any,
@@ -225,13 +255,13 @@ def _process_webhook_data(
 
     event_type = event_data.get("type", "")
     workspace_id = str(workspace.uuid) if workspace else "global"
-    external_id = event_data.get("external_id", "")
     idempotency_key = event_data.get("idempotency_key")
+    dedup_key = _get_dedup_key(event_data)
 
-    # Check for exact duplicate (same external_id) - applies to all events
-    if event_consolidation_service.is_duplicate(workspace_id, external_id):
+    # Check for exact duplicate (same provider event) - applies to all events
+    if event_consolidation_service.is_duplicate(workspace_id, dedup_key):
         logger.info(
-            f"Skipping duplicate event {external_id} for workspace {workspace_id}"
+            f"Skipping duplicate event {dedup_key} for workspace {workspace_id}"
         )
         return JsonResponse(
             create_success_response(
@@ -240,17 +270,18 @@ def _process_webhook_data(
             status=200,
         )
 
-    # Record event ID to prevent exact duplicates
-    event_consolidation_service.record_event(
-        event_type=event_type,
-        customer_id=event_data.get("customer_id", ""),
-        workspace_id=workspace_id,
-        external_id=external_id,
-    )
+    # NOTE: the dedup marker is recorded only AFTER the event has been
+    # successfully queued or dispatched. Recording it earlier would make a
+    # failed dispatch (which returns 5xx) suppress the provider's retry,
+    # permanently losing the event.
 
     # Providers with complete data in one webhook - process immediately
     if provider_name in _IMMEDIATE_PROCESSING_PROVIDERS:
-        return _process_immediately(event_data, customer_data, provider_name, workspace)
+        response = _process_immediately(
+            event_data, customer_data, provider_name, workspace
+        )
+        _record_dedup_marker(event_data, workspace_id, dedup_key)
+        return response
 
     # Queue Stripe for delayed processing (needs invoice + subscription aggregation)
     should_aggregate = event_type in _AGGREGATABLE_EVENT_TYPES
@@ -270,6 +301,9 @@ def _process_webhook_data(
             provider_name=provider_name,
             workspace=workspace,
         )
+        # Queued events are owned by our system now (orphan recovery retries
+        # failed sends), so it is safe to suppress provider retries.
+        _record_dedup_marker(event_data, workspace_id, dedup_key)
 
         # Log with truncated key for readability
         if len(aggregation_key) > 20:
@@ -284,7 +318,9 @@ def _process_webhook_data(
         )
 
     # Events WITHOUT idempotency_key that don't benefit from aggregation
-    return _process_immediately(event_data, customer_data, provider_name, workspace)
+    response = _process_immediately(event_data, customer_data, provider_name, workspace)
+    _record_dedup_marker(event_data, workspace_id, dedup_key)
+    return response
 
 
 def _process_immediately(
@@ -344,13 +380,10 @@ def _process_immediately(
                 ),
                 status=200,
             )
-        try:
-            slack_plugin.send(formatted, {"webhook_url": slack_webhook_url})
-        except Exception as e:
-            logger.error(
-                f"Failed to send Slack notification for workspace "
-                f"{workspace.uuid if workspace else 'unknown'}: {str(e)}"
-            )
+        # Let delivery failures propagate: the router then returns 5xx so
+        # the provider retries, instead of the notification being silently
+        # lost (consistent with pending_event_queue._send_notification).
+        slack_plugin.send(formatted, {"webhook_url": slack_webhook_url})
     else:
         logger.warning(
             f"No Slack webhook URL configured for workspace "
@@ -366,6 +399,7 @@ def _process_immediately(
 
 def _handle_webhook_exceptions(e: Exception, provider_name: str) -> JsonResponse:
     """Handle different types of webhook exceptions."""
+    from plugins.sources.base import WebhookError as PluginWebhookError
     from webhooks.services.rate_limiter import RateLimitException
 
     if isinstance(e, WebhookSignatureError):
@@ -377,7 +411,8 @@ def _handle_webhook_exceptions(e: Exception, provider_name: str) -> JsonResponse
         logger.info(f"Rate limit exceeded for {provider_name} webhook: {e!s}")
         error_response = create_error_response(e, 429)
         return JsonResponse(error_response, status=429)
-    elif isinstance(e, WebhookError):
+    elif isinstance(e, (WebhookError, PluginWebhookError)):
+        # Malformed/invalid webhook data - retrying won't help, return 4xx
         logger.warning(f"Webhook validation error for {provider_name}: {str(e)}")
         error_response = create_error_response(e, 400)
         return JsonResponse(error_response, status=400)
@@ -625,15 +660,15 @@ def billing_stripe_webhook(request: HttpRequest) -> JsonResponse:
         ).first()
 
         if not billing_integration:
-            # Return 200 to acknowledge receipt - don't trigger Stripe retries
-            # Log error so we know configuration is missing
+            # Server-side misconfiguration: return 5xx so Stripe retries
+            # (with its own backoff) instead of the event being lost.
             logger.error(
                 "GlobalBillingIntegration not configured for stripe_billing. "
                 "Create record with integration_type='stripe_billing', is_active=True."
             )
             return JsonResponse(
                 {"status": "error", "message": "Billing integration not configured"},
-                status=200,  # 200 to prevent Stripe retries
+                status=500,
             )
 
         provider = StripeSourcePlugin(webhook_secret=billing_integration.webhook_secret)
@@ -644,8 +679,11 @@ def billing_stripe_webhook(request: HttpRequest) -> JsonResponse:
 
     except Exception as e:
         logger.error(f"Error in billing Stripe webhook: {str(e)}", exc_info=True)
-        # Return 200 to acknowledge receipt - prevents infinite retries
+        # Transient/unknown errors must return 5xx so Stripe redelivers.
+        # Stripe has its own exponential backoff and max-attempt policy,
+        # so this does not cause infinite retries. Signature and validation
+        # errors are mapped to 4xx inside _process_webhook.
         return JsonResponse(
             {"status": "error", "message": "Internal error processing webhook"},
-            status=200,
+            status=500,
         )

--- a/tests/test_billing_webhook.py
+++ b/tests/test_billing_webhook.py
@@ -21,13 +21,14 @@ def client() -> Client:
 class TestBillingStripeWebhook:
     """Tests for the /webhook/billing/stripe/ endpoint."""
 
-    def test_missing_global_billing_integration_returns_200(
+    def test_missing_global_billing_integration_returns_500(
         self, client: Client
     ) -> None:
-        """Verify graceful handling when GlobalBillingIntegration is not configured.
+        """Verify a 5xx when GlobalBillingIntegration is not configured.
 
-        The webhook should return 200 to prevent Stripe from retrying infinitely,
-        but log an error so operators know configuration is missing.
+        Stripe retries with its own backoff, so returning 5xx means the
+        events are redelivered once configuration is fixed instead of
+        being permanently lost.
         """
         # Ensure no GlobalBillingIntegration exists
         from core.models import GlobalBillingIntegration
@@ -42,17 +43,17 @@ class TestBillingStripeWebhook:
             content_type="application/json",
         )
 
-        # Should return 200 to prevent Stripe retries
-        assert response.status_code == 200
+        # Should return 500 so Stripe retries after configuration is fixed
+        assert response.status_code == 500
         response_data = response.json()
         assert response_data["status"] == "error"
         assert "not configured" in response_data["message"]
 
     @pytest.mark.django_db
-    def test_inactive_global_billing_integration_returns_200(
+    def test_inactive_global_billing_integration_returns_500(
         self, client: Client
     ) -> None:
-        """Verify graceful handling when GlobalBillingIntegration is inactive."""
+        """Verify a 5xx when GlobalBillingIntegration is inactive."""
         from core.models import GlobalBillingIntegration
 
         # Create an inactive integration
@@ -71,8 +72,8 @@ class TestBillingStripeWebhook:
             content_type="application/json",
         )
 
-        # Should return 200 to prevent Stripe retries
-        assert response.status_code == 200
+        # Should return 500 so Stripe retries after configuration is fixed
+        assert response.status_code == 500
         response_data = response.json()
         assert response_data["status"] == "error"
         assert "not configured" in response_data["message"]
@@ -112,8 +113,8 @@ class TestBillingStripeWebhook:
             assert response.status_code == 400
 
     @pytest.mark.django_db
-    def test_exception_during_processing_returns_200(self, client: Client) -> None:
-        """Verify exceptions during processing return 200 to prevent Stripe retries."""
+    def test_exception_during_processing_returns_500(self, client: Client) -> None:
+        """Verify transient/unknown exceptions return 5xx so Stripe retries."""
         from core.models import GlobalBillingIntegration
 
         # Create an active integration
@@ -137,7 +138,7 @@ class TestBillingStripeWebhook:
                 content_type="application/json",
             )
 
-            # Should return 200 to prevent Stripe retries
-            assert response.status_code == 200
+            # Should return 500 so Stripe redelivers the event
+            assert response.status_code == 500
             response_data = response.json()
             assert response_data["status"] == "error"

--- a/tests/test_chargify_webhooks_comprehensive.py
+++ b/tests/test_chargify_webhooks_comprehensive.py
@@ -5,7 +5,6 @@ deduplication, timestamp handling, and error scenarios for the
 Chargify provider.
 """
 
-import time
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
@@ -292,69 +291,61 @@ class TestChargifyWebhookParsing:
 
 
 class TestChargifyWebhookDeduplication:
-    """Test Chargify webhook deduplication logic."""
+    """Test Chargify webhook deduplication key handling.
+
+    Deduplication itself happens at the router level via the event
+    consolidation service; the plugin's job is to surface a stable
+    dedup key (the webhook id) and reject webhooks without one.
+    """
 
     @pytest.fixture
     def provider(self) -> ChargifySourcePlugin:
-        """Create a Chargify provider with short dedup window for testing."""
+        """Create a Chargify provider instance for testing."""
+        return ChargifySourcePlugin(webhook_secret="test_secret")
 
-        # Create a custom provider class for testing with shorter dedup window
-        class TestChargifySourcePlugin(ChargifySourcePlugin):
-            _DEDUP_WINDOW_SECONDS = 60  # 1 minute for testing
+    @pytest.fixture
+    def form_data(self) -> dict[str, str]:
+        """Valid payment_success form data."""
+        return {
+            "event": "payment_success",
+            "payload[subscription][id]": "sub_12345",
+            "payload[subscription][customer][id]": "cust_456",
+            "payload[subscription][customer][email]": "test@example.com",
+            "payload[subscription][product][name]": "Premium Plan",
+            "payload[transaction][id]": "txn_789",
+            "payload[transaction][amount_in_cents]": "2999",
+            "created_at": "2024-01-15T10:30:00Z",
+        }
 
-        return TestChargifySourcePlugin(webhook_secret="test_secret")
+    def test_webhook_id_surfaced_as_event_id(
+        self, provider: ChargifySourcePlugin, form_data: dict[str, str]
+    ) -> None:
+        """Test that the webhook id is surfaced for router-level dedup."""
+        mock_request = MagicMock()
+        mock_request.content_type = "application/x-www-form-urlencoded"
+        mock_request.headers = {"X-Chargify-Webhook-Id": "webhook_12345"}
+        mock_request.POST.dict.return_value = form_data
 
-    def test_webhook_deduplication_prevents_duplicates(self, provider):
-        """Test that duplicate webhook IDs are rejected"""
-        webhook_id = "webhook_12345"
+        result = provider.parse_webhook(mock_request)
 
-        # First webhook should be allowed
-        assert not provider._check_webhook_duplicate(webhook_id)
+        assert result is not None
+        assert result["event_id"] == "webhook_12345"
 
-        # Second webhook with same ID should be rejected
-        assert provider._check_webhook_duplicate(webhook_id)
+    def test_missing_webhook_id_rejected_in_parse(
+        self, provider: ChargifySourcePlugin, form_data: dict[str, str]
+    ) -> None:
+        """Test that a missing X-Chargify-Webhook-Id fails validation.
 
-    def test_webhook_deduplication_allows_different_webhook_ids(self, provider):
-        """Test that webhooks with different IDs are allowed"""
-        assert not provider._check_webhook_duplicate("webhook_123")
-        assert not provider._check_webhook_duplicate("webhook_456")
+        Without the webhook id there is no stable dedup key, so the
+        webhook must be rejected (400) rather than bypassing dedup.
+        """
+        mock_request = MagicMock()
+        mock_request.content_type = "application/x-www-form-urlencoded"
+        mock_request.headers = {}
+        mock_request.POST.dict.return_value = form_data
 
-    def test_webhook_deduplication_cache_cleanup(self, provider):
-        """Test that old webhook entries are cleaned up"""
-
-        # Create a provider with very short dedup window for this test
-        class QuickTestProvider(ChargifySourcePlugin):
-            _DEDUP_WINDOW_SECONDS = 1  # 1 second for quick testing
-
-        quick_provider = QuickTestProvider(webhook_secret="test_secret")
-
-        webhook_id = "webhook_12345"
-
-        # Process webhook
-        quick_provider._check_webhook_duplicate(webhook_id)
-
-        # Wait for window to expire
-        time.sleep(2)
-
-        # Should be allowed again after window expires
-        assert not quick_provider._check_webhook_duplicate(webhook_id)
-
-    def test_webhook_cache_size_limit(self, provider):
-        """Test that webhook cache respects size limits"""
-        provider._CACHE_MAX_SIZE = 5
-
-        # Fill cache beyond limit
-        for i in range(10):
-            provider._check_webhook_duplicate(f"webhook_{i}")
-
-        # Cache should not exceed max size
-        assert len(provider._webhook_cache) <= provider._CACHE_MAX_SIZE
-
-    def test_webhook_duplicate_with_empty_id(self, provider):
-        """Test handling of empty webhook ID"""
-        # Should return False and log warning for empty webhook ID
-        assert not provider._check_webhook_duplicate("")
-        assert not provider._check_webhook_duplicate(None)
+        with pytest.raises(InvalidDataError, match="X-Chargify-Webhook-Id"):
+            provider.parse_webhook(mock_request)
 
 
 class TestChargifyWebhookTimestampValidation:

--- a/tests/test_payment_providers.py
+++ b/tests/test_payment_providers.py
@@ -332,7 +332,6 @@ def test_chargify_subscription_state_change() -> None:
     Tests that subscription cancellation events are correctly parsed.
     """
     provider = ChargifySourcePlugin(webhook_secret="test_secret")
-    provider._webhook_cache.clear()  # Clear cache before test
 
     mock_request = MagicMock()
     mock_request.content_type = "application/x-www-form-urlencoded"
@@ -425,15 +424,13 @@ def test_shopify_customer_data_update() -> None:
 
 
 def test_chargify_webhook_deduplication() -> None:
-    """Verify Chargify webhook deduplication logic.
+    """Verify Chargify webhook dedup key handling.
 
-    Tests that duplicate webhook IDs are rejected while
-    different webhook IDs are processed.
+    The plugin surfaces the webhook id as ``event_id`` so the router can
+    deduplicate via the event consolidation service, and rejects webhooks
+    without an id (no stable dedup key).
     """
     provider = ChargifySourcePlugin("")
-    provider._DEDUP_WINDOW_SECONDS = (
-        60  # Set deduplication window to 60 seconds for testing
-    )
 
     # Create a mock request with payment_success event
     mock_request = MagicMock()
@@ -456,30 +453,23 @@ def test_chargify_webhook_deduplication() -> None:
         "created_at": "2024-03-15T10:00:00Z",
     }
     mock_request.POST.dict.return_value = form_data
-    # First event should process
+    # Event parses and surfaces the webhook id as the dedup key
     event1 = provider.parse_webhook(mock_request)
     assert event1 is not None
     assert event1["type"] == "payment_success"
     assert event1["customer_id"] == "cust_123"
+    assert event1["event_id"] == "test_webhook_1"
 
-    # Same webhook ID should be considered duplicate
-    mock_request.headers["X-Chargify-Webhook-Id"] = "test_webhook_1"  # Same webhook ID
-    form_data["event"] = "renewal_success"  # change event type
-    mock_request.POST.dict.return_value = form_data
-    with pytest.raises(InvalidDataError, match="Duplicate webhook"):
-        provider.parse_webhook(mock_request)
-
-    # Different webhook ID should be allowed (proper idempotency)
+    # A different webhook ID produces a different dedup key
     mock_request.headers["X-Chargify-Webhook-Id"] = "different_webhook_id"
-    form_data["event"] = "payment_success"
-    form_data["payload[subscription][customer][id]"] = "cust_123"  # Same customer
-    mock_request.POST.dict.return_value = form_data
-
-    # Should process successfully since it's a different webhook ID
     event2 = provider.parse_webhook(mock_request)
     assert event2 is not None
-    assert event2["type"] == "payment_success"
-    assert event2["customer_id"] == "cust_123"
+    assert event2["event_id"] == "different_webhook_id"
+
+    # Missing webhook ID must not bypass dedup - it is a validation error
+    mock_request.headers = {}
+    with pytest.raises(InvalidDataError, match="X-Chargify-Webhook-Id"):
+        provider.parse_webhook(mock_request)
 
 
 def test_event_processor_notification_formatting() -> None:

--- a/tests/test_stripe_realistic_scenarios.py
+++ b/tests/test_stripe_realistic_scenarios.py
@@ -21,6 +21,7 @@ from webhooks.services.event_consolidation import EventConsolidationService
 from webhooks.services.event_processor import EventProcessor
 
 
+@pytest.mark.django_db
 class TestTrialSignupIntegration:
     """Integration test: Trial signup webhook flow.
 
@@ -417,6 +418,7 @@ class TestTrialSignupIntegration:
         assert len(notifications_sent) == 1
 
 
+@pytest.mark.django_db
 class TestTrialConversionIntegration:
     """Integration test: Trial conversion to paid subscription.
 
@@ -526,6 +528,7 @@ class TestTrialConversionIntegration:
         assert "Trial converted" in notification.headline
 
 
+@pytest.mark.django_db
 class TestSubscriptionUpgradeIntegration:
     """Integration test: Subscription plan upgrade.
 

--- a/tests/test_sync_stripe_subscriptions.py
+++ b/tests/test_sync_stripe_subscriptions.py
@@ -259,14 +259,28 @@ class TestSyncWorkspaceFromStripe:
             assert workspace.trial_end_date is not None
 
     def test_handles_stripe_api_error(self, workspace: Workspace) -> None:
-        """Verify sync handles API errors gracefully."""
+        """Verify sync handles Stripe API errors gracefully."""
+        import stripe
+
         with patch("webhooks.services.billing.StripeAPI") as mock_stripe_api_class:
             mock_api = MagicMock()
-            mock_api.get_customer_subscriptions.side_effect = Exception("API Error")
+            mock_api.get_customer_subscriptions.side_effect = stripe.StripeError(
+                "API Error"
+            )
             mock_stripe_api_class.return_value = mock_api
 
             result = BillingService.sync_workspace_from_stripe("cus_test123")
             assert result is False
+
+    def test_propagates_database_error(self, workspace: Workspace) -> None:
+        """Verify unexpected errors propagate instead of being swallowed."""
+        from django.db import OperationalError
+
+        with patch("webhooks.services.billing.Workspace.objects.filter") as mock_filter:
+            mock_filter.side_effect = OperationalError("connection lost")
+
+            with pytest.raises(OperationalError):
+                BillingService.sync_workspace_from_stripe("cus_test123")
 
 
 @pytest.mark.django_db

--- a/tests/test_webhook_retry_semantics.py
+++ b/tests/test_webhook_retry_semantics.py
@@ -1,0 +1,402 @@
+"""Tests for webhook dedup and retry semantics.
+
+Verifies that webhooks are never silently lost:
+- The dedup marker is written only after successful queue/dispatch, so a
+  failed dispatch is retried by the provider instead of being suppressed.
+- Deduplication is keyed on the provider event id (or a composite of
+  event type and object id), so distinct events for the same object
+  both process.
+- Delivery and billing failures surface as 5xx so providers redeliver.
+- Chargify webhooks without an id are rejected instead of bypassing dedup.
+"""
+
+import json
+from typing import Any, Generator
+from unittest.mock import MagicMock, Mock, patch
+from urllib.parse import urlencode
+
+import pytest
+from core.models import GlobalBillingIntegration, Integration, Workspace
+from django.test import Client
+from plugins.destinations.base import BaseDestinationPlugin
+from webhooks.webhook_router import _get_dedup_key, _process_webhook_data
+
+
+@pytest.fixture
+def mock_consolidation_cache() -> Generator[dict, None, None]:
+    """Back the event consolidation cache with a real dict.
+
+    Tests run with DummyCache, which would make every dedup check a
+    no-op. This fixture provides working get/set semantics.
+
+    Yields:
+        The dict backing the cache, for inspection.
+    """
+    cache_data: dict = {}
+
+    def mock_get(key: str, default: Any = None) -> Any:
+        return cache_data.get(key, default)
+
+    def mock_set(key: str, value: Any, timeout: Any = None) -> None:
+        cache_data[key] = value
+
+    with patch("webhooks.services.event_consolidation.cache") as mock:
+        mock.get = mock_get
+        mock.set = mock_set
+        yield cache_data
+
+
+@pytest.fixture
+def mock_provider() -> Mock:
+    """Create a mock source provider for router-level tests.
+
+    Returns:
+        Mock provider with empty customer data.
+    """
+    provider = Mock()
+    provider.get_customer_data.return_value = {}
+    return provider
+
+
+class TestDedupKey:
+    """Tests for the deduplication key derivation."""
+
+    def test_prefers_event_id(self) -> None:
+        """The provider event id wins over the object id."""
+        event_data = {
+            "type": "subscription_created",
+            "event_id": "evt_123",
+            "external_id": "sub_ABC",
+        }
+        assert _get_dedup_key(event_data) == "evt_123"
+
+    def test_falls_back_to_composite_key(self) -> None:
+        """Without an event id, the key combines type and object id."""
+        event_data = {"type": "subscription_created", "external_id": "sub_ABC"}
+        assert _get_dedup_key(event_data) == "subscription_created:sub_ABC"
+
+    def test_empty_without_identifiers(self) -> None:
+        """No identifiers means no dedup key (dedup disabled)."""
+        assert _get_dedup_key({"type": "payment_success"}) == ""
+
+
+class TestDedupMarkerAfterDispatch:
+    """Finding 1: dedup marker must be written only after dispatch."""
+
+    def _event_data(self) -> dict[str, Any]:
+        """Build a Stripe-style event with an idempotency key."""
+        return {
+            "type": "payment_success",
+            "customer_id": "cus_1",
+            "external_id": "in_1",
+            "event_id": "evt_1",
+            "idempotency_key": "idem_1",
+            "amount": 10.0,
+        }
+
+    def test_failed_queue_is_not_dedup_marked(
+        self, mock_consolidation_cache: dict, mock_provider: Mock
+    ) -> None:
+        """An event whose dispatch raises is retried, not dedup-suppressed."""
+        with patch(
+            "webhooks.webhook_router.pending_event_queue.queue_event",
+            side_effect=RuntimeError("redis unavailable"),
+        ):
+            with pytest.raises(RuntimeError):
+                _process_webhook_data(
+                    self._event_data(), mock_provider, "customer_stripe", None
+                )
+
+        # The provider retry (same event) must process, not be suppressed
+        with patch(
+            "webhooks.webhook_router.pending_event_queue.queue_event"
+        ) as mock_queue:
+            response = _process_webhook_data(
+                self._event_data(), mock_provider, "customer_stripe", None
+            )
+
+        assert response.status_code == 200
+        assert "queued" in json.loads(response.content)["message"]
+        mock_queue.assert_called_once()
+
+    def test_successful_queue_is_dedup_marked(
+        self, mock_consolidation_cache: dict, mock_provider: Mock
+    ) -> None:
+        """After a successful dispatch, a redelivery is suppressed."""
+        with patch("webhooks.webhook_router.pending_event_queue.queue_event"):
+            first = _process_webhook_data(
+                self._event_data(), mock_provider, "customer_stripe", None
+            )
+            second = _process_webhook_data(
+                self._event_data(), mock_provider, "customer_stripe", None
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert "duplicate suppressed" in json.loads(second.content)["message"]
+
+
+class TestDistinctEventsSameObject:
+    """Finding 2: dedup must not collide distinct events for one object."""
+
+    @patch("django.conf.settings.EVENT_PROCESSOR")
+    def test_created_then_updated_both_process(
+        self,
+        mock_processor: Mock,
+        mock_consolidation_cache: dict,
+        mock_provider: Mock,
+    ) -> None:
+        """subscription.created and .updated for one subscription both process."""
+        mock_processor.process_event_rich.return_value = {"blocks": []}
+
+        created = {
+            "type": "subscription_created",
+            "customer_id": "cus_1",
+            "external_id": "sub_ABC",
+            "event_id": "evt_created_1",
+            "idempotency_key": None,
+            "amount": 26.60,
+        }
+        updated = {
+            "type": "subscription_updated",
+            "customer_id": "cus_1",
+            "external_id": "sub_ABC",
+            "event_id": "evt_updated_2",
+            "idempotency_key": None,
+            "amount": 49.00,
+        }
+
+        with patch("webhooks.webhook_router.pending_event_queue.queue_event"):
+            first = _process_webhook_data(
+                created, mock_provider, "customer_stripe", None
+            )
+            second = _process_webhook_data(
+                updated, mock_provider, "customer_stripe", None
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert "duplicate" not in json.loads(second.content)["message"]
+
+    @pytest.mark.django_db
+    def test_stripe_parser_surfaces_event_id(self) -> None:
+        """parse_webhook exposes the evt_... id separately from external_id."""
+        from plugins.sources.stripe import StripeSourcePlugin
+
+        plugin = StripeSourcePlugin(webhook_secret="whsec_test")
+
+        mock_event = Mock()
+        mock_event.id = "evt_outer_123"
+        mock_event.type = "customer.subscription.updated"
+        mock_event.data.object = {
+            "id": "sub_ABC",
+            "customer": "cus_1",
+            "status": "active",
+            "plan": {"amount": 4900, "interval": "month"},
+        }
+        mock_event.data.previous_attributes = None
+        mock_event.request = None
+
+        mock_request = Mock()
+        mock_request.content_type = "application/json"
+        mock_request.POST = None
+        mock_request.headers = {"Stripe-Signature": "sig"}
+        mock_request.body = b"{}"
+
+        with patch(
+            "plugins.sources.stripe.stripe.Webhook.construct_event",
+            return_value=mock_event,
+        ):
+            event_data = plugin.parse_webhook(mock_request)
+
+        assert event_data is not None
+        assert event_data["event_id"] == "evt_outer_123"
+        assert event_data["external_id"] == "sub_ABC"
+
+
+@pytest.mark.django_db
+class TestImmediateDeliveryFailureReturns5xx:
+    """Finding 3: Slack delivery failures must return 5xx, not 200."""
+
+    @pytest.fixture
+    def workspace(self) -> Workspace:
+        """Create a workspace with Chargify and Slack integrations."""
+        workspace = Workspace.objects.create(
+            name="Test Workspace", shop_domain="test.myshopify.com"
+        )
+        Integration.objects.create(
+            workspace=workspace,
+            integration_type="chargify",
+            webhook_secret="test-webhook-secret",
+            is_active=True,
+        )
+        Integration.objects.create(
+            workspace=workspace,
+            integration_type="slack_notifications",
+            is_active=True,
+            oauth_credentials={
+                "incoming_webhook": {"url": "https://hooks.slack.com/test"}
+            },
+        )
+        return workspace
+
+    def _post_chargify(self, client: Client, workspace: Workspace) -> Any:
+        """Send a valid Chargify payment_success webhook."""
+        return client.post(
+            f"/webhook/customer/{workspace.uuid}/chargify/",
+            data=urlencode(
+                {
+                    "event": "payment_success",
+                    "payload[subscription][id]": "sub_789",
+                    "payload[subscription][customer][id]": "cust_123",
+                    "payload[subscription][customer][email]": "test@example.com",
+                    "payload[subscription][product][name]": "Premium Plan",
+                    "payload[transaction][id]": "txn_1",
+                    "payload[transaction][amount_in_cents]": "2999",
+                    "created_at": "2024-03-15T10:00:00Z",
+                }
+            ),
+            content_type="application/x-www-form-urlencoded",
+            HTTP_X_CHARGIFY_WEBHOOK_ID="webhook_retry_1",
+            HTTP_X_CHARGIFY_WEBHOOK_SIGNATURE_HMAC_SHA_256="sig",
+        )
+
+    @patch("django.conf.settings.EVENT_PROCESSOR")
+    @patch("plugins.sources.chargify.ChargifySourcePlugin.validate_webhook")
+    def test_slack_failure_returns_5xx_then_retry_processes(
+        self,
+        mock_validate: Mock,
+        mock_processor: Mock,
+        mock_consolidation_cache: dict,
+        client: Client,
+        workspace: Workspace,
+    ) -> None:
+        """A failed Slack send returns 5xx; the retry is not dedup'd."""
+        mock_validate.return_value = True
+        mock_processor.process_event_rich.return_value = {"blocks": []}
+
+        slack_plugin = MagicMock(spec=BaseDestinationPlugin)
+        mock_registry = Mock()
+        mock_registry.get.return_value = slack_plugin
+
+        with patch(
+            "plugins.registry.PluginRegistry.instance", return_value=mock_registry
+        ):
+            # First delivery: Slack is down -> 5xx so Chargify retries
+            slack_plugin.send.side_effect = Exception("slack webhook revoked")
+            first = self._post_chargify(client, workspace)
+            assert first.status_code == 500
+
+            # Retry: Slack is back -> processed, not suppressed as duplicate
+            slack_plugin.send.side_effect = None
+            second = self._post_chargify(client, workspace)
+            assert second.status_code == 200
+            assert "successfully" in second.json()["message"]
+
+            # Third delivery of the same webhook id is now a duplicate
+            third = self._post_chargify(client, workspace)
+            assert third.status_code == 200
+            assert "duplicate suppressed" in third.json()["message"]
+
+        assert slack_plugin.send.call_count == 2
+
+
+@pytest.mark.django_db
+class TestBillingWebhookPropagatesDbErrors:
+    """Finding 5: billing handler errors must surface as 5xx."""
+
+    @pytest.fixture
+    def billing_integration(self) -> GlobalBillingIntegration:
+        """Create an active global billing integration."""
+        GlobalBillingIntegration.objects.filter(
+            integration_type="stripe_billing"
+        ).delete()
+        return GlobalBillingIntegration.objects.create(
+            integration_type="stripe_billing",
+            webhook_secret="whsec_test_secret",
+            is_active=True,
+        )
+
+    def test_db_error_in_subscription_updated_returns_5xx(
+        self, client: Client, billing_integration: GlobalBillingIntegration
+    ) -> None:
+        """A DB error inside handle_subscription_updated returns 5xx."""
+        from django.db import OperationalError
+
+        mock_event = Mock()
+        mock_event.id = "evt_billing_1"
+        mock_event.type = "customer.subscription.updated"
+        mock_event.data.object = {
+            "id": "sub_1",
+            "customer": "cus_1",
+            "status": "active",
+            "plan": {"amount": 999, "interval": "month"},
+        }
+        mock_event.data.previous_attributes = None
+        mock_event.request = None
+
+        with (
+            patch(
+                "plugins.sources.stripe.StripeSourcePlugin.validate_webhook",
+                return_value=True,
+            ),
+            patch(
+                "plugins.sources.stripe.stripe.Webhook.construct_event",
+                return_value=mock_event,
+            ),
+            patch(
+                "webhooks.services.billing.Workspace.objects.filter",
+                side_effect=OperationalError("connection lost"),
+            ),
+        ):
+            response = client.post(
+                "/webhook/billing/stripe/",
+                data=json.dumps({"type": "customer.subscription.updated"}),
+                content_type="application/json",
+                HTTP_STRIPE_SIGNATURE="sig",
+            )
+
+        assert response.status_code == 500
+
+
+@pytest.mark.django_db
+class TestChargifyMissingWebhookId:
+    """Finding 7: a missing X-Chargify-Webhook-Id must return 400."""
+
+    @pytest.fixture
+    def workspace(self) -> Workspace:
+        """Create a workspace with an active Chargify integration."""
+        workspace = Workspace.objects.create(
+            name="Test Workspace", shop_domain="test.myshopify.com"
+        )
+        Integration.objects.create(
+            workspace=workspace,
+            integration_type="chargify",
+            webhook_secret="test-webhook-secret",
+            is_active=True,
+        )
+        return workspace
+
+    @patch("plugins.sources.chargify.ChargifySourcePlugin.validate_webhook")
+    def test_missing_webhook_id_returns_400(
+        self, mock_validate: Mock, client: Client, workspace: Workspace
+    ) -> None:
+        """A webhook without an id has no dedup key and is rejected."""
+        mock_validate.return_value = True
+
+        response = client.post(
+            f"/webhook/customer/{workspace.uuid}/chargify/",
+            data=urlencode(
+                {
+                    "event": "payment_success",
+                    "payload[subscription][customer][id]": "cust_123",
+                    "payload[transaction][amount_in_cents]": "2999",
+                    "created_at": "2024-03-15T10:00:00Z",
+                }
+            ),
+            content_type="application/x-www-form-urlencoded",
+            HTTP_X_CHARGIFY_WEBHOOK_SIGNATURE_HMAC_SHA_256="sig",
+        )
+
+        assert response.status_code == 400
+        assert "X-Chargify-Webhook-Id" in response.json()["message"]

--- a/tests/webhooks/tests.py
+++ b/tests/webhooks/tests.py
@@ -171,6 +171,7 @@ class StripeProviderTest(TestCase):
             "customer_id": "cus_123",
             "provider": "stripe",
             "external_id": "in_123",
+            "event_id": None,
             "status": "succeeded",
             "created_at": 1234567890,
             "currency": "USD",
@@ -180,6 +181,22 @@ class StripeProviderTest(TestCase):
         }
 
         self.assertEqual(result, expected)
+
+    def test_build_stripe_event_data_includes_event_id(self):
+        """Test that the Stripe event id is surfaced separately."""
+        data = {"id": "sub_123", "status": "active"}
+
+        result = self.provider._build_stripe_event_data(
+            "subscription_created",
+            "cus_123",
+            data,
+            20.00,
+            idempotency_key=None,
+            event_id="evt_abc123",
+        )
+
+        self.assertEqual(result["event_id"], "evt_abc123")
+        self.assertEqual(result["external_id"], "sub_123")
 
     def test_handle_stripe_billing_unknown_event(self):
         """Test handling unknown billing event."""


### PR DESCRIPTION
Fixes #76 — all seven silent-event-loss findings from the webhook-pipeline audit (Group 2).

## Changes

1. **Dedup marker written only after successful dispatch.** `_process_webhook_data` records the dedup marker after `pending_event_queue.queue_event` succeeds (or after immediate processing returns), so a failed dispatch returns 5xx and the provider's retry is processed instead of being suppressed as a "duplicate".
2. **Dedup keyed on the provider event id, not the object id.** The Stripe parser surfaces the outer envelope id (`evt_...`) as a new `event_id` field; the router's `_get_dedup_key` prefers it and falls back to `(event_type, external_id)`. `subscription.created` + `subscription.updated` for the same `sub_...` no longer collide.
3. **`_process_immediately` no longer swallows Slack failures** — delivery errors propagate so the router returns 5xx and the provider retries (consistent with `pending_event_queue._send_notification`).
4. **`billing_stripe_webhook` returns 5xx on transient/unknown errors** — only signature/validation errors are 4xx. Stripe has its own backoff; the "prevent infinite retries" rationale was a misread. `_handle_webhook_exceptions` now also maps plugin-level `WebhookError` to 400.
5. **`billing.py` handlers no longer catch bare `Exception` → 200.** Expected no-ops (missing customer id, unknown workspace) return normally; unexpected errors (DB failures) propagate so Stripe redelivers. `sync_workspace_from_stripe` keeps its bool contract but only swallows `stripe.StripeError`.
6. **Chargify dedup moved to the shared consolidation service.** The per-instance `OrderedDict` cache (useless — the plugin is constructed per request) is gone; Chargify surfaces `X-Chargify-Webhook-Id` as `event_id` and goes through the same router-level `is_duplicate`/`record_event` path as Stripe/Shopify.
7. **Missing `X-Chargify-Webhook-Id` is now a 400** (`InvalidDataError`) instead of silently bypassing dedup.

## Tests

New `tests/test_webhook_retry_semantics.py`: failed dispatch → retry processes (incl. an end-to-end Chargify Slack-down → 500 → retry → 200 → third delivery suppressed sequence); two distinct Stripe events for one subscription both process; `OperationalError` in `handle_subscription_updated` → billing endpoint 500; missing webhook id → 400.
Updated existing tests that assumed swallow-and-200 semantics.

`uv run pytest`: 803 passed. ruff/mypy clean (mypy baseline identical to master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)