### PR TITLE
fix: derive Stripe trial conversion and amounts from invoice/items data

### DIFF
--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -25,6 +25,12 @@ logger = logging.getLogger(__name__)
 CUSTOMER_EMAIL_CACHE_PREFIX = "stripe_customer_email:"
 CUSTOMER_EMAIL_CACHE_TTL = 3600  # 1 hour
 
+# Maximum allowed gap between a subscription's trial_end and the invoice's
+# period_start for the invoice to count as the first post-trial invoice.
+# Stripe sets period_start equal to trial_end on the first paid invoice;
+# a small tolerance absorbs clock drift and invoice-finalization lag.
+TRIAL_CONVERSION_TOLERANCE_SECONDS = 3600
+
 
 class StripeSourcePlugin(BaseSourcePlugin):
     """Handle Stripe webhooks using official Stripe SDK.
@@ -194,10 +200,88 @@ class StripeSourcePlugin(BaseSourcePlugin):
             # Don't fail webhook processing if we can't get idempotency key
             return None
 
+    def _extract_item_amount(self, item: dict[str, Any]) -> int | None:
+        """Extract the per-unit amount in cents from a subscription item.
+
+        Supports both the old API shape (``item.plan.amount``) and the
+        newer prices API shape (``item.price.unit_amount``).
+
+        Args:
+            item: A single subscription item dict from items.data[].
+
+        Returns:
+            Per-unit amount in cents, or None if not determinable.
+        """
+        plan = item.get("plan")
+        if isinstance(plan, dict) and plan.get("amount") is not None:
+            return int(plan["amount"])
+
+        price = item.get("price")
+        if isinstance(price, dict) and price.get("unit_amount") is not None:
+            return int(price["unit_amount"])
+
+        return None
+
+    def _sum_item_amounts(self, items_data: Any) -> int | None:
+        """Sum ``amount * quantity`` across subscription items.
+
+        Args:
+            items_data: The items.data[] list from a subscription payload
+                (or from _previous_attributes.items).
+
+        Returns:
+            Total amount in cents, or None if no item amount is determinable.
+        """
+        if not isinstance(items_data, list):
+            return None
+
+        total = 0
+        found = False
+        for item in items_data:
+            if not isinstance(item, dict):
+                continue
+            unit_amount = self._extract_item_amount(item)
+            if unit_amount is None:
+                continue
+            quantity = item.get("quantity")
+            if not isinstance(quantity, int) or quantity < 1:
+                quantity = 1
+            total += unit_amount * quantity
+            found = True
+
+        return total if found else None
+
+    def _extract_subscription_amount(self, sub_data: dict[str, Any]) -> int:
+        """Extract the total recurring amount in cents for a subscription.
+
+        Modern multi-item subscriptions have a null top-level ``plan``, so
+        the item amounts (``items[].plan.amount * quantity`` or
+        ``items[].price.unit_amount * quantity``) are summed first, with
+        the top-level plan as a legacy single-item fallback.
+
+        Args:
+            sub_data: Subscription payload dictionary.
+
+        Returns:
+            Total amount in cents, or 0 if not determinable.
+        """
+        items = sub_data.get("items")
+        if isinstance(items, dict):
+            items_total = self._sum_item_amounts(items.get("data"))
+            if items_total is not None:
+                return items_total
+
+        plan = sub_data.get("plan")
+        if isinstance(plan, dict) and plan.get("amount") is not None:
+            return int(plan["amount"])
+
+        return 0
+
     def _get_previous_plan_amount(self, data: dict[str, Any]) -> int | None:
         """Extract previous plan amount from subscription update data.
 
-        Checks both direct plan changes and multi-item subscription changes.
+        Checks both direct plan changes and multi-item subscription changes,
+        summing all previous item amounts (with quantities) for the latter.
 
         Args:
             data: Event data dictionary with _previous_attributes.
@@ -216,13 +300,8 @@ class StripeSourcePlugin(BaseSourcePlugin):
 
         # Check items for multi-item subscriptions
         prev_items = prev_attrs.get("items", {})
-        if isinstance(prev_items, dict) and "data" in prev_items:
-            items_data = prev_items.get("data", [])
-            if items_data:
-                return cast(
-                    "int | None",
-                    items_data[0].get("plan", {}).get("amount"),
-                )
+        if isinstance(prev_items, dict):
+            return self._sum_item_amounts(prev_items.get("data"))
 
         return None
 
@@ -328,7 +407,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
         if data.get("status") == "trialing":
             return self._flag_as_trial(data)
 
-        return int(data.get("plan", {}).get("amount", 0))
+        return self._extract_subscription_amount(data)
 
     def _flag_as_trial(self, data: dict[str, Any]) -> int:
         """Flag subscription data as trial and extract trial metadata.
@@ -341,7 +420,8 @@ class StripeSourcePlugin(BaseSourcePlugin):
         """
         data["_is_trial"] = True
         data["_trial_end"] = data.get("trial_end")
-        data["_plan_amount_cents"] = data.get("plan", {}).get("amount", 0)
+        # Sum item amounts: top-level plan is null on multi-item subscriptions
+        data["_plan_amount_cents"] = self._extract_subscription_amount(data)
 
         # Calculate trial days from trial_start and trial_end (Unix timestamps)
         trial_start = data.get("trial_start")
@@ -362,7 +442,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
         """
         from webhooks.services.billing import BillingService
 
-        current_amount: int = int(data.get("plan", {}).get("amount", 0))
+        current_amount: int = self._extract_subscription_amount(data)
         prev_amount = self._get_previous_plan_amount(data)
         change_direction = self._detect_change_direction(current_amount, prev_amount)
 
@@ -387,13 +467,76 @@ class StripeSourcePlugin(BaseSourcePlugin):
         amount_cents: int = int(data.get("amount_paid", 0))
 
         # Detect trial conversion: first real payment after trial.
-        # billing_reason "subscription_cycle" indicates recurring payment.
+        # billing_reason "subscription_cycle" alone is NOT sufficient - it
+        # fires on every recurring cycle, not just the first one after a
+        # trial. Require the invoice period to start at the trial's end.
         billing_reason = data.get("billing_reason", "")
-        if billing_reason == "subscription_cycle" and amount_cents > 0:
+        if (
+            billing_reason == "subscription_cycle"
+            and amount_cents > 0
+            and self._is_first_invoice_after_trial(data)
+        ):
             data["_is_trial_conversion"] = True
 
         BillingService.handle_payment_success(data)
         return amount_cents
+
+    def _extract_invoice_trial_end(self, data: dict[str, Any]) -> int | None:
+        """Extract the subscription's trial_end timestamp from an invoice.
+
+        The invoice's ``subscription`` field (old API) or
+        ``parent.subscription_details.subscription`` (new API) may be an
+        expanded subscription object carrying ``trial_end``. When it is only
+        an id string, the trial end is not derivable from the payload.
+
+        Args:
+            data: Raw invoice event data.
+
+        Returns:
+            Unix timestamp of the trial end, or None if not available.
+        """
+        subscription = data.get("subscription")
+        if isinstance(subscription, dict):
+            trial_end = subscription.get("trial_end")
+            if isinstance(trial_end, int):
+                return trial_end
+
+        parent = data.get("parent")
+        if isinstance(parent, dict):
+            sub_details = parent.get("subscription_details")
+            if isinstance(sub_details, dict):
+                nested_sub = sub_details.get("subscription")
+                if isinstance(nested_sub, dict):
+                    trial_end = nested_sub.get("trial_end")
+                    if isinstance(trial_end, int):
+                        return trial_end
+
+        return None
+
+    def _is_first_invoice_after_trial(self, data: dict[str, Any]) -> bool:
+        """Check whether an invoice is the first paid one after a trial.
+
+        Stateless check derived from the invoice payload alone: on the
+        first post-trial invoice, Stripe sets the invoice's period_start
+        equal to the subscription's trial_end. A small tolerance absorbs
+        clock drift and invoice-finalization lag.
+
+        Args:
+            data: Raw invoice event data.
+
+        Returns:
+            True if the invoice period starts at (or immediately after)
+            the subscription's trial end.
+        """
+        trial_end = self._extract_invoice_trial_end(data)
+        if trial_end is None:
+            return False
+
+        period_start = data.get("period_start")
+        if not isinstance(period_start, int):
+            return False
+
+        return 0 <= period_start - trial_end <= TRIAL_CONVERSION_TOLERANCE_SECONDS
 
     def _build_stripe_event_data(
         self,
@@ -506,8 +649,9 @@ class StripeSourcePlugin(BaseSourcePlugin):
         """
         metadata["subscription_id"] = data.get("id", "")
 
-        # Map Stripe interval to billing period
-        plan = data.get("plan", {})
+        # Map Stripe interval to billing period.
+        # Top-level plan is null on multi-item subscriptions, so guard it.
+        plan = data.get("plan") or {}
         interval = plan.get("interval")
         if interval:
             interval_map = {
@@ -670,6 +814,36 @@ class StripeSourcePlugin(BaseSourcePlugin):
             return "weekly"
         return None
 
+    def _billing_period_from_structured_fields(
+        self, item: dict[str, Any]
+    ) -> str | None:
+        """Extract billing period from structured line item fields.
+
+        Checks the old API shape (``plan.interval``) and the prices API
+        shape (``price.recurring.interval``).
+
+        Args:
+            item: A single line item dict from lines.data[].
+
+        Returns:
+            Billing period string, or None if not found.
+        """
+        plan = item.get("plan")
+        if isinstance(plan, dict):
+            interval = plan.get("interval")
+            if interval and interval in self.INTERVAL_MAP:
+                return self.INTERVAL_MAP[interval]
+
+        price = item.get("price")
+        if isinstance(price, dict):
+            recurring = price.get("recurring")
+            if isinstance(recurring, dict):
+                interval = recurring.get("interval")
+                if interval and interval in self.INTERVAL_MAP:
+                    return self.INTERVAL_MAP[interval]
+
+        return None
+
     def _extract_billing_period_from_line_item(
         self, item: dict[str, Any]
     ) -> str | None:
@@ -685,12 +859,10 @@ class StripeSourcePlugin(BaseSourcePlugin):
         Returns:
             Billing period string (monthly, annual, weekly, daily), or None.
         """
-        # 1. Old API: plan.interval
-        plan = item.get("plan")
-        if isinstance(plan, dict):
-            interval = plan.get("interval")
-            if interval and interval in self.INTERVAL_MAP:
-                return self.INTERVAL_MAP[interval]
+        # 1. Structured fields: plan.interval or price.recurring.interval
+        structured = self._billing_period_from_structured_fields(item)
+        if structured:
+            return structured
 
         # 2. Calculate from period start/end timestamps
         period = item.get("period")
@@ -731,6 +903,9 @@ class StripeSourcePlugin(BaseSourcePlugin):
                 sub_details = parent.get("subscription_details", {})
                 if isinstance(sub_details, dict):
                     subscription_id = sub_details.get("subscription")
+        # The subscription may be an expanded object rather than an id string
+        if isinstance(subscription_id, dict):
+            subscription_id = subscription_id.get("id")
         return subscription_id or None
 
     def _add_line_item_metadata(
@@ -754,8 +929,8 @@ class StripeSourcePlugin(BaseSourcePlugin):
             if plan_name:
                 metadata["plan_name"] = plan_name
 
-        # Refine billing_period if it was set to the "monthly" default
-        if metadata.get("billing_period") == "monthly":
+        # Compute billing_period from the line item unless already known
+        if not metadata.get("billing_period"):
             parsed_period = self._extract_billing_period_from_line_item(first_item)
             if parsed_period:
                 metadata["billing_period"] = parsed_period
@@ -784,9 +959,6 @@ class StripeSourcePlugin(BaseSourcePlugin):
         billing_reason = data.get("billing_reason")
         if billing_reason:
             metadata["billing_reason"] = billing_reason
-            if billing_reason.startswith("subscription_"):
-                if "billing_period" not in metadata:
-                    metadata["billing_period"] = "monthly"
 
         attempt_count = data.get("attempt_count")
         if attempt_count is not None:
@@ -801,6 +973,17 @@ class StripeSourcePlugin(BaseSourcePlugin):
             metadata["invoice_number"] = invoice_number
 
         self._add_line_item_metadata(metadata, data)
+
+        # Last-resort fallback only: assume monthly for subscription invoices
+        # whose interval could not be determined from the line items. This
+        # must run AFTER line-item inspection so annual invoices are not
+        # mislabeled as monthly.
+        if (
+            billing_reason
+            and billing_reason.startswith("subscription_")
+            and not metadata.get("billing_period")
+        ):
+            metadata["billing_period"] = "monthly"
 
     def parse_webhook(
         self, request: HttpRequest, **kwargs: Any

--- a/tests/test_stripe_realistic_scenarios.py
+++ b/tests/test_stripe_realistic_scenarios.py
@@ -425,6 +425,11 @@ class TestTrialConversionIntegration:
     When a trial converts, we receive invoice.payment_succeeded with:
     - billing_reason="subscription_cycle"
     - Positive amount (first real payment)
+    - The invoice's period_start equal to the subscription's trial_end
+
+    billing_reason="subscription_cycle" alone is NOT sufficient - it fires
+    on every recurring renewal. Only the trial_end/period_start match
+    identifies the first paid invoice after a trial.
 
     The Slack notification should show trial conversion in headline.
     """
@@ -441,7 +446,11 @@ class TestTrialConversionIntegration:
 
     @pytest.fixture
     def trial_conversion_payload(self) -> dict[str, Any]:
-        """Invoice payload for first real payment after trial."""
+        """Invoice payload for first real payment after a multi-item trial.
+
+        The expanded subscription has a null top-level plan (modern
+        multi-item shape) and trial_end equal to the invoice period_start.
+        """
         return {
             "id": "evt_conversion123",
             "object": "event",
@@ -457,7 +466,66 @@ class TestTrialConversionIntegration:
                     "currency": "usd",
                     "status": "paid",
                     "billing_reason": "subscription_cycle",
-                    "subscription": "sub_1ABC123DEF456GHI",
+                    "period_start": 1770537317,
+                    "period_end": 1773215717,
+                    "subscription": {
+                        "id": "sub_1ABC123DEF456GHI",
+                        "object": "subscription",
+                        "status": "active",
+                        "plan": None,  # Null on multi-item subscriptions
+                        "trial_start": 1769327717,
+                        "trial_end": 1770537317,  # == invoice period_start
+                        "items": {
+                            "data": [
+                                {
+                                    "id": "si_base",
+                                    "price": {"unit_amount": 1660},
+                                    "quantity": 1,
+                                },
+                                {
+                                    "id": "si_addon",
+                                    "price": {"unit_amount": 500},
+                                    "quantity": 2,
+                                },
+                            ]
+                        },
+                    },
+                    "created": 1770537317,
+                },
+            },
+        }
+
+    @pytest.fixture
+    def regular_renewal_payload(self) -> dict[str, Any]:
+        """Invoice payload for an ordinary recurring renewal (no trial).
+
+        billing_reason is still "subscription_cycle", but the customer
+        never had a trial - this must NOT be flagged as a conversion.
+        """
+        return {
+            "id": "evt_renewal456",
+            "object": "event",
+            "type": "invoice.payment_succeeded",
+            "data": {
+                "object": {
+                    "id": "in_renewal456",
+                    "object": "invoice",
+                    "customer": "cus_TestCustomer123",
+                    "amount_due": 2660,
+                    "amount_paid": 2660,
+                    "amount_remaining": 0,
+                    "currency": "usd",
+                    "status": "paid",
+                    "billing_reason": "subscription_cycle",
+                    "period_start": 1770537317,
+                    "period_end": 1773215717,
+                    "subscription": {
+                        "id": "sub_1ABC123DEF456GHI",
+                        "object": "subscription",
+                        "status": "active",
+                        "trial_start": None,
+                        "trial_end": None,
+                    },
                     "created": 1770537317,
                 },
             },
@@ -498,6 +566,36 @@ class TestTrialConversionIntegration:
             event_type, data["customer"], data, amount
         )
         assert event_data["metadata"]["is_trial_conversion"] is True
+        # The expanded subscription object must not leak into subscription_id
+        assert event_data["metadata"]["subscription_id"] == "sub_1ABC123DEF456GHI"
+
+    def test_regular_renewal_not_flagged_as_trial_conversion(
+        self,
+        stripe_plugin: StripeSourcePlugin,
+        regular_renewal_payload: dict[str, Any],
+    ) -> None:
+        """Test that an ordinary renewal cycle is NOT a trial conversion.
+
+        Regression test: billing_reason="subscription_cycle" fires on every
+        recurring payment; previously each one was mislabeled as a trial
+        conversion even for customers who never had a trial.
+        """
+        mock_event = Mock()
+        mock_event.type = regular_renewal_payload["type"]
+        mock_event.data.object = regular_renewal_payload["data"]["object"]
+        mock_event.data.previous_attributes = None
+
+        event_type, data = stripe_plugin._extract_stripe_event_info(mock_event)
+        assert event_type == "payment_success"
+
+        amount = stripe_plugin._handle_stripe_billing(event_type, data)
+        assert amount == 26.60
+        assert data.get("_is_trial_conversion") is None
+
+        event_data = stripe_plugin._build_stripe_event_data(
+            event_type, data["customer"], data, amount
+        )
+        assert "is_trial_conversion" not in event_data["metadata"]
 
     def test_trial_conversion_generates_rich_notification(
         self,
@@ -1149,7 +1247,11 @@ class TestInvoiceMetadataExtraction:
     def test_extracts_subscription_id_from_new_api_path(
         self, stripe_plugin: StripeSourcePlugin
     ) -> None:
-        """Test subscription_id extraction from new Stripe API path."""
+        """Test subscription_id extraction from new Stripe API path.
+
+        With no line items the billing interval is undeterminable, so the
+        billing_period falls back to "monthly" as a last resort.
+        """
         metadata: dict[str, Any] = {}
         data: dict[str, Any] = {
             "subscription": None,
@@ -1207,10 +1309,48 @@ class TestInvoiceMetadataExtraction:
         assert metadata["plan_name"] == "Enterprise Plan"
         assert metadata["billing_period"] == "annual"
 
+    def test_annual_billing_period_from_price_recurring_interval(
+        self, stripe_plugin: StripeSourcePlugin
+    ) -> None:
+        """Test annual invoice with price.recurring.interval is not "monthly".
+
+        Regression test: subscription_cycle invoices used to be pre-labeled
+        "monthly" before line-item inspection, so a $1200/year renewal whose
+        line item only carried price.recurring.interval="year" was silently
+        mislabeled. The interval must be computed from the line item first
+        ("annual" is this codebase's label for yearly billing).
+        """
+        metadata: dict[str, Any] = {}
+        data: dict[str, Any] = {
+            "subscription": "sub_annual_123",
+            "billing_reason": "subscription_cycle",
+            "lines": {
+                "data": [
+                    {
+                        "description": "Enterprise Plan",
+                        "quantity": 1,
+                        "price": {
+                            "unit_amount": 120000,
+                            "recurring": {"interval": "year"},
+                        },
+                    }
+                ]
+            },
+        }
+
+        stripe_plugin._add_invoice_metadata(metadata, data)
+
+        assert metadata["billing_period"] == "annual"
+        assert metadata["billing_period"] != "monthly"
+
     def test_no_line_items_still_extracts_other_metadata(
         self, stripe_plugin: StripeSourcePlugin
     ) -> None:
-        """Test metadata extraction works even without line items."""
+        """Test metadata extraction works even without line items.
+
+        billing_period falls back to "monthly" only because the interval
+        is truly undeterminable without line items.
+        """
         metadata: dict[str, Any] = {}
         data: dict[str, Any] = {
             "subscription": "sub_789",

--- a/tests/webhooks/tests_stripe_provider.py
+++ b/tests/webhooks/tests_stripe_provider.py
@@ -17,6 +17,7 @@ parsing event data, and triggering appropriate billing service handlers
 for subscription management and payment processing.
 """
 
+from typing import Any
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
@@ -453,8 +454,15 @@ class StripeProviderTest(TestCase):
 
         self.assertIsNone(result)
 
-    def test_handle_stripe_billing_trial_conversion_detected(self) -> None:
-        """Test that trial conversion is detected for subscription_cycle payments."""
+    def test_handle_stripe_billing_no_trial_conversion_for_plain_cycle(self) -> None:
+        """Test that subscription_cycle alone is NOT a trial conversion.
+
+        Flipped from the original assertion: billing_reason
+        "subscription_cycle" fires on every recurring renewal, so treating
+        it as a trial conversion mislabeled all recurring payments. Without
+        evidence of a trial ending at the invoice period start, no
+        conversion may be flagged.
+        """
         data = {
             "amount_paid": 2660,  # $26.60
             "billing_reason": "subscription_cycle",
@@ -462,13 +470,69 @@ class StripeProviderTest(TestCase):
 
         self.provider._handle_stripe_billing("payment_success", data)
 
+        self.assertIsNone(data.get("_is_trial_conversion"))
+
+    def test_handle_stripe_billing_trial_conversion_detected(self) -> None:
+        """Test trial conversion for the first paid invoice after a trial.
+
+        A multi-item subscription's trial ends and its first paid invoice
+        arrives with the subscription trial_end equal to the invoice
+        period_start - the stateless signal for a genuine conversion.
+        """
+        data = {
+            "amount_paid": 2660,  # $26.60
+            "billing_reason": "subscription_cycle",
+            "period_start": 1770537317,
+            "subscription": {
+                "id": "sub_123",
+                "status": "active",
+                "plan": None,  # Null on multi-item subscriptions
+                "trial_end": 1770537317,  # == period_start
+                "items": {
+                    "data": [
+                        {"price": {"unit_amount": 1330}, "quantity": 2},
+                    ]
+                },
+            },
+        }
+
+        self.provider._handle_stripe_billing("payment_success", data)
+
         self.assertTrue(data.get("_is_trial_conversion"))
+
+    def test_handle_stripe_billing_trial_conversion_with_small_gap(self) -> None:
+        """Test conversion when period_start is just after trial_end."""
+        data = {
+            "amount_paid": 2660,
+            "billing_reason": "subscription_cycle",
+            "period_start": 1770537317 + 60,  # 1 minute after trial_end
+            "subscription": {"id": "sub_123", "trial_end": 1770537317},
+        }
+
+        self.provider._handle_stripe_billing("payment_success", data)
+
+        self.assertTrue(data.get("_is_trial_conversion"))
+
+    def test_handle_stripe_billing_no_trial_conversion_for_later_cycle(self) -> None:
+        """Test that a renewal long after the trial ended is not a conversion."""
+        data = {
+            "amount_paid": 2660,
+            "billing_reason": "subscription_cycle",
+            "period_start": 1770537317 + 2_592_000,  # 30 days after trial_end
+            "subscription": {"id": "sub_123", "trial_end": 1770537317},
+        }
+
+        self.provider._handle_stripe_billing("payment_success", data)
+
+        self.assertIsNone(data.get("_is_trial_conversion"))
 
     def test_handle_stripe_billing_no_trial_conversion_for_zero_amount(self) -> None:
         """Test that trial conversion is not set for $0 payments."""
         data = {
             "amount_paid": 0,
             "billing_reason": "subscription_cycle",
+            "period_start": 1770537317,
+            "subscription": {"id": "sub_123", "trial_end": 1770537317},
         }
 
         self.provider._handle_stripe_billing("payment_success", data)
@@ -480,6 +544,8 @@ class StripeProviderTest(TestCase):
         data = {
             "amount_paid": 2660,
             "billing_reason": "manual",
+            "period_start": 1770537317,
+            "subscription": {"id": "sub_123", "trial_end": 1770537317},
         }
 
         self.provider._handle_stripe_billing("payment_success", data)
@@ -534,6 +600,89 @@ class StripeProviderTest(TestCase):
         self.provider._handle_stripe_billing("subscription_updated", data)
 
         self.assertIsNone(data.get("_change_direction"))
+
+    def test_handle_stripe_billing_multi_item_upgrade_detected(self) -> None:
+        """Test upgrade detection on a multi-item subscription ($50 -> $100).
+
+        Modern multi-item subscriptions have a null top-level plan, so the
+        current amount must be summed from items[] (previously this yielded
+        $0 and every multi-item update was reported as a $0 downgrade).
+        """
+        data: dict[str, Any] = {
+            "plan": None,  # Null on multi-item subscriptions
+            "items": {
+                "data": [
+                    {"price": {"unit_amount": 4000}, "quantity": 2},  # $80
+                    {"plan": {"amount": 2000}, "quantity": 1},  # $20
+                ]
+            },
+            "_previous_attributes": {
+                "items": {
+                    "data": [
+                        {"price": {"unit_amount": 2000}, "quantity": 2},  # $40
+                        {"plan": {"amount": 1000}, "quantity": 1},  # $10
+                    ]
+                },
+            },
+        }
+
+        amount = self.provider._handle_stripe_billing("subscription_updated", data)
+
+        self.assertEqual(data.get("_change_direction"), "upgrade")
+        self.assertEqual(amount, 100.00)
+
+    def test_extract_subscription_amount_sums_items_with_quantity(self) -> None:
+        """Test that item amounts are summed with quantities."""
+        sub_data: dict[str, Any] = {
+            "plan": None,
+            "items": {
+                "data": [
+                    {"plan": {"amount": 1500}, "quantity": 2},
+                    {"price": {"unit_amount": 500}},  # No quantity -> 1
+                ]
+            },
+        }
+
+        self.assertEqual(self.provider._extract_subscription_amount(sub_data), 3500)
+
+    def test_extract_subscription_amount_falls_back_to_top_level_plan(self) -> None:
+        """Test fallback to top-level plan when items carry no amounts."""
+        sub_data: dict[str, Any] = {
+            "plan": {"amount": 2500},
+            "items": {"data": [{"id": "si_123"}]},
+        }
+
+        self.assertEqual(self.provider._extract_subscription_amount(sub_data), 2500)
+
+    def test_extract_subscription_amount_returns_zero_when_unknown(self) -> None:
+        """Test that missing plan and items yields 0 rather than crashing."""
+        self.assertEqual(self.provider._extract_subscription_amount({"plan": None}), 0)
+
+    def test_flag_as_trial_multi_item_plan_amount(self) -> None:
+        """Test that trial flagging sums item amounts when plan is null.
+
+        Previously _flag_as_trial read top-level plan.amount, which is null
+        on multi-item subscriptions, dropping plan_amount from the trial
+        notification (or crashing when plan was present as None).
+        """
+        data: dict[str, Any] = {
+            "status": "trialing",
+            "plan": None,
+            "trial_start": 1769327717,
+            "trial_end": 1770537317,
+            "items": {
+                "data": [
+                    {"price": {"unit_amount": 1660}, "quantity": 1},
+                    {"price": {"unit_amount": 500}, "quantity": 2},
+                ]
+            },
+        }
+
+        amount_cents = self.provider._flag_as_trial(data)
+
+        self.assertEqual(amount_cents, 0)  # Trials are not charged
+        self.assertTrue(data["_is_trial"])
+        self.assertEqual(data["_plan_amount_cents"], 2660)
 
     def test_build_stripe_event_data_includes_trial_conversion_metadata(self) -> None:
         """Test that trial conversion flag is included in event metadata."""


### PR DESCRIPTION
Fixes #78 — Stripe trial-conversion misclassification and multi-item subscription handling (audit Group 4).

Production evidence: 61/61 `subscription_cycle` invoices in the last 7 days were flagged as trial conversions, including customers who never had a trial.

## Changes

1. **Trial conversion is now detected statelessly from the invoice payload.** `subscription_cycle` alone no longer flags a conversion; the invoice's subscription `trial_end` must fall within a 1-hour tolerance before the invoice `period_start` (`_is_first_invoice_after_trial`). Handles both the legacy expanded `subscription` object and the new-API `parent.subscription_details` shape. With no trial evidence in the payload, no conversion is flagged — conservative by design given the production data.
2. **Multi-item subscription amounts.** New `_extract_subscription_amount()` sums `items[].plan.amount × quantity` (or `price.unit_amount × quantity`) with fallback to top-level `plan.amount`. Used by `_handle_subscription_updated`, `_handle_subscription_created`, and `_get_previous_plan_amount` (which previously read only `items[0]`) — multi-item updates are no longer reported as $0 downgrades.
3. **`_flag_as_trial` uses the same helper** — multi-item trials keep their `plan_amount` (previously 0 or AttributeError when top-level `plan` was null).
4. **`billing_period` no longer pre-defaults to "monthly".** It's computed from line items first (now including new-API `price.recurring.interval`), with "monthly" only as a last resort. Annual renewals label as `annual` (the codebase's canonical yearly label, which ARR rendering branches on).

## Tests

The PR deliberately flips tests that enshrined the bug (noted in their docstrings): the old `subscription_cycle → _is_trial_conversion=True` assertions in `tests/webhooks/tests_stripe_provider.py` and the trial-conversion scenarios in `tests/test_stripe_realistic_scenarios.py` now assert the correct behavior, with new positive tests for a genuine first post-trial invoice (multi-item, `trial_end == period_start`), a $50→$100 multi-item upgrade (amount 100.00), a regular-renewal regression test, and an annual `price.recurring.interval="year"` invoice labeling as `annual` not `monthly`.

`uv run pytest`: 805 passed. ruff/mypy clean (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)