### PR TITLE
fix: correct event consolidation, suppression scoping, and insight detection

### DIFF
--- a/app/webhooks/management/commands/replay_shopify_webhooks.py
+++ b/app/webhooks/management/commands/replay_shopify_webhooks.py
@@ -207,12 +207,16 @@ class Command(BaseCommand):
             body, topic, order_id, workspace_id
         )
 
-        # Check consolidation filter
+        # Check consolidation filter (suppression is scoped to the
+        # transaction-level correlator, e.g. the Shopify order id)
         if not event_consolidation_service.should_send_notification(
             event_type=event_data["type"],
             customer_id=event_data["customer_id"],
             workspace_id=workspace_id,
             amount=event_data.get("amount"),
+            correlation_id=event_consolidation_service.extract_correlation_id(
+                event_data
+            ),
         ):
             self.stdout.write(
                 f"  Skipping order {order_id} - filtered by consolidation"

--- a/app/webhooks/services/event_consolidation.py
+++ b/app/webhooks/services/event_consolidation.py
@@ -113,27 +113,25 @@ class EventConsolidationService:
         self,
         workspace_id: str,
         customer_id: str,
-        correlation_id: str | None = None,
+        correlation_id: str,
     ) -> str:
         """Generate cache key for tracking which events to suppress.
 
-        Suppression is scoped to the transaction-level correlator (e.g.
-        subscription_id or invoice_id) when one is available, so a primary
-        event for one transaction never suppresses events belonging to an
-        unrelated transaction for the same customer.
+        Suppression is always scoped to the transaction-level correlator
+        (e.g. subscription_id or invoice_id), so a primary event for one
+        transaction never suppresses events belonging to an unrelated
+        transaction for the same customer. Events without a correlator
+        never participate in suppression (see should_send_notification).
 
         Args:
             workspace_id: The workspace UUID.
             customer_id: The customer identifier.
-            correlation_id: Optional transaction-level correlator.
+            correlation_id: Transaction-level correlator.
 
         Returns:
             Cache key string for suppression tracking.
         """
-        base = f"event_suppress:{workspace_id}:{customer_id}"
-        if correlation_id:
-            return f"{base}:{correlation_id}"
-        return base
+        return f"event_suppress:{workspace_id}:{customer_id}:{correlation_id}"
 
     def extract_correlation_id(self, event_data: dict[str, Any]) -> str | None:
         """Extract the transaction-level correlator from a parsed event.
@@ -183,10 +181,12 @@ class EventConsolidationService:
             customer_id: The customer identifier.
             workspace_id: The workspace UUID.
             amount: Optional payment amount for filtering zero-amount events.
-            correlation_id: Optional transaction-level correlator
-                (subscription_id, invoice_id, charge_id, ...). When provided,
-                suppression only applies between events sharing the same
-                correlator.
+            correlation_id: Transaction-level correlator (subscription_id,
+                invoice_id, charge_id, ...). Suppression only applies
+                between events sharing the same correlator; without one the
+                event is always delivered (never suppressed and never
+                suppressing), since a coarse customer-level fallback could
+                swallow an unrelated transaction's notification.
 
         Returns:
             True if notification should be sent, False if it should be suppressed.
@@ -208,6 +208,16 @@ class EventConsolidationService:
         if event_type in self.NEVER_SUPPRESS:
             logger.debug(
                 f"Event {event_type} is in NEVER_SUPPRESS list, allowing notification"
+            )
+            return True
+
+        # Without a transaction-level correlator we cannot tell which
+        # transaction a suppression marker belongs to. Deliver rather than
+        # risk suppressing (or being suppressed by) an unrelated transaction.
+        if not correlation_id:
+            logger.debug(
+                f"Event {event_type} has no transaction correlator, "
+                f"skipping consolidation suppression"
             )
             return True
 
@@ -243,7 +253,7 @@ class EventConsolidationService:
         workspace_id: str,
         customer_id: str,
         events_to_suppress: set[str],
-        correlation_id: str | None = None,
+        correlation_id: str,
     ) -> None:
         """Mark events for suppression within the consolidation window.
 
@@ -251,8 +261,8 @@ class EventConsolidationService:
             workspace_id: The workspace UUID.
             customer_id: The customer identifier.
             events_to_suppress: Set of event types to suppress.
-            correlation_id: Optional transaction-level correlator scoping
-                the suppression to a single transaction.
+            correlation_id: Transaction-level correlator scoping the
+                suppression to a single transaction.
         """
         suppression_key = self._get_suppression_key(
             workspace_id, customer_id, correlation_id

--- a/app/webhooks/services/event_consolidation.py
+++ b/app/webhooks/services/event_consolidation.py
@@ -12,7 +12,7 @@ This service tracks recent events and suppresses redundant ones.
 """
 
 import logging
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from django.core.cache import cache
 
@@ -61,24 +61,28 @@ class EventConsolidationService:
         "checkout_completed": {"payment_success", "invoice_paid"},
         # Shopify: Order creation suppresses the payment notification that follows
         "order_created": {"payment_success"},
-        # Trial conversion: payment suppresses trial_ending warning
-        # (trial_ending will be shown as "Trial converted" insight on payment)
-        "payment_success": {"trial_ending"},
-        "invoice_paid": {"trial_ending"},
     }
 
     # Events that should never be suppressed (always important)
+    # trial_ending is delivered as its own "trial ending in N days" warning;
+    # the later "Trial converted" insight is derived statelessly from the
+    # first post-trial invoice payload (see StripePlugin), so both
+    # notifications fire for a full trial lifecycle.
     NEVER_SUPPRESS: ClassVar[set[str]] = {
         "payment_failure",
         "payment_action_required",
-    }
-
-    # Events that are suppressed but tracked for insight enrichment
-    # When these events are suppressed, we record them so that the
-    # suppressing event can show a richer insight (e.g., "Trial converted")
-    TRACK_WHEN_SUPPRESSED: ClassVar[set[str]] = {
         "trial_ending",
     }
+
+    # Metadata fields that identify the transaction an event belongs to,
+    # in preference order. Used to scope suppression so a primary event
+    # only suppresses secondaries for the SAME transaction.
+    CORRELATION_METADATA_FIELDS: ClassVar[tuple[str, ...]] = (
+        "subscription_id",
+        "invoice_id",
+        "charge_id",
+        "order_id",
+    )
 
     # Payment events that should be suppressed when amount is $0 (trial invoices)
     ZERO_AMOUNT_FILTER_EVENTS: ClassVar[set[str]] = {
@@ -105,17 +109,58 @@ class EventConsolidationService:
         """
         return f"event_consolidation:{workspace_id}:{customer_id}:{event_type}"
 
-    def _get_suppression_key(self, workspace_id: str, customer_id: str) -> str:
+    def _get_suppression_key(
+        self,
+        workspace_id: str,
+        customer_id: str,
+        correlation_id: str | None = None,
+    ) -> str:
         """Generate cache key for tracking which events to suppress.
+
+        Suppression is scoped to the transaction-level correlator (e.g.
+        subscription_id or invoice_id) when one is available, so a primary
+        event for one transaction never suppresses events belonging to an
+        unrelated transaction for the same customer.
 
         Args:
             workspace_id: The workspace UUID.
             customer_id: The customer identifier.
+            correlation_id: Optional transaction-level correlator.
 
         Returns:
             Cache key string for suppression tracking.
         """
-        return f"event_suppress:{workspace_id}:{customer_id}"
+        base = f"event_suppress:{workspace_id}:{customer_id}"
+        if correlation_id:
+            return f"{base}:{correlation_id}"
+        return base
+
+    def extract_correlation_id(self, event_data: dict[str, Any]) -> str | None:
+        """Extract the transaction-level correlator from a parsed event.
+
+        Prefers explicit metadata identifiers (subscription_id, invoice_id,
+        charge_id, order_id) and falls back to the event's external object
+        id. Related events for the same transaction (e.g. a subscription and
+        its invoices) share the metadata identifier, while unrelated
+        transactions for the same customer do not.
+
+        Args:
+            event_data: Parsed event data dictionary.
+
+        Returns:
+            Correlator string, or None if the event carries none.
+        """
+        metadata = event_data.get("metadata") or {}
+        for field in self.CORRELATION_METADATA_FIELDS:
+            value = metadata.get(field)
+            if value:
+                return str(value)
+
+        external_id = event_data.get("external_id")
+        if external_id:
+            return str(external_id)
+
+        return None
 
     def should_send_notification(
         self,
@@ -123,6 +168,7 @@ class EventConsolidationService:
         customer_id: str,
         workspace_id: str,
         amount: float | None = None,
+        correlation_id: str | None = None,
     ) -> bool:
         """Check if notification should be sent or suppressed.
 
@@ -137,6 +183,10 @@ class EventConsolidationService:
             customer_id: The customer identifier.
             workspace_id: The workspace UUID.
             amount: Optional payment amount for filtering zero-amount events.
+            correlation_id: Optional transaction-level correlator
+                (subscription_id, invoice_id, charge_id, ...). When provided,
+                suppression only applies between events sharing the same
+                correlator.
 
         Returns:
             True if notification should be sent, False if it should be suppressed.
@@ -161,27 +211,17 @@ class EventConsolidationService:
             )
             return True
 
-        # Check if this event should be suppressed
-        suppression_key = self._get_suppression_key(workspace_id, customer_id)
+        # Check if this event should be suppressed. Only a primary event
+        # for the SAME transaction (same correlator) can suppress this one.
+        suppression_key = self._get_suppression_key(
+            workspace_id, customer_id, correlation_id
+        )
         suppressed_events = cache.get(suppression_key) or set()
 
         if event_type in suppressed_events:
-            # Track suppressed events that should enrich other notifications
-            if event_type in self.TRACK_WHEN_SUPPRESSED:
-                self._mark_event_pending(workspace_id, customer_id, event_type)
             logger.info(
                 f"Suppressing {event_type} notification for customer {customer_id} "
                 f"in workspace {workspace_id} (consolidation with primary event)"
-            )
-            return False
-
-        # Special handling for trial_ending: always suppress and track
-        # The payment notification will show "Trial converted" instead
-        if event_type == "trial_ending":
-            self._mark_event_pending(workspace_id, customer_id, event_type)
-            logger.info(
-                f"Suppressing {event_type} notification for customer {customer_id} "
-                f"in workspace {workspace_id} (will merge with payment notification)"
             )
             return False
 
@@ -189,7 +229,7 @@ class EventConsolidationService:
         if event_type in self.PRIMARY_EVENTS:
             events_to_suppress = self.PRIMARY_EVENTS[event_type]
             self._mark_events_for_suppression(
-                workspace_id, customer_id, events_to_suppress
+                workspace_id, customer_id, events_to_suppress, correlation_id
             )
             logger.debug(
                 f"Primary event {event_type} processed, marking {events_to_suppress} "
@@ -203,6 +243,7 @@ class EventConsolidationService:
         workspace_id: str,
         customer_id: str,
         events_to_suppress: set[str],
+        correlation_id: str | None = None,
     ) -> None:
         """Mark events for suppression within the consolidation window.
 
@@ -210,8 +251,12 @@ class EventConsolidationService:
             workspace_id: The workspace UUID.
             customer_id: The customer identifier.
             events_to_suppress: Set of event types to suppress.
+            correlation_id: Optional transaction-level correlator scoping
+                the suppression to a single transaction.
         """
-        suppression_key = self._get_suppression_key(workspace_id, customer_id)
+        suppression_key = self._get_suppression_key(
+            workspace_id, customer_id, correlation_id
+        )
 
         # Get existing suppressed events and merge
         existing = cache.get(suppression_key) or set()
@@ -223,71 +268,6 @@ class EventConsolidationService:
             updated,
             timeout=self.CONSOLIDATION_WINDOW_SECONDS,
         )
-
-    def _get_pending_key(self, workspace_id: str, customer_id: str) -> str:
-        """Generate cache key for pending events.
-
-        Args:
-            workspace_id: The workspace UUID.
-            customer_id: The customer identifier.
-
-        Returns:
-            Cache key string for pending events.
-        """
-        return f"event_pending:{workspace_id}:{customer_id}"
-
-    def _mark_event_pending(
-        self,
-        workspace_id: str,
-        customer_id: str,
-        event_type: str,
-    ) -> None:
-        """Mark an event as pending for insight enrichment.
-
-        When certain events are suppressed (e.g., trial_ending), we track them
-        so that the primary event can show a richer insight (e.g., "Trial converted").
-
-        Args:
-            workspace_id: The workspace UUID.
-            customer_id: The customer identifier.
-            event_type: The event type being tracked.
-        """
-        pending_key = self._get_pending_key(workspace_id, customer_id)
-
-        # Get existing pending events and add this one
-        existing = cache.get(pending_key) or set()
-        updated = existing | {event_type}
-
-        # Store with TTL
-        cache.set(
-            pending_key,
-            updated,
-            timeout=self.CONSOLIDATION_WINDOW_SECONDS,
-        )
-        logger.debug(
-            f"Marked {event_type} as pending for customer {customer_id} "
-            f"in workspace {workspace_id}"
-        )
-
-    def has_pending_trial(self, workspace_id: str, customer_id: str) -> bool:
-        """Check if there's a pending trial_ending event for this customer.
-
-        Used by insight detection to show "Trial converted" when a payment
-        arrives after a trial_ending event.
-
-        Args:
-            workspace_id: The workspace UUID.
-            customer_id: The customer identifier.
-
-        Returns:
-            True if a trial_ending event is pending.
-        """
-        if not workspace_id or not customer_id:
-            return False
-
-        pending_key = self._get_pending_key(workspace_id, customer_id)
-        pending_events = cache.get(pending_key) or set()
-        return "trial_ending" in pending_events
 
     def record_event(
         self,

--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -257,7 +257,7 @@ class InsightDetector:
             InsightInfo describing the failed payment or None.
         """
         _ = customer_data  # unused
-        metadata = event_data.get("metadata", {})
+        metadata = event_data.get("metadata") or {}
         if not metadata.get("has_payment_failure"):
             return None
 
@@ -273,14 +273,31 @@ class InsightDetector:
         if attempt_count and attempt_count >= 2:
             text += f" (attempt #{attempt_count})"
 
-        next_attempt = metadata.get("next_payment_attempt")
-        if next_attempt:
-            next_date = datetime.fromtimestamp(next_attempt, tz=timezone.utc).strftime(
-                "%b %-d"
-            )
-            text += f" · Next retry {next_date}"
+        next_retry = self._format_retry_date(metadata.get("next_payment_attempt"))
+        if next_retry:
+            text += f" · Next retry {next_retry}"
 
         return InsightInfo(icon=self.ICONS["failed_attempt"], text=text)
+
+    def _format_retry_date(self, next_attempt: Any) -> str | None:
+        """Format a next-payment-attempt timestamp as a short date.
+
+        Portable (no glibc-only ``%-d`` strftime code) and tolerant of
+        non-integer timestamp values from provider payloads.
+
+        Args:
+            next_attempt: Unix timestamp (int, float, or numeric string).
+
+        Returns:
+            Short date string like "Feb 22", or None if unparseable.
+        """
+        if next_attempt is None:
+            return None
+        try:
+            retry_dt = datetime.fromtimestamp(int(next_attempt), tz=timezone.utc)
+        except (ValueError, TypeError, OverflowError, OSError):
+            return None
+        return f"{retry_dt.strftime('%b')} {retry_dt.day}"
 
     def _detect_trial_converted(
         self, event_data: dict[str, Any], customer_data: dict[str, Any]
@@ -304,7 +321,7 @@ class InsightDetector:
         if event_type not in ("payment_success", "invoice_paid"):
             return None
 
-        metadata = event_data.get("metadata", {})
+        metadata = event_data.get("metadata") or {}
         if metadata.get("is_trial_conversion"):
             return InsightInfo(
                 icon=self.ICONS["trial_converted"],
@@ -401,6 +418,13 @@ class InsightDetector:
         marker ensures a customer paying multiple times inside the window
         (e.g. weekly) celebrates each anniversary exactly once.
 
+        Requires both customer_id and workspace_id: the dedup key is
+        tenant-scoped, and customer ids are only unique per provider
+        account, so claiming without a workspace could let one tenant's
+        celebration swallow another tenant's. Skipping the insight when
+        the workspace is unknown is the only behavior that cannot collide
+        across tenants.
+
         Args:
             event_data: Event data dictionary.
             customer_data: Customer data dictionary.
@@ -412,8 +436,9 @@ class InsightDetector:
             return None
 
         customer_id = event_data.get("customer_id", "")
-        if not customer_id:
-            # Cannot attribute (or dedup) an anniversary without a customer
+        workspace_id = event_data.get("workspace_id", "")
+        if not customer_id or not workspace_id:
+            # Cannot attribute (or tenant-scope the dedup of) an anniversary
             return None
 
         created_at = customer_data.get("created_at") or customer_data.get(
@@ -435,7 +460,7 @@ class InsightDetector:
                 continue
 
             if not self._claim_anniversary(
-                event_data.get("workspace_id", ""), customer_id, anniversary_month
+                workspace_id, customer_id, anniversary_month
             ):
                 return None  # Already celebrated this anniversary
 
@@ -457,7 +482,8 @@ class InsightDetector:
         detection window cannot both celebrate the same anniversary.
 
         Args:
-            workspace_id: The workspace UUID (may be empty).
+            workspace_id: The workspace UUID (never empty; enforced by caller
+                so dedup keys are always tenant-scoped).
             customer_id: The customer identifier.
             anniversary_month: The anniversary being claimed, in months.
 

--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -4,11 +4,21 @@ This module analyzes payment events and customer data to detect significant
 milestones and generate contextual insights for notifications.
 """
 
+import calendar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from django.core.cache import cache
 from webhooks.models.rich_notification import InsightInfo
+
+# How long the "anniversary fired" dedup marker lives. Must be longer than
+# the +/- ANNIVERSARY_TOLERANCE_DAYS detection window so a customer paying
+# multiple times inside the window only celebrates once per anniversary.
+ANNIVERSARY_DEDUP_TTL_SECONDS = 30 * 24 * 60 * 60  # 30 days
+
+# A payment within this many days of the true anniversary date counts.
+ANNIVERSARY_TOLERANCE_DAYS = 3
 
 
 def _to_float(value: Any, default: float = 0.0) -> float:
@@ -98,6 +108,7 @@ class InsightDetector:
         """
         # Priority order for milestone detection
         detectors = [
+            self._detect_initial_payment_failure,
             self._detect_trial_started,
             self._detect_trial_converted,
             self._detect_first_payment,
@@ -226,14 +237,60 @@ class InsightDetector:
             text="New trial - Welcome aboard!",
         )
 
+    def _detect_initial_payment_failure(
+        self, event_data: dict[str, Any], customer_data: dict[str, Any]
+    ) -> InsightInfo | None:
+        """Detect a payment failure folded into an aggregated event.
+
+        When a subscription is created with an immediately-declining card,
+        Stripe queues subscription.created and invoice.payment_failed under
+        the same idempotency key. The aggregation keeps the subscription
+        event as the notification but preserves the failure details in
+        metadata (see PendingEventQueue._aggregate_events). Surface that
+        failure prominently so it is never silently dropped.
+
+        Args:
+            event_data: Event data dictionary.
+            customer_data: Customer data dictionary (unused but required for interface).
+
+        Returns:
+            InsightInfo describing the failed payment or None.
+        """
+        _ = customer_data  # unused
+        metadata = event_data.get("metadata", {})
+        if not metadata.get("has_payment_failure"):
+            return None
+
+        text = "Payment failed"
+        failure_reason = metadata.get("failure_reason")
+        decline_code = metadata.get("decline_code")
+        if failure_reason:
+            text += f": {failure_reason}"
+        elif decline_code:
+            text += f": {decline_code}"
+
+        attempt_count = metadata.get("attempt_count")
+        if attempt_count and attempt_count >= 2:
+            text += f" (attempt #{attempt_count})"
+
+        next_attempt = metadata.get("next_payment_attempt")
+        if next_attempt:
+            next_date = datetime.fromtimestamp(next_attempt, tz=timezone.utc).strftime(
+                "%b %-d"
+            )
+            text += f" · Next retry {next_date}"
+
+        return InsightInfo(icon=self.ICONS["failed_attempt"], text=text)
+
     def _detect_trial_converted(
         self, event_data: dict[str, Any], customer_data: dict[str, Any]
     ) -> InsightInfo | None:
         """Detect if this payment converted a trial.
 
-        When a payment arrives and there was a pending trial_ending event
-        for the same customer, show "Trial converted" instead of separate
-        notifications.
+        Stateless: the Stripe parser flags the first paid invoice after a
+        trial (invoice period_start at the subscription's trial_end) with
+        ``is_trial_conversion`` metadata, so no cross-event cache marker is
+        needed even though trial_will_end fires ~3 days earlier.
 
         Args:
             event_data: Event data dictionary.
@@ -243,18 +300,12 @@ class InsightDetector:
             InsightInfo for trial converted or None.
         """
         _ = customer_data  # unused
-        # Late import to avoid circular dependency
-        from webhooks.services.event_consolidation import event_consolidation_service
-
         event_type = event_data.get("type", "")
         if event_type not in ("payment_success", "invoice_paid"):
             return None
 
-        # Check if there's a pending trial_ending for this customer
-        workspace_id = event_data.get("workspace_id", "")
-        customer_id = event_data.get("customer_id", "")
-
-        if event_consolidation_service.has_pending_trial(workspace_id, customer_id):
+        metadata = event_data.get("metadata", {})
+        if metadata.get("is_trial_conversion"):
             return InsightInfo(
                 icon=self.ICONS["trial_converted"],
                 text="Trial converted to paid subscription",
@@ -284,13 +335,18 @@ class InsightDetector:
         )
         new_ltv = previous_ltv + current_amount
 
-        # Check which milestone was crossed
-        for milestone in self.config.ltv_milestones:
-            if previous_ltv < milestone <= new_ltv:
-                return InsightInfo(
-                    icon=self.ICONS["ltv_milestone"],
-                    text=f"Crossed ${milestone:,.0f} lifetime!",
-                )
+        # Celebrate the LARGEST milestone crossed by this payment (a big
+        # payment can cross several at once - one Slack message per event).
+        crossed = [
+            milestone
+            for milestone in self.config.ltv_milestones
+            if previous_ltv < milestone <= new_ltv
+        ]
+        if crossed:
+            return InsightInfo(
+                icon=self.ICONS["ltv_milestone"],
+                text=f"Crossed ${max(crossed):,.0f} lifetime!",
+            )
 
         return None
 
@@ -314,26 +370,36 @@ class InsightDetector:
             pass
         return None
 
-    def _get_months_active(self, created_date: datetime) -> int:
-        """Calculate months active from creation date.
+    def _add_months(self, date: datetime, months: int) -> datetime:
+        """Return the date shifted forward by a number of calendar months.
+
+        Clamps the day when the target month is shorter (e.g. a customer
+        created Jan 31 has a Feb 28/29 monthly anniversary).
 
         Args:
-            created_date: Customer creation datetime.
+            date: Base datetime.
+            months: Number of months to add.
 
         Returns:
-            Number of months active.
+            Shifted datetime.
         """
-        # Use timezone-aware now if created_date is timezone-aware
-        if created_date.tzinfo is not None:
-            now = datetime.now(timezone.utc)
-        else:
-            now = datetime.now()
-        return (now - created_date).days // 30
+        total_months = date.month - 1 + months
+        year = date.year + total_months // 12
+        month = total_months % 12 + 1
+        # Clamp day to the last day of the target month
+        days_in_month = calendar.monthrange(year, month)[1]
+        return date.replace(year=year, month=month, day=min(date.day, days_in_month))
 
     def _detect_anniversary(
         self, event_data: dict[str, Any], customer_data: dict[str, Any]
     ) -> InsightInfo | None:
         """Detect customer anniversary milestones.
+
+        Computes each configured anniversary's TRUE calendar date from the
+        customer's creation date and fires only when the payment lands
+        within +/- ANNIVERSARY_TOLERANCE_DAYS of it. A cache-backed dedup
+        marker ensures a customer paying multiple times inside the window
+        (e.g. weekly) celebrates each anniversary exactly once.
 
         Args:
             event_data: Event data dictionary.
@@ -345,6 +411,11 @@ class InsightDetector:
         if event_data.get("type", "") != "payment_success":
             return None
 
+        customer_id = event_data.get("customer_id", "")
+        if not customer_id:
+            # Cannot attribute (or dedup) an anniversary without a customer
+            return None
+
         created_at = customer_data.get("created_at") or customer_data.get(
             "subscription_start"
         )
@@ -352,18 +423,49 @@ class InsightDetector:
         if not created_date:
             return None
 
-        months_active = self._get_months_active(created_date)
+        if created_date.tzinfo is not None:
+            now = datetime.now(timezone.utc)
+        else:
+            now = datetime.now()
 
         for anniversary_month in self.config.anniversary_months:
-            if abs(months_active - anniversary_month) <= 0.5:
-                years = anniversary_month // 12
-                if years == 1:
-                    text = "1 year anniversary!"
-                else:
-                    text = f"{years} year anniversary!"
-                return InsightInfo(icon=self.ICONS["anniversary"], text=text)
+            anniversary_date = self._add_months(created_date, anniversary_month)
+            days_off = (now.date() - anniversary_date.date()).days
+            if abs(days_off) > ANNIVERSARY_TOLERANCE_DAYS:
+                continue
+
+            if not self._claim_anniversary(
+                event_data.get("workspace_id", ""), customer_id, anniversary_month
+            ):
+                return None  # Already celebrated this anniversary
+
+            years = anniversary_month // 12
+            if years == 1:
+                text = "1 year anniversary!"
+            else:
+                text = f"{years} year anniversary!"
+            return InsightInfo(icon=self.ICONS["anniversary"], text=text)
 
         return None
+
+    def _claim_anniversary(
+        self, workspace_id: str, customer_id: str, anniversary_month: int
+    ) -> bool:
+        """Atomically claim an anniversary celebration for a customer.
+
+        Uses cache.add (SETNX on Redis) so concurrent payments inside the
+        detection window cannot both celebrate the same anniversary.
+
+        Args:
+            workspace_id: The workspace UUID (may be empty).
+            customer_id: The customer identifier.
+            anniversary_month: The anniversary being claimed, in months.
+
+        Returns:
+            True if this event won the claim and should celebrate.
+        """
+        dedup_key = f"anniversary_sent:{workspace_id}:{customer_id}:{anniversary_month}"
+        return bool(cache.add(dedup_key, True, timeout=ANNIVERSARY_DEDUP_TTL_SECONDS))
 
     def _detect_payment_growth(
         self, event_data: dict[str, Any], customer_data: dict[str, Any]

--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -273,31 +273,32 @@ class InsightDetector:
         if attempt_count and attempt_count >= 2:
             text += f" (attempt #{attempt_count})"
 
-        next_retry = self._format_retry_date(metadata.get("next_payment_attempt"))
+        next_retry = self._format_short_date(metadata.get("next_payment_attempt"))
         if next_retry:
             text += f" · Next retry {next_retry}"
 
         return InsightInfo(icon=self.ICONS["failed_attempt"], text=text)
 
-    def _format_retry_date(self, next_attempt: Any) -> str | None:
-        """Format a next-payment-attempt timestamp as a short date.
+    def _format_short_date(self, timestamp: Any) -> str | None:
+        """Format a unix timestamp as a short human date (e.g. "Feb 22").
 
-        Portable (no glibc-only ``%-d`` strftime code) and tolerant of
-        non-integer timestamp values from provider payloads.
+        Single formatting path for all insight dates. Portable (no
+        glibc-only ``%-d`` strftime code) and tolerant of non-integer
+        timestamp values from provider payloads.
 
         Args:
-            next_attempt: Unix timestamp (int, float, or numeric string).
+            timestamp: Unix timestamp (int, float, or numeric string).
 
         Returns:
             Short date string like "Feb 22", or None if unparseable.
         """
-        if next_attempt is None:
+        if timestamp is None:
             return None
         try:
-            retry_dt = datetime.fromtimestamp(int(next_attempt), tz=timezone.utc)
+            dt = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
         except (ValueError, TypeError, OverflowError, OSError):
             return None
-        return f"{retry_dt.strftime('%b')} {retry_dt.day}"
+        return f"{dt.strftime('%b')} {dt.day}"
 
     def _detect_trial_converted(
         self, event_data: dict[str, Any], customer_data: dict[str, Any]
@@ -592,20 +593,14 @@ class InsightDetector:
         # Use Stripe's attempt_count from metadata (most reliable for Stripe)
         attempt_count = metadata.get("attempt_count")
         if attempt_count is not None and attempt_count >= 1:
-            next_attempt = metadata.get("next_payment_attempt")
+            next_date = self._format_short_date(metadata.get("next_payment_attempt"))
             if attempt_count >= 2:
                 text = f"Retry #{attempt_count}"
-                if next_attempt:
-                    next_date = datetime.fromtimestamp(
-                        next_attempt, tz=timezone.utc
-                    ).strftime("%b %-d")
+                if next_date:
                     text += f" · Next attempt {next_date}"
                 return InsightInfo(icon=self.ICONS["failed_attempt"], text=text)
             # First attempt with next retry scheduled
-            if next_attempt:
-                next_date = datetime.fromtimestamp(
-                    next_attempt, tz=timezone.utc
-                ).strftime("%b %-d")
+            if next_date:
                 return InsightInfo(
                     icon=self.ICONS["failed_attempt"],
                     text=f"Next retry {next_date}",

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -17,6 +17,7 @@ Thread Safety:
 - Timer scheduling uses threading.Lock for in-process safety
 """
 
+import copy
 import json
 import logging
 import threading
@@ -443,10 +444,11 @@ class PendingEventQueue:
         result_event = winner["event_data"].copy()
         # Always give the result its own metadata dict: a shared reference
         # (or a None/missing value) must never leak into later mutation by
-        # _merge_payment_failure.
-        winner_metadata = result_event.get("metadata")
+        # _merge_payment_failure or downstream consumers. Deep copy because
+        # metadata can hold nested structures (e.g. Shopify line_items).
+        winner_metadata = winner["event_data"].get("metadata")
         result_event["metadata"] = (
-            dict(winner_metadata) if isinstance(winner_metadata, dict) else {}
+            copy.deepcopy(winner_metadata) if isinstance(winner_metadata, dict) else {}
         )
         result_customer = winner["customer_data"].copy()
 

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -21,7 +21,7 @@ import json
 import logging
 import threading
 import time
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from core.models import Integration, Workspace
 from django.conf import settings
@@ -385,15 +385,42 @@ class PendingEventQueue:
         except Exception as e:
             logger.warning(f"Failed to release lock {lock_key}: {e}")
 
+    # Event type priority for aggregation (higher = preferred)
+    TYPE_PRIORITY: ClassVar[dict[str, int]] = {
+        "trial_started": 100,
+        "subscription_created": 90,
+        "subscription_updated": 80,
+        "subscription_deleted": 80,
+        "checkout_completed": 70,
+        "payment_failure": 60,  # Never dropped: folded into winner's metadata
+        "payment_success": 50,
+        "invoice_paid": 40,
+    }
+
+    # Failure details preserved when a payment_failure loses the priority
+    # contest (e.g. to subscription_created in the same idempotency bucket)
+    FAILURE_METADATA_FIELDS: ClassVar[tuple[str, ...]] = (
+        "failure_reason",
+        "decline_code",
+        "attempt_count",
+        "next_payment_attempt",
+    )
+
     def _aggregate_events(
         self, stored_items: list[dict[str, Any]]
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Combine multiple events, prioritizing best data.
 
         Priority rules:
-        - event_type: Prefer subscription_created/trial_started over invoice events
-        - customer_email: Take from ANY event that has it (invoice events have it)
-        - Other fields: Take from first event, update if better data found
+        - event: The FULL event (type, amount, external_id, currency,
+          metadata, ...) is taken from the highest-priority event so the
+          notification never mixes fields from unrelated events.
+        - customer_email: Take from ANY event that has it (invoice events
+          have it, subscription events don't).
+        - payment_failure: Never silently dropped. If a failure shares the
+          bucket with a higher-priority event (e.g. subscription created
+          with an immediately-declining card), its details are merged into
+          the winner's metadata so one richer notification surfaces both.
 
         Args:
             stored_items: List of stored items with event_data and customer_data.
@@ -404,25 +431,23 @@ class PendingEventQueue:
         if not stored_items:
             return {}, {}
 
-        # Start with first item as base
-        result_event = stored_items[0]["event_data"].copy()
-        result_customer = stored_items[0]["customer_data"].copy()
+        # Pick the highest-priority event as the winner (first wins ties)
+        # and copy it in FULL - amount, external_id, currency and metadata
+        # must all come from the same event, not from stored_items[0].
+        winner = max(
+            stored_items,
+            key=lambda item: self.TYPE_PRIORITY.get(
+                item["event_data"].get("type", ""), 0
+            ),
+        )
+        result_event = winner["event_data"].copy()
+        if result_event.get("metadata"):
+            result_event["metadata"] = dict(result_event["metadata"])
+        result_customer = winner["customer_data"].copy()
 
-        # Event type priority (higher = preferred)
-        type_priority = {
-            "trial_started": 100,
-            "subscription_created": 90,
-            "subscription_updated": 80,
-            "subscription_deleted": 80,
-            "checkout_completed": 70,
-            "payment_success": 50,
-            "invoice_paid": 40,
-            "payment_failure": 60,  # Important, keep if present
-        }
-
-        best_type_priority = type_priority.get(result_event.get("type", ""), 0)
-
-        for item in stored_items[1:]:
+        for item in stored_items:
+            if item is winner:
+                continue
             event_data = item["event_data"]
             customer_data = item["customer_data"]
 
@@ -439,22 +464,12 @@ class PendingEventQueue:
             if event_data.get("customer_email") and not result_customer.get("email"):
                 result_customer["email"] = event_data["customer_email"]
 
-            # Priority: prefer subscription/trial events for the notification type
-            event_type = event_data.get("type", "")
-            event_priority = type_priority.get(event_type, 0)
-
-            if event_priority > best_type_priority:
-                result_event["type"] = event_type
-                best_type_priority = event_priority
-
-                # Copy metadata from the preferred event type
-                if event_data.get("metadata"):
-                    result_event["metadata"] = event_data["metadata"]
-
             # Merge other customer data if missing
             for field in ["first_name", "last_name", "company_name"]:
                 if customer_data.get(field) and not result_customer.get(field):
                     result_customer[field] = customer_data[field]
+
+        self._merge_payment_failure(result_event, stored_items)
 
         logger.info(
             f"Aggregated {len(stored_items)} events: type={result_event.get('type')}, "
@@ -464,6 +479,51 @@ class PendingEventQueue:
         self._warn_if_missing_email(result_event, result_customer, stored_items)
 
         return result_event, result_customer
+
+    def _merge_payment_failure(
+        self,
+        result_event: dict[str, Any],
+        stored_items: list[dict[str, Any]],
+    ) -> None:
+        """Fold a losing payment_failure's details into the winning event.
+
+        When subscription.created and invoice.payment_failed share an
+        idempotency bucket, the subscription event wins the type contest but
+        the failure must still be surfaced. Marks the winner's metadata with
+        ``has_payment_failure`` plus the failure details so the notification
+        (via InsightDetector) reports "new subscription - but the initial
+        payment failed" instead of a bare "New subscription!".
+
+        Args:
+            result_event: Aggregated event data (mutated).
+            stored_items: Original list of stored items.
+        """
+        if result_event.get("type") == "payment_failure":
+            return  # The failure IS the notification
+
+        failure_items = [
+            item
+            for item in stored_items
+            if item["event_data"].get("type") == "payment_failure"
+        ]
+        if not failure_items:
+            return
+
+        failure_event = failure_items[0]["event_data"]
+        failure_metadata = failure_event.get("metadata", {})
+
+        metadata = result_event.setdefault("metadata", {})
+        metadata["has_payment_failure"] = True
+        for field in self.FAILURE_METADATA_FIELDS:
+            if failure_metadata.get(field) is not None:
+                metadata[field] = failure_metadata[field]
+        if failure_event.get("amount"):
+            metadata["failed_amount"] = failure_event["amount"]
+
+        logger.info(
+            f"Merged payment_failure into {result_event.get('type')} notification "
+            f"(reason: {failure_metadata.get('failure_reason', 'unknown')})"
+        )
 
     def _warn_if_missing_email(
         self,
@@ -527,12 +587,17 @@ class PendingEventQueue:
         external_id = event_data.get("external_id", "")
 
         # Check if this event should be suppressed due to consolidation
-        # (e.g., $0 trial invoices)
+        # (e.g., $0 trial invoices). Suppression is scoped to the
+        # transaction-level correlator so an unrelated second transaction
+        # for the same customer is never suppressed.
         should_notify = event_consolidation_service.should_send_notification(
             event_type=event_type,
             customer_id=customer_id,
             workspace_id=workspace_id,
             amount=event_data.get("amount"),
+            correlation_id=event_consolidation_service.extract_correlation_id(
+                event_data
+            ),
         )
 
         if not should_notify:

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -441,8 +441,13 @@ class PendingEventQueue:
             ),
         )
         result_event = winner["event_data"].copy()
-        if result_event.get("metadata"):
-            result_event["metadata"] = dict(result_event["metadata"])
+        # Always give the result its own metadata dict: a shared reference
+        # (or a None/missing value) must never leak into later mutation by
+        # _merge_payment_failure.
+        winner_metadata = result_event.get("metadata")
+        result_event["metadata"] = (
+            dict(winner_metadata) if isinstance(winner_metadata, dict) else {}
+        )
         result_customer = winner["customer_data"].copy()
 
         for item in stored_items:
@@ -510,14 +515,21 @@ class PendingEventQueue:
             return
 
         failure_event = failure_items[0]["event_data"]
-        failure_metadata = failure_event.get("metadata", {})
+        failure_metadata = failure_event.get("metadata")
+        if not isinstance(failure_metadata, dict):
+            failure_metadata = {}
 
-        metadata = result_event.setdefault("metadata", {})
+        metadata = result_event.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+            result_event["metadata"] = metadata
+
         metadata["has_payment_failure"] = True
         for field in self.FAILURE_METADATA_FIELDS:
             if failure_metadata.get(field) is not None:
                 metadata[field] = failure_metadata[field]
-        if failure_event.get("amount"):
+        # `is not None` (not truthiness): a legitimate 0.0 must be kept
+        if failure_event.get("amount") is not None:
             metadata["failed_amount"] = failure_event["amount"]
 
         logger.info(
@@ -585,6 +597,10 @@ class PendingEventQueue:
         customer_id = event_data.get("customer_id", "")
         workspace_id = str(workspace.uuid) if workspace else ""
         external_id = event_data.get("external_id", "")
+
+        # Add workspace_id to event_data for insight detection (tenant-scoped
+        # anniversary dedup), mirroring webhook_router._process_immediately
+        event_data["workspace_id"] = workspace_id
 
         # Check if this event should be suppressed due to consolidation
         # (e.g., $0 trial invoices). Suppression is scoped to the

--- a/app/webhooks/webhook_router.py
+++ b/app/webhooks/webhook_router.py
@@ -345,12 +345,15 @@ def _process_immediately(
     # Add workspace_id to event_data for insight detection
     event_data["workspace_id"] = workspace_id
 
-    # Check if this event should be suppressed due to consolidation
+    # Check if this event should be suppressed due to consolidation.
+    # Suppression is scoped to the transaction-level correlator so an
+    # unrelated second transaction for the same customer is never suppressed.
     should_notify = event_consolidation_service.should_send_notification(
         event_type=event_type,
         customer_id=customer_id,
         workspace_id=workspace_id,
         amount=event_data.get("amount"),
+        correlation_id=event_consolidation_service.extract_correlation_id(event_data),
     )
 
     if not should_notify:

--- a/tests/test_event_consolidation.py
+++ b/tests/test_event_consolidation.py
@@ -113,21 +113,183 @@ class TestEventConsolidationService:
 
         assert result is True
 
-    def test_trial_ending_always_suppressed_and_tracked(
+    def test_trial_ending_never_suppressed(
         self, service: EventConsolidationService, mock_cache
     ) -> None:
-        """Test that trial_ending is suppressed and tracked for merging with payment."""
-        # Trial ending should be suppressed (it merges with payment notification)
+        """Test that trial_ending is delivered as its own notification.
+
+        Stripe fires trial_will_end ~3 days before the trial converts, so a
+        cache-based merge with the later payment can never work. The product
+        decision is to deliver BOTH: "trial ending in 3 days" now and
+        "trial converted" later (detected statelessly from the invoice).
+        """
         result = service.should_send_notification(
             event_type="trial_ending",
             customer_id="cus_123",
             workspace_id="ws_456",
         )
 
-        assert result is False
+        assert result is True
 
-        # Check that it's tracked as pending for insight enrichment
-        assert service.has_pending_trial("ws_456", "cus_123") is True
+    def test_trial_ending_not_suppressed_even_after_payment(
+        self, service: EventConsolidationService, mock_cache
+    ) -> None:
+        """Test that a recent payment does not suppress a trial_ending warning."""
+        service.should_send_notification(
+            event_type="payment_success",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            amount=100.00,
+        )
+
+        result = service.should_send_notification(
+            event_type="trial_ending",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+        )
+
+        assert result is True
+
+    def test_trial_lifecycle_produces_both_notifications(
+        self, service: EventConsolidationService, mock_cache
+    ) -> None:
+        """Test the full trial lifecycle: warning AND conversion notifications.
+
+        Sequence: trial_will_end fires ~3 days before the trial ends, then
+        the first paid invoice arrives when it actually converts. The user
+        must receive both notifications - the conversion is detected
+        statelessly from the invoice payload (is_trial_conversion metadata
+        set by the Stripe parser), not from a cache marker that would have
+        expired days earlier.
+        """
+        from webhooks.services.insight_detector import InsightDetector
+
+        # T=0: trial_will_end arrives -> "trial ending in 3 days" delivered
+        trial_ending_allowed = service.should_send_notification(
+            event_type="trial_ending",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+        )
+        assert trial_ending_allowed is True
+
+        # T=+3 days: first paid invoice after the trial arrives. The parser
+        # flagged it as a trial conversion from the payload alone.
+        payment_event = {
+            "type": "payment_success",
+            "customer_id": "cus_123",
+            "workspace_id": "ws_456",
+            "amount": 29.00,
+            "metadata": {"is_trial_conversion": True},
+        }
+        payment_allowed = service.should_send_notification(
+            event_type="payment_success",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            amount=29.00,
+        )
+        assert payment_allowed is True
+
+        # And the payment notification carries the "Trial converted" insight
+        insight = InsightDetector().detect(payment_event, {"payment_history": []})
+        assert insight is not None
+        assert "Trial converted" in insight.text
+
+    def test_unrelated_transaction_not_suppressed(
+        self, service: EventConsolidationService, mock_cache
+    ) -> None:
+        """Test that suppression is scoped to the transaction correlator.
+
+        A checkout for product A must not suppress the payment_success of an
+        unrelated second purchase (different charge) by the same customer
+        within the 5-minute window.
+        """
+        # T=0: checkout for product A suppresses ITS payment notifications
+        service.should_send_notification(
+            event_type="checkout_completed",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            correlation_id="ch_A",
+        )
+
+        # The same transaction's payment IS suppressed
+        same_txn = service.should_send_notification(
+            event_type="payment_success",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            amount=50.00,
+            correlation_id="ch_A",
+        )
+        assert same_txn is False
+
+        # T=+90s: unrelated purchase (different charge) is NOT suppressed
+        other_txn = service.should_send_notification(
+            event_type="payment_success",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            amount=500.00,
+            correlation_id="ch_B",
+        )
+        assert other_txn is True
+
+    def test_cancelling_one_sub_does_not_suppress_other_subs(
+        self, service: EventConsolidationService, mock_cache
+    ) -> None:
+        """Test that cancelling one subscription only suppresses ITS invoice.
+
+        A customer cancels their add-on subscription; the Basic
+        subscription's monthly renewal invoice arriving within 5 minutes
+        must still notify.
+        """
+        # Cancel the add-on subscription
+        service.should_send_notification(
+            event_type="subscription_deleted",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            correlation_id="sub_addon",
+        )
+
+        # The add-on's final invoice IS suppressed (consolidated)
+        addon_invoice = service.should_send_notification(
+            event_type="invoice_paid",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            amount=10.00,
+            correlation_id="sub_addon",
+        )
+        assert addon_invoice is False
+
+        # The Basic subscription's renewal invoice is NOT suppressed
+        basic_invoice = service.should_send_notification(
+            event_type="invoice_paid",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            amount=29.00,
+            correlation_id="sub_basic",
+        )
+        assert basic_invoice is True
+
+    def test_extract_correlation_id_prefers_metadata(
+        self, service: EventConsolidationService
+    ) -> None:
+        """Test correlator extraction prefers transaction metadata ids."""
+        event = {
+            "external_id": "in_123",
+            "metadata": {"subscription_id": "sub_abc"},
+        }
+        assert service.extract_correlation_id(event) == "sub_abc"
+
+    def test_extract_correlation_id_falls_back_to_external_id(
+        self, service: EventConsolidationService
+    ) -> None:
+        """Test correlator extraction falls back to the external object id."""
+        event = {"external_id": "in_123", "metadata": {}}
+        assert service.extract_correlation_id(event) == "in_123"
+
+    def test_extract_correlation_id_returns_none_without_identifiers(
+        self, service: EventConsolidationService
+    ) -> None:
+        """Test correlator extraction returns None when nothing identifies it."""
+        assert service.extract_correlation_id({"metadata": {}}) is None
 
     def test_different_customer_not_affected(
         self, service: EventConsolidationService, mock_cache
@@ -470,8 +632,14 @@ class TestEventConsolidationConstants:
 
         assert "payment_failure" in never_suppress
         assert "payment_action_required" in never_suppress
-        # Note: trial_ending is NOT in NEVER_SUPPRESS anymore
-        # It's suppressed and merged with payment notifications as "Trial converted"
+        # trial_ending is delivered as its own warning; the later "Trial
+        # converted" insight is derived statelessly from the invoice payload
+        assert "trial_ending" in never_suppress
+
+    def test_trial_ending_not_a_suppression_target(self) -> None:
+        """Test that no primary event suppresses trial_ending anymore."""
+        for suppressed in EventConsolidationService.PRIMARY_EVENTS.values():
+            assert "trial_ending" not in suppressed
 
     def test_primary_events_defined(self) -> None:
         """Test that primary events are properly defined."""

--- a/tests/test_event_consolidation.py
+++ b/tests/test_event_consolidation.py
@@ -57,12 +57,13 @@ class TestEventConsolidationService:
     def test_secondary_event_suppressed_after_primary(
         self, service: EventConsolidationService, mock_cache
     ) -> None:
-        """Test that secondary events are suppressed after a primary event."""
+        """Test that secondary events of the same transaction are suppressed."""
         # First, process the primary event
         service.should_send_notification(
             event_type="subscription_created",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="sub_1",
         )
 
         # Now the secondary event should be suppressed
@@ -70,6 +71,7 @@ class TestEventConsolidationService:
             event_type="payment_success",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="sub_1",
         )
 
         assert result is False
@@ -83,6 +85,7 @@ class TestEventConsolidationService:
             event_type="subscription_created",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="sub_1",
         )
 
         # invoice_paid should be suppressed
@@ -90,15 +93,20 @@ class TestEventConsolidationService:
             event_type="invoice_paid",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="sub_1",
         )
 
         assert result is False
 
-    def test_payment_failure_never_suppressed(
+    def test_events_without_correlator_never_suppressed(
         self, service: EventConsolidationService, mock_cache
     ) -> None:
-        """Test that payment_failure is never suppressed."""
-        # Even after a primary event, payment_failure should go through
+        """Test that events lacking a transaction correlator are delivered.
+
+        Without a correlator we cannot tell which transaction a suppression
+        marker belongs to, so a coarse customer-level fallback could swallow
+        an unrelated transaction's notification. Deliver instead.
+        """
         service.should_send_notification(
             event_type="subscription_created",
             customer_id="cus_123",
@@ -106,9 +114,52 @@ class TestEventConsolidationService:
         )
 
         result = service.should_send_notification(
+            event_type="payment_success",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            amount=100.00,
+        )
+
+        assert result is True
+
+    def test_correlated_primary_does_not_suppress_uncorrelated_secondary(
+        self, service: EventConsolidationService, mock_cache
+    ) -> None:
+        """Test that a correlated primary never suppresses a correlator-less event."""
+        service.should_send_notification(
+            event_type="subscription_created",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            correlation_id="sub_1",
+        )
+
+        result = service.should_send_notification(
+            event_type="payment_success",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            amount=100.00,
+        )
+
+        assert result is True
+
+    def test_payment_failure_never_suppressed(
+        self, service: EventConsolidationService, mock_cache
+    ) -> None:
+        """Test that payment_failure is never suppressed."""
+        # Even after a primary event for the SAME transaction,
+        # payment_failure should go through
+        service.should_send_notification(
+            event_type="subscription_created",
+            customer_id="cus_123",
+            workspace_id="ws_456",
+            correlation_id="sub_1",
+        )
+
+        result = service.should_send_notification(
             event_type="payment_failure",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="sub_1",
         )
 
         assert result is True
@@ -300,6 +351,7 @@ class TestEventConsolidationService:
             event_type="subscription_created",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="sub_1",
         )
 
         # Different customer should not be suppressed
@@ -309,6 +361,7 @@ class TestEventConsolidationService:
             customer_id="cus_789",
             workspace_id="ws_456",
             amount=100.00,
+            correlation_id="sub_1",
         )
 
         assert result is True
@@ -322,6 +375,7 @@ class TestEventConsolidationService:
             event_type="subscription_created",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="sub_1",
         )
 
         # Different workspace should not be suppressed
@@ -331,6 +385,7 @@ class TestEventConsolidationService:
             customer_id="cus_123",
             workspace_id="ws_other",
             amount=100.00,
+            correlation_id="sub_1",
         )
 
         assert result is True
@@ -338,11 +393,12 @@ class TestEventConsolidationService:
     def test_checkout_completed_suppresses_payment_events(
         self, service: EventConsolidationService, mock_cache
     ) -> None:
-        """Test that checkout_completed suppresses payment events."""
+        """Test that checkout_completed suppresses its own payment events."""
         service.should_send_notification(
             event_type="checkout_completed",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="cs_1",
         )
 
         # Both payment_success and invoice_paid should be suppressed
@@ -350,11 +406,15 @@ class TestEventConsolidationService:
             event_type="payment_success",
             customer_id="cus_123",
             workspace_id="ws_456",
+            amount=50.00,
+            correlation_id="cs_1",
         )
         result2 = service.should_send_notification(
             event_type="invoice_paid",
             customer_id="cus_123",
             workspace_id="ws_456",
+            amount=50.00,
+            correlation_id="cs_1",
         )
 
         assert result1 is False
@@ -455,6 +515,7 @@ class TestEventConsolidationService:
             customer_id="cus_123",
             workspace_id="ws_456",
             amount=100.00,
+            correlation_id="in_1",
         )
 
         # Another payment_success should still go through
@@ -463,6 +524,7 @@ class TestEventConsolidationService:
             customer_id="cus_123",
             workspace_id="ws_456",
             amount=100.00,
+            correlation_id="in_1",
         )
 
         assert result is True
@@ -470,17 +532,20 @@ class TestEventConsolidationService:
     def test_subscription_deleted_suppresses_invoice_paid(
         self, service: EventConsolidationService, mock_cache
     ) -> None:
-        """Test that subscription_deleted suppresses invoice_paid."""
+        """Test that subscription_deleted suppresses its own invoice_paid."""
         service.should_send_notification(
             event_type="subscription_deleted",
             customer_id="cus_123",
             workspace_id="ws_456",
+            correlation_id="sub_1",
         )
 
         result = service.should_send_notification(
             event_type="invoice_paid",
             customer_id="cus_123",
             workspace_id="ws_456",
+            amount=10.00,
+            correlation_id="sub_1",
         )
 
         assert result is False
@@ -494,11 +559,14 @@ class TestEventConsolidationService:
         fire. The order_created event should suppress the subsequent payment_success
         to prevent duplicate notifications.
         """
-        # First, process order_created (from orders/create webhook)
+        # First, process order_created (from orders/create webhook).
+        # Both webhooks carry the same order id as external_id, which
+        # extract_correlation_id uses as the transaction correlator.
         service.should_send_notification(
             event_type="order_created",
             customer_id="shopify_cus_123",
             workspace_id="ws_456",
+            correlation_id="450789469",
         )
 
         # Now payment_success (from orders/paid webhook) should be suppressed
@@ -506,6 +574,8 @@ class TestEventConsolidationService:
             event_type="payment_success",
             customer_id="shopify_cus_123",
             workspace_id="ws_456",
+            amount=100.00,
+            correlation_id="450789469",
         )
 
         assert result is False

--- a/tests/test_insight_detector.py
+++ b/tests/test_insight_detector.py
@@ -1060,3 +1060,63 @@ class TestFailedAttemptsWithAttemptCount:
 
         assert result is not None
         assert "Attempt #3" in result.text
+
+    def test_string_next_attempt_timestamp_formatted(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test that a numeric-string next_payment_attempt still formats."""
+        event: dict = {
+            "type": "payment_failure",
+            "amount": 53.20,
+            "metadata": {
+                "attempt_count": 2,
+                "next_payment_attempt": "1740182400",  # Feb 22 2025, as string
+            },
+        }
+        customer: dict = {"payment_history": []}
+
+        result = detector.detect(event, customer)
+
+        assert result is not None
+        assert "Retry #2" in result.text
+        assert "Next attempt Feb 22" in result.text
+
+    def test_invalid_next_attempt_timestamp_does_not_crash(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test that garbage next_payment_attempt drops the date, not the insight."""
+        event: dict = {
+            "type": "payment_failure",
+            "amount": 53.20,
+            "metadata": {
+                "attempt_count": 2,
+                "next_payment_attempt": "soon",
+            },
+        }
+        customer: dict = {"payment_history": []}
+
+        result = detector.detect(event, customer)
+
+        assert result is not None
+        assert "Retry #2" in result.text
+        assert "Next attempt" not in result.text
+
+    def test_invalid_timestamp_attempt_1_falls_back_to_reason(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test that attempt 1 with a bad timestamp falls back to the reason."""
+        event: dict = {
+            "type": "payment_failure",
+            "amount": 53.20,
+            "metadata": {
+                "attempt_count": 1,
+                "failure_reason": "Card declined",
+                "next_payment_attempt": "not-a-timestamp",
+            },
+        }
+        customer: dict = {"payment_history": []}
+
+        result = detector.detect(event, customer)
+
+        assert result is not None
+        assert "Card declined" in result.text

--- a/tests/test_insight_detector.py
+++ b/tests/test_insight_detector.py
@@ -413,6 +413,29 @@ class TestAnniversaryDetection:
 
         assert result is None
 
+    def test_no_anniversary_without_workspace_id(
+        self,
+        detector: InsightDetector,
+        anniversary_customer: dict,
+        mock_insight_cache,
+    ) -> None:
+        """Test that anniversary is skipped when the workspace is unknown.
+
+        The dedup key is tenant-scoped; customer ids are only unique per
+        provider account, so an unscoped claim could collide across
+        tenants. Skipping is the only behavior that cannot collide.
+        """
+        event = {
+            "type": "payment_success",
+            "customer_id": "cus_anniv",
+            "amount": 25.00,
+            "metadata": {},
+        }
+
+        result = detector.detect(event, anniversary_customer)
+
+        assert result is None
+
     def test_add_months_clamps_short_months(self, detector: InsightDetector) -> None:
         """Test that month arithmetic clamps Jan 31 to end of February."""
         jan_31 = datetime(2025, 1, 31, tzinfo=timezone.utc)
@@ -483,6 +506,19 @@ class TestTrialConvertedDetection:
 
         assert result is not None
         assert "Trial converted" in result.text
+
+    def test_none_metadata_does_not_crash(self, detector: InsightDetector) -> None:
+        """Test that an explicit metadata=None is handled gracefully."""
+        event = {
+            "type": "payment_success",
+            "customer_id": "cus_123",
+            "amount": 29.00,
+            "metadata": None,
+        }
+
+        result = detector._detect_trial_converted(event, {})
+
+        assert result is None
 
 
 class TestInitialPaymentFailureDetection:
@@ -557,6 +593,46 @@ class TestInitialPaymentFailureDetection:
         result = detector._detect_initial_payment_failure(event, {})
 
         assert result is None
+
+    def test_none_metadata_does_not_crash(self, detector: InsightDetector) -> None:
+        """Test that an explicit metadata=None is handled gracefully."""
+        event = {"type": "subscription_created", "metadata": None}
+
+        result = detector._detect_initial_payment_failure(event, {})
+
+        assert result is None
+
+    def test_retry_date_from_string_timestamp(self, detector: InsightDetector) -> None:
+        """Test that a numeric-string timestamp is still formatted."""
+        event = {
+            "type": "subscription_created",
+            "metadata": {
+                "has_payment_failure": True,
+                "next_payment_attempt": "1740182400",  # Feb 22 2025, as string
+            },
+        }
+
+        result = detector._detect_initial_payment_failure(event, {})
+
+        assert result is not None
+        assert "Next retry Feb 22" in result.text
+
+    def test_invalid_retry_timestamp_ignored(self, detector: InsightDetector) -> None:
+        """Test that an unparseable timestamp drops the retry date, not the insight."""
+        event = {
+            "type": "subscription_created",
+            "metadata": {
+                "has_payment_failure": True,
+                "failure_reason": "Card declined",
+                "next_payment_attempt": "soon",
+            },
+        }
+
+        result = detector._detect_initial_payment_failure(event, {})
+
+        assert result is not None
+        assert "Card declined" in result.text
+        assert "Next retry" not in result.text
 
 
 class TestPaymentGrowthDetection:

--- a/tests/test_insight_detector.py
+++ b/tests/test_insight_detector.py
@@ -4,8 +4,49 @@ This module tests the InsightDetector class that identifies
 milestones and generates insights for notifications.
 """
 
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
 import pytest
 from webhooks.services.insight_detector import InsightDetector, MilestoneConfig
+
+
+def _years_ago(years: int, offset_days: int = 0) -> str:
+    """Build an ISO timestamp exactly N calendar years before now.
+
+    Args:
+        years: Number of years to go back.
+        offset_days: Extra days to shift the result by (can be negative).
+
+    Returns:
+        ISO-formatted UTC timestamp string.
+    """
+    now = datetime.now(timezone.utc)
+    day = now.day
+    if now.month == 2 and now.day == 29:
+        day = 28  # Leap day has no exact match in non-leap years
+    created = now.replace(year=now.year - years, day=day)
+    return (created + timedelta(days=offset_days)).isoformat()
+
+
+@pytest.fixture
+def mock_insight_cache():
+    """Stateful cache mock for anniversary dedup (cache.add semantics).
+
+    Yields:
+        Mock cache whose add() returns True only for previously-unseen keys.
+    """
+    store: dict = {}
+
+    def mock_add(key: str, value, timeout=None) -> bool:
+        if key in store:
+            return False
+        store[key] = value
+        return True
+
+    with patch("webhooks.services.insight_detector.cache") as mock:
+        mock.add = mock_add
+        yield mock
 
 
 @pytest.fixture
@@ -199,6 +240,323 @@ class TestLTVMilestoneDetection:
 
         assert result is not None
         assert "500" in result.text
+
+
+class TestLargestLTVMilestone:
+    """Test that the LARGEST crossed LTV milestone is celebrated."""
+
+    def test_big_jump_fires_largest_milestone(self, detector: InsightDetector) -> None:
+        """Test $500 -> $60,500 fires the $50,000 milestone, not $1,000."""
+        event = {"type": "payment_success", "amount": 60000.00}
+        customer = {
+            "orders_count": 10,
+            "total_spent": 500.00,
+            "payment_history": [{"status": "success", "amount": 250}] * 2,
+        }
+
+        result = detector.detect(event, customer)
+
+        assert result is not None
+        assert "50,000" in result.text
+        assert "1,000" not in result.text.replace("50,000", "")
+
+    def test_crossing_single_milestone_unchanged(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test that crossing exactly one milestone still fires it."""
+        event = {"type": "payment_success", "amount": 200.00}
+        customer = {
+            "orders_count": 10,
+            "total_spent": 4900.00,  # Crosses only $5,000
+            "payment_history": [{"status": "success", "amount": 200}] * 2,
+        }
+
+        result = detector.detect(event, customer)
+
+        assert result is not None
+        assert "5,000" in result.text
+
+
+class TestAnniversaryDetection:
+    """Test true-date anniversary detection with dedup."""
+
+    @pytest.fixture
+    def anniversary_customer(self) -> dict:
+        """Customer created exactly one year ago with quiet history.
+
+        History is shaped so no higher-priority insight (first payment, LTV
+        milestone, growth) fires before the anniversary check.
+        """
+        return {
+            "email": "loyal@example.com",
+            "orders_count": 12,
+            "total_spent": 300.00,
+            "payment_history": [{"status": "success", "amount": 25}] * 2,
+            "created_at": _years_ago(1),
+        }
+
+    @pytest.fixture
+    def anniversary_event(self) -> dict:
+        """Payment event for the anniversary customer."""
+        return {
+            "type": "payment_success",
+            "customer_id": "cus_anniv",
+            "workspace_id": "ws_123",
+            "amount": 25.00,
+            "metadata": {},
+        }
+
+    def test_fires_on_true_anniversary_date(
+        self,
+        detector: InsightDetector,
+        anniversary_event: dict,
+        anniversary_customer: dict,
+        mock_insight_cache,
+    ) -> None:
+        """Test that the 1-year anniversary fires on the true date."""
+        result = detector.detect(anniversary_event, anniversary_customer)
+
+        assert result is not None
+        assert "1 year anniversary" in result.text
+        assert result.icon == "celebration"
+
+    def test_fires_within_tolerance_window(
+        self,
+        detector: InsightDetector,
+        anniversary_event: dict,
+        anniversary_customer: dict,
+        mock_insight_cache,
+    ) -> None:
+        """Test that a payment 2 days after the true date still fires."""
+        anniversary_customer["created_at"] = _years_ago(1, offset_days=-2)
+
+        result = detector.detect(anniversary_event, anniversary_customer)
+
+        assert result is not None
+        assert "1 year anniversary" in result.text
+
+    def test_does_not_fire_outside_tolerance_window(
+        self,
+        detector: InsightDetector,
+        anniversary_event: dict,
+        anniversary_customer: dict,
+        mock_insight_cache,
+    ) -> None:
+        """Test that a payment 10 days off the true date does not fire.
+
+        The old `days // 30` heuristic matched a ~30-day span (any payment
+        between day 360 and day 389), so a weekly payer got several
+        "1 year anniversary!" insights in a row.
+        """
+        anniversary_customer["created_at"] = _years_ago(1, offset_days=-10)
+
+        result = detector.detect(anniversary_event, anniversary_customer)
+
+        assert result is None
+
+    def test_fires_exactly_once_per_anniversary(
+        self,
+        detector: InsightDetector,
+        anniversary_event: dict,
+        anniversary_customer: dict,
+        mock_insight_cache,
+    ) -> None:
+        """Test dedup: a second payment inside the window does not re-fire."""
+        first = detector.detect(anniversary_event, anniversary_customer)
+        second = detector.detect(anniversary_event, anniversary_customer)
+
+        assert first is not None
+        assert "1 year anniversary" in first.text
+        assert second is None
+
+    def test_different_customers_dedup_independently(
+        self,
+        detector: InsightDetector,
+        anniversary_event: dict,
+        anniversary_customer: dict,
+        mock_insight_cache,
+    ) -> None:
+        """Test that one customer's celebration doesn't block another's."""
+        first = detector.detect(anniversary_event, anniversary_customer)
+
+        other_event = dict(anniversary_event, customer_id="cus_other")
+        second = detector.detect(other_event, anniversary_customer)
+
+        assert first is not None
+        assert second is not None
+
+    def test_two_year_anniversary(
+        self,
+        detector: InsightDetector,
+        anniversary_event: dict,
+        anniversary_customer: dict,
+        mock_insight_cache,
+    ) -> None:
+        """Test the 2-year anniversary text."""
+        anniversary_customer["created_at"] = _years_ago(2)
+
+        result = detector.detect(anniversary_event, anniversary_customer)
+
+        assert result is not None
+        assert "2 year anniversary" in result.text
+
+    def test_no_anniversary_without_customer_id(
+        self,
+        detector: InsightDetector,
+        anniversary_customer: dict,
+        mock_insight_cache,
+    ) -> None:
+        """Test that anniversary needs a customer id (for attribution/dedup)."""
+        event = {"type": "payment_success", "amount": 25.00, "metadata": {}}
+
+        result = detector.detect(event, anniversary_customer)
+
+        assert result is None
+
+    def test_add_months_clamps_short_months(self, detector: InsightDetector) -> None:
+        """Test that month arithmetic clamps Jan 31 to end of February."""
+        jan_31 = datetime(2025, 1, 31, tzinfo=timezone.utc)
+
+        result = detector._add_months(jan_31, 13)
+
+        assert result == datetime(2026, 2, 28, tzinfo=timezone.utc)
+
+    def test_add_months_handles_leap_year(self, detector: InsightDetector) -> None:
+        """Test that a Jan 31 anniversary lands on Feb 29 in leap years."""
+        jan_31 = datetime(2027, 1, 31, tzinfo=timezone.utc)
+
+        result = detector._add_months(jan_31, 13)
+
+        assert result == datetime(2028, 2, 29, tzinfo=timezone.utc)
+
+
+class TestTrialConvertedDetection:
+    """Test stateless trial conversion detection from invoice metadata."""
+
+    def test_detects_trial_conversion_from_metadata(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test that is_trial_conversion metadata yields the insight.
+
+        The Stripe parser flags the first paid invoice after a trial
+        (period_start at trial_end) - no cache marker involved, so the
+        3-day gap between trial_will_end and the conversion is irrelevant.
+        """
+        event = {
+            "type": "payment_success",
+            "customer_id": "cus_123",
+            "amount": 29.00,
+            "metadata": {"is_trial_conversion": True},
+        }
+
+        result = detector.detect(event, {"payment_history": []})
+
+        assert result is not None
+        assert "Trial converted" in result.text
+        assert result.icon == "celebration"
+
+    def test_no_trial_conversion_without_metadata(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test that an ordinary payment does not claim a trial conversion."""
+        event = {
+            "type": "payment_success",
+            "customer_id": "cus_123",
+            "amount": 29.00,
+            "metadata": {},
+        }
+
+        result = detector._detect_trial_converted(event, {})
+
+        assert result is None
+
+    def test_trial_conversion_on_invoice_paid(self, detector: InsightDetector) -> None:
+        """Test that invoice_paid events can also carry the conversion flag."""
+        event = {
+            "type": "invoice_paid",
+            "customer_id": "cus_123",
+            "amount": 29.00,
+            "metadata": {"is_trial_conversion": True},
+        }
+
+        result = detector._detect_trial_converted(event, {})
+
+        assert result is not None
+        assert "Trial converted" in result.text
+
+
+class TestInitialPaymentFailureDetection:
+    """Test surfacing of a payment_failure folded into an aggregated event."""
+
+    def test_subscription_with_failed_payment_surfaces_failure(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test that has_payment_failure metadata produces a warning insight.
+
+        This is the aggregation case: subscription.created +
+        invoice.payment_failed in the same idempotency bucket must not read
+        as a plain "New subscription!".
+        """
+        event = {
+            "type": "subscription_created",
+            "customer_id": "cus_123",
+            "amount": 49.00,
+            "metadata": {
+                "has_payment_failure": True,
+                "failure_reason": "Your card was declined",
+                "decline_code": "insufficient_funds",
+                "attempt_count": 1,
+            },
+        }
+
+        result = detector.detect(event, {"orders_count": 0, "payment_history": []})
+
+        assert result is not None
+        assert result.icon == "warning"
+        assert "Your card was declined" in result.text
+
+    def test_failure_insight_outranks_first_payment(
+        self, detector: InsightDetector, new_customer_data: dict
+    ) -> None:
+        """Test that the failure warning wins over 'First payment'."""
+        event = {
+            "type": "subscription_created",
+            "amount": 49.00,
+            "metadata": {"has_payment_failure": True, "failure_reason": "declined"},
+        }
+
+        result = detector.detect(event, new_customer_data)
+
+        assert result is not None
+        assert result.icon == "warning"
+
+    def test_failure_insight_includes_retry_info(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test that retry count and next attempt date are included."""
+        event = {
+            "type": "subscription_created",
+            "metadata": {
+                "has_payment_failure": True,
+                "failure_reason": "Card declined",
+                "attempt_count": 2,
+                "next_payment_attempt": 1740182400,  # Feb 22 2025
+            },
+        }
+
+        result = detector._detect_initial_payment_failure(event, {})
+
+        assert result is not None
+        assert "attempt #2" in result.text
+        assert "Next retry" in result.text
+
+    def test_no_failure_insight_without_flag(self, detector: InsightDetector) -> None:
+        """Test that plain subscription_created events are unaffected."""
+        event = {"type": "subscription_created", "metadata": {}}
+
+        result = detector._detect_initial_payment_failure(event, {})
+
+        assert result is None
 
 
 class TestPaymentGrowthDetection:

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -210,6 +210,157 @@ class TestPendingEventQueueAggregation:
         assert customer["first_name"] == "John"  # From first event
         assert customer["last_name"] == "Doe"  # From second event
 
+    def test_aggregate_copies_full_winning_event(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test that the winner's amount/external_id/currency are used.
+
+        When a later event wins the priority contest, the ENTIRE event must
+        be copied - not just type and metadata. Otherwise the notification
+        reports the first event's amount ($29.99) while the customer
+        actually paid the winner's amount ($500).
+        """
+        stored_items = [
+            {
+                "event_data": {
+                    "type": "invoice_paid",
+                    "customer_id": "cus_123",
+                    "amount": 29.99,
+                    "currency": "EUR",
+                    "external_id": "in_first",
+                },
+                "customer_data": {"email": "test@example.com"},
+            },
+            {
+                "event_data": {
+                    "type": "payment_success",
+                    "customer_id": "cus_123",
+                    "amount": 500.00,
+                    "currency": "USD",
+                    "external_id": "in_second",
+                },
+                "customer_data": {"email": "test@example.com"},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        assert event["type"] == "payment_success"
+        assert event["amount"] == 500.00
+        assert event["currency"] == "USD"
+        assert event["external_id"] == "in_second"
+
+    def test_aggregate_surfaces_payment_failure_with_subscription_created(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test that a payment_failure in the bucket is never silently dropped.
+
+        A subscription created with an immediately-declining card queues
+        subscription.created + invoice.payment_failed under the same
+        idempotency key. The aggregated notification keeps the subscription
+        as the primary event but must surface the failure details.
+        """
+        stored_items = [
+            {
+                "event_data": {
+                    "type": "subscription_created",
+                    "customer_id": "cus_123",
+                    "amount": 49.00,
+                    "external_id": "sub_abc",
+                    "metadata": {"subscription_id": "sub_abc"},
+                },
+                "customer_data": {"email": ""},
+            },
+            {
+                "event_data": {
+                    "type": "payment_failure",
+                    "customer_id": "cus_123",
+                    "amount": 49.00,
+                    "external_id": "in_fail",
+                    "metadata": {
+                        "failure_reason": "Your card was declined",
+                        "decline_code": "insufficient_funds",
+                        "attempt_count": 1,
+                        "next_payment_attempt": 1740182400,
+                    },
+                },
+                "customer_data": {"email": "test@example.com"},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        # Subscription is still the primary notification...
+        assert event["type"] == "subscription_created"
+        # ...but the failure is folded into its metadata, not dropped
+        metadata = event["metadata"]
+        assert metadata["has_payment_failure"] is True
+        assert metadata["failure_reason"] == "Your card was declined"
+        assert metadata["decline_code"] == "insufficient_funds"
+        assert metadata["attempt_count"] == 1
+        assert metadata["next_payment_attempt"] == 1740182400
+        assert metadata["failed_amount"] == 49.00
+        # Winner's own metadata is preserved alongside
+        assert metadata["subscription_id"] == "sub_abc"
+        # Email still merged from the failure event
+        assert customer["email"] == "test@example.com"
+
+    def test_aggregate_failure_merge_does_not_mutate_stored_metadata(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test that merging failure details doesn't mutate the stored items."""
+        winner_metadata = {"subscription_id": "sub_abc"}
+        stored_items = [
+            {
+                "event_data": {
+                    "type": "subscription_created",
+                    "metadata": winner_metadata,
+                },
+                "customer_data": {},
+            },
+            {
+                "event_data": {
+                    "type": "payment_failure",
+                    "metadata": {"failure_reason": "Card declined"},
+                },
+                "customer_data": {},
+            },
+        ]
+
+        queue._aggregate_events(stored_items)
+
+        assert "has_payment_failure" not in winner_metadata
+
+    def test_aggregate_lone_payment_failure_stays_failure(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test that a bucket of only failure events notifies as a failure."""
+        stored_items = [
+            {
+                "event_data": {
+                    "type": "payment_failure",
+                    "customer_id": "cus_123",
+                    "amount": 49.00,
+                    "metadata": {"failure_reason": "Card declined"},
+                },
+                "customer_data": {"email": "test@example.com"},
+            },
+            {
+                "event_data": {
+                    "type": "invoice_paid",
+                    "customer_id": "cus_123",
+                    "amount": 0,
+                },
+                "customer_data": {"email": "test@example.com"},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        assert event["type"] == "payment_failure"
+        assert event["metadata"]["failure_reason"] == "Card declined"
+        assert "has_payment_failure" not in event["metadata"]
+
     def test_aggregate_copies_metadata_from_preferred_type(
         self, queue: PendingEventQueue
     ) -> None:

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -308,8 +308,16 @@ class TestPendingEventQueueAggregation:
     def test_aggregate_failure_merge_does_not_mutate_stored_metadata(
         self, queue: PendingEventQueue
     ) -> None:
-        """Test that merging failure details doesn't mutate the stored items."""
-        winner_metadata = {"subscription_id": "sub_abc"}
+        """Test that the aggregated metadata is deep-copied, not shared.
+
+        Metadata can contain nested structures (e.g. Shopify line_items),
+        so a shallow copy would still share the inner lists/dicts - any
+        later mutation of the result would corrupt the stored item.
+        """
+        winner_metadata = {
+            "subscription_id": "sub_abc",
+            "line_items": [{"title": "Widget", "quantity": 1}],
+        }
         stored_items = [
             {
                 "event_data": {
@@ -327,9 +335,16 @@ class TestPendingEventQueueAggregation:
             },
         ]
 
-        queue._aggregate_events(stored_items)
+        event, customer = queue._aggregate_events(stored_items)
 
+        # Top-level merge must not leak into the stored item
         assert "has_payment_failure" not in winner_metadata
+
+        # Nested structures must be independent copies too
+        event["metadata"]["line_items"][0]["title"] = "MUTATED"
+        event["metadata"]["line_items"].append({"title": "extra"})
+
+        assert winner_metadata["line_items"] == [{"title": "Widget", "quantity": 1}]
 
     def test_aggregate_failure_merge_with_absent_winner_metadata(
         self, queue: PendingEventQueue

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -331,6 +331,99 @@ class TestPendingEventQueueAggregation:
 
         assert "has_payment_failure" not in winner_metadata
 
+    def test_aggregate_failure_merge_with_absent_winner_metadata(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test failure merge when the winner has no metadata key at all."""
+        winner_event = {"type": "subscription_created", "customer_id": "cus_123"}
+        stored_items = [
+            {"event_data": winner_event, "customer_data": {}},
+            {
+                "event_data": {
+                    "type": "payment_failure",
+                    "metadata": {"failure_reason": "Card declined"},
+                },
+                "customer_data": {},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        assert event["metadata"]["has_payment_failure"] is True
+        assert event["metadata"]["failure_reason"] == "Card declined"
+        # The stored item must not have been mutated
+        assert "metadata" not in winner_event
+
+    def test_aggregate_failure_merge_with_none_winner_metadata(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test failure merge when the winner's metadata is explicitly None."""
+        stored_items = [
+            {
+                "event_data": {"type": "subscription_created", "metadata": None},
+                "customer_data": {},
+            },
+            {
+                "event_data": {
+                    "type": "payment_failure",
+                    "metadata": {"failure_reason": "Card declined"},
+                },
+                "customer_data": {},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        assert event["metadata"]["has_payment_failure"] is True
+        assert event["metadata"]["failure_reason"] == "Card declined"
+
+    def test_aggregate_failure_merge_with_none_failure_metadata(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test that a failure event with None metadata still gets surfaced."""
+        stored_items = [
+            {
+                "event_data": {"type": "subscription_created", "metadata": {}},
+                "customer_data": {},
+            },
+            {
+                "event_data": {
+                    "type": "payment_failure",
+                    "amount": 49.00,
+                    "metadata": None,
+                },
+                "customer_data": {},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        assert event["metadata"]["has_payment_failure"] is True
+        assert event["metadata"]["failed_amount"] == 49.00
+
+    def test_aggregate_preserves_zero_failed_amount(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test that a legitimate 0.0 failed amount is kept (is not None check)."""
+        stored_items = [
+            {
+                "event_data": {"type": "subscription_created", "metadata": {}},
+                "customer_data": {},
+            },
+            {
+                "event_data": {
+                    "type": "payment_failure",
+                    "amount": 0.0,
+                    "metadata": {"failure_reason": "Card declined"},
+                },
+                "customer_data": {},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        assert event["metadata"]["failed_amount"] == 0.0
+
     def test_aggregate_lone_payment_failure_stays_failure(
         self, queue: PendingEventQueue
     ) -> None:


### PR DESCRIPTION
Fixes #82 — event consolidation & insight detection (audit Group 8).

## Changes

1. **Trial conversion is stateless.** `InsightDetector._detect_trial_converted` reads the `is_trial_conversion` flag the Stripe parser (#88) derives from the invoice payload; the 5-minute pending-marker path — which could never bridge Stripe's ~3-day `trial_will_end` → invoice gap — is deleted (`has_pending_trial`, `_mark_event_pending`, `_get_pending_key`, `TRACK_WHEN_SUPPRESSED`).
2. **`trial_ending` is no longer suppressed.** Users get both "trial ending in 3 days" and, later, "trial converted" (the confirmed product call from the audit).
3/4. **Suppression is scoped by transaction correlator**, not just `(workspace, customer)`: keys are now `event_suppress:{ws}:{cust}:{correlator}` (subscription_id | invoice_id | charge_id | order_id, fallback external_id). A checkout for product A no longer swallows an unrelated payment for product B; cancelling an add-on no longer suppresses another subscription's renewal invoice.
5. **`payment_failure` can no longer be silently outranked in aggregation.** When a `subscription.created` + `invoice.payment_failed` land in the same idempotency bucket, the failure's metadata (`failure_reason`, `decline_code`, `attempt_count`, `next_payment_attempt`, `failed_amount`) is folded into the winning event and a new top-priority insight surfaces it — one richer "new subscription, but the initial payment failed" notification.
6. **Aggregation winner is copied in full** (amount, external_id, currency, metadata — deep-copied), so a $500 payment no longer reports as the first-stored event's $29.99.
7. **Anniversaries use real calendar math** (`_add_months` with end-of-month clamping), fire within ±3 days of the true date, and are deduped via SETNX (`anniversary_sent:{ws}:{cust}:{months}`, 30-day TTL) — once per anniversary, no more weekly repeats or `days//30` drift.
8. **LTV milestones celebrate the largest crossed milestone** — $500 → $60,500 fires "$50,000", not "$1,000".

## Tests

All seven acceptance scenarios plus correlator extraction, stored-metadata immutability, lone-failure buckets, leap-year clamping, and per-customer dedup independence (`tests/test_event_consolidation.py`, `tests/test_pending_event_queue.py`, `tests/test_insight_detector.py`).

`uv run pytest`: 835 passed. ruff/mypy clean (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)