### PR TITLE
fix(notifications): correct notification builder mapping, headlines, and action links

### DIFF
--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -575,13 +575,17 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         metadata so notification action buttons can link to the right
         site. Empty when the payload does not carry site information.
 
+        The value is normalized (stripped, lowercased) here; the
+        notification builder additionally validates it as a single DNS
+        label before interpolating it into a URL host.
+
         Args:
             data: Form data dictionary.
 
         Returns:
-            Site subdomain string, or "" when unknown.
+            Normalized site subdomain string, or "" when unknown.
         """
-        return str(data.get("payload[site][subdomain]", "") or "")
+        return str(data.get("payload[site][subdomain]", "") or "").strip().lower()
 
     def _parse_payment_success(self, data: dict[str, Any]) -> dict[str, Any]:
         """Parse payment_success webhook data.

--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -566,6 +566,23 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         except (InvalidOperation, ValueError, TypeError) as e:
             raise InvalidDataError(f"Invalid amount format: {amount_cents}") from e
 
+    @staticmethod
+    def _extract_site_subdomain(data: dict[str, Any]) -> str:
+        """Extract the Chargify site subdomain from a webhook payload.
+
+        The subdomain identifies the per-site dashboard host
+        (``<subdomain>.chargify.com``) and is threaded through event
+        metadata so notification action buttons can link to the right
+        site. Empty when the payload does not carry site information.
+
+        Args:
+            data: Form data dictionary.
+
+        Returns:
+            Site subdomain string, or "" when unknown.
+        """
+        return str(data.get("payload[site][subdomain]", "") or "")
+
     def _parse_payment_success(self, data: dict[str, Any]) -> dict[str, Any]:
         """Parse payment_success webhook data.
 
@@ -612,6 +629,7 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             "provider": "chargify",
             "metadata": {
                 "subscription_id": subscription_id,
+                "site_subdomain": self._extract_site_subdomain(data),
                 "transaction_id": data.get("payload[transaction][id]", ""),
                 "plan_name": plan_name,
                 "shopify_order_ref": shopify_order_ref,
@@ -665,6 +683,7 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             "provider": "chargify",
             "metadata": {
                 "subscription_id": data.get("payload[subscription][id]", ""),
+                "site_subdomain": self._extract_site_subdomain(data),
                 "transaction_id": data.get("payload[transaction][id]", ""),
                 "plan_name": data.get("payload[subscription][product][name]", ""),
                 "failure_reason": data.get(
@@ -714,6 +733,7 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             "provider": "chargify",
             "metadata": {
                 "subscription_id": data.get("payload[subscription][id]", ""),
+                "site_subdomain": self._extract_site_subdomain(data),
                 "plan_name": data.get("payload[subscription][product][name]", ""),
                 "new_state": state,
                 "previous_state": data.get("payload[subscription][previous_state]"),
@@ -751,6 +771,7 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             "provider": "chargify",
             "metadata": {
                 "subscription_id": data.get("payload[subscription][id]", ""),
+                "site_subdomain": self._extract_site_subdomain(data),
                 "plan_name": data.get("payload[subscription][product][name]", ""),
                 "previous_state": data.get("payload[subscription][previous_state]"),
                 "cancel_at_period_end": data.get(

--- a/app/webhooks/services/notification_builder.py
+++ b/app/webhooks/services/notification_builder.py
@@ -309,18 +309,23 @@ class NotificationBuilder:
         # Calculate tenure display
         tenure_display = self._format_tenure(customer_data)
 
-        # Calculate LTV display
-        total_spent_raw = customer_data.get("total_spent") or customer_data.get(
-            "lifetime_value", 0
-        )
-        try:
-            total_spent = float(total_spent_raw) if total_spent_raw else 0.0
-        except (ValueError, TypeError):
-            logger.warning(
-                "Could not parse customer lifetime value; defaulting to 0.0",
-                extra={"total_spent_raw": repr(total_spent_raw)},
-            )
+        # Calculate LTV display. Explicit None checks so a legitimate
+        # zero lifetime value (0, 0.0, Decimal("0")) is not treated as
+        # missing and does not fall back to the other key or warn.
+        total_spent_raw = customer_data.get("total_spent")
+        if total_spent_raw is None:
+            total_spent_raw = customer_data.get("lifetime_value")
+        if total_spent_raw is None:
             total_spent = 0.0
+        else:
+            try:
+                total_spent = float(total_spent_raw)
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Could not parse customer lifetime value; defaulting to 0.0",
+                    extra={"total_spent_raw": repr(total_spent_raw)},
+                )
+                total_spent = 0.0
         ltv_display = self._format_ltv(total_spent, currency) if total_spent else None
 
         return CustomerInfo(

--- a/app/webhooks/services/notification_builder.py
+++ b/app/webhooks/services/notification_builder.py
@@ -5,6 +5,7 @@ and customer data into RichNotification objects ready for formatting.
 """
 
 import logging
+import re
 from datetime import datetime
 from typing import Any
 
@@ -25,6 +26,36 @@ from .insight_detector import InsightDetector
 from .utils import get_display_name
 
 logger = logging.getLogger(__name__)
+
+# A Chargify site subdomain must be a single DNS label: no dots, no
+# slashes, no whitespace. Anything else could point the dashboard
+# button at an unintended host.
+_CHARGIFY_SUBDOMAIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+def _normalize_chargify_subdomain(value: Any) -> str | None:
+    """Normalize and validate a Chargify site subdomain.
+
+    The subdomain originates from webhook payload data and is
+    interpolated into a URL host, so it is normalized (surrounding
+    whitespace stripped, lowercased) and then required to be a single
+    valid DNS label. Values that still do not match (dots, slashes,
+    interior whitespace, ...) are rejected.
+
+    Args:
+        value: Raw subdomain value from event metadata.
+
+    Returns:
+        The normalized subdomain, or None when the value is missing or
+        not a safe single DNS label.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not _CHARGIFY_SUBDOMAIN_RE.fullmatch(normalized):
+        return None
+    return normalized
+
 
 # Provider display configurations
 PROVIDER_DISPLAY: dict[str, str] = {
@@ -691,8 +722,10 @@ class NotificationBuilder:
             subscription_id = metadata.get("subscription_id")
             # Chargify (Maxio) dashboards live on per-site subdomains;
             # a hardcoded app.chargify.com URL does not resolve. Omit
-            # the button when the site subdomain is unknown.
-            subdomain = metadata.get("site_subdomain")
+            # the button when the site subdomain is unknown or is not a
+            # safe single DNS label (it comes from webhook payload data
+            # and is interpolated into the URL host).
+            subdomain = _normalize_chargify_subdomain(metadata.get("site_subdomain"))
             if subscription_id and subdomain:
                 return ActionButton(
                     text="View in Chargify",

--- a/app/webhooks/services/notification_builder.py
+++ b/app/webhooks/services/notification_builder.py
@@ -4,6 +4,7 @@ This module provides the NotificationBuilder class that transforms raw event
 and customer data into RichNotification objects ready for formatting.
 """
 
+import logging
 from datetime import datetime
 from typing import Any
 
@@ -22,6 +23,8 @@ from webhooks.utils.currency import CURRENCY_SYMBOLS, format_money
 
 from .insight_detector import InsightDetector
 from .utils import get_display_name
+
+logger = logging.getLogger(__name__)
 
 # Provider display configurations
 PROVIDER_DISPLAY: dict[str, str] = {
@@ -253,10 +256,9 @@ class NotificationBuilder:
         # Build headline
         headline = self._build_headline(event_data, customer_data, company)
 
-        # Determine notification type and severity
-        notification_type = EVENT_TYPE_MAP.get(
-            event_type, NotificationType.PAYMENT_SUCCESS
-        )
+        # Determine notification type and severity. Unknown event types
+        # fall back to CUSTOM so they never render as successful payments.
+        notification_type = EVENT_TYPE_MAP.get(event_type, NotificationType.CUSTOM)
         severity = EVENT_SEVERITY_MAP.get(event_type, NotificationSeverity.INFO)
         headline_icon = EVENT_ICON_MAP.get(event_type, "info")
 
@@ -314,6 +316,10 @@ class NotificationBuilder:
         try:
             total_spent = float(total_spent_raw) if total_spent_raw else 0.0
         except (ValueError, TypeError):
+            logger.warning(
+                "Could not parse customer lifetime value; defaulting to 0.0",
+                extra={"total_spent_raw": repr(total_spent_raw)},
+            )
             total_spent = 0.0
         ltv_display = self._format_ltv(total_spent, currency) if total_spent else None
 
@@ -347,7 +353,6 @@ class NotificationBuilder:
             return None
 
         currency = event_data.get("currency", "USD")
-        metadata = event_data.get("metadata", {})
 
         # Detect billing interval
         _, interval = self._detect_recurring(event_data)
@@ -467,7 +472,9 @@ class NotificationBuilder:
             attempt_count = metadata.get("attempt_count")
             if amount is not None and attempt_count and attempt_count > 1:
                 money = format_money(amount, currency)
-                return f"{money} payment failed (retry #{attempt_count})"
+                # Stripe's attempt_count includes the initial attempt, so
+                # attempt_count=2 is the first retry.
+                return f"{money} payment failed (retry #{attempt_count - 1})"
             elif amount is not None:
                 return f"{format_money(amount, currency)} payment failed"
             return "Payment failed"
@@ -519,6 +526,21 @@ class NotificationBuilder:
                 return "Subscription downgraded"
             return "Subscription updated"
 
+        elif event_type == "subscription_renewed":
+            # No parser currently emits this type (Chargify acknowledges
+            # and skips subscription_renewed webhooks), but it remains a
+            # valid event type so a renewal must not collapse to a bare
+            # title without amount/plan context.
+            plan_name = metadata.get("plan_name")
+            suffix = _interval_suffix(metadata.get("billing_period"))
+            if plan_name and amount is not None:
+                money = format_money(amount, currency)
+                return f"Subscription renewed: {plan_name} ({money}{suffix})"
+            elif amount is not None:
+                money = format_money(amount, currency)
+                return f"Subscription renewed at {money}{suffix}"
+            return "Subscription renewed"
+
         elif event_type in ("subscription_canceled", "subscription_deleted"):
             return "Subscription canceled"
 
@@ -551,14 +573,12 @@ class NotificationBuilder:
             return "Order canceled"
 
         elif event_type == "order_fulfilled":
-            metadata = event_data.get("metadata", {})
             order_number = metadata.get("order_number") or metadata.get("order_ref")
             if order_number:
                 return f"Order #{order_number} fulfilled"
             return "Order fulfilled"
 
         elif event_type == "fulfillment_created":
-            metadata = event_data.get("metadata", {})
             order_number = metadata.get("order_number") or metadata.get("order_ref")
             tracking_number = metadata.get("tracking_number")
             if order_number and tracking_number:
@@ -568,7 +588,6 @@ class NotificationBuilder:
             return "Fulfillment created"
 
         elif event_type == "fulfillment_updated":
-            metadata = event_data.get("metadata", {})
             order_number = metadata.get("order_number") or metadata.get("order_ref")
             status = metadata.get("shipment_status") or metadata.get(
                 "fulfillment_status"
@@ -580,7 +599,6 @@ class NotificationBuilder:
             return "Shipment updated"
 
         elif event_type == "shipment_delivered":
-            metadata = event_data.get("metadata", {})
             order_number = metadata.get("order_number") or metadata.get("order_ref")
             if order_number:
                 return f"Order #{order_number} delivered"
@@ -607,45 +625,13 @@ class NotificationBuilder:
             List of ActionButton objects.
         """
         event_type = event_data.get("type", "")
-        provider = event_data.get("provider", "")
-        metadata = event_data.get("metadata", {})
 
         actions: list[ActionButton] = []
 
         # Provider-specific dashboard link
-        if provider == "stripe":
-            customer_id = metadata.get("stripe_customer_id")
-            if customer_id:
-                actions.append(
-                    ActionButton(
-                        text="View in Stripe",
-                        url=f"https://dashboard.stripe.com/customers/{customer_id}",
-                        style="primary",
-                    )
-                )
-
-        elif provider == "chargify":
-            subscription_id = metadata.get("subscription_id")
-            if subscription_id:
-                actions.append(
-                    ActionButton(
-                        text="View in Chargify",
-                        url=f"https://app.chargify.com/subscriptions/{subscription_id}",
-                        style="primary",
-                    )
-                )
-
-        elif provider == "shopify":
-            order_id = metadata.get("order_id")
-            shop_domain = metadata.get("shop_domain")
-            if order_id and shop_domain:
-                actions.append(
-                    ActionButton(
-                        text="View Order",
-                        url=f"https://{shop_domain}/admin/orders/{order_id}",
-                        style="primary",
-                    )
-                )
+        dashboard_action = self._build_provider_dashboard_action(event_data)
+        if dashboard_action:
+            actions.append(dashboard_action)
 
         # Add company website link if enriched
         if company and company.domain:
@@ -670,6 +656,60 @@ class NotificationBuilder:
 
         return actions
 
+    def _build_provider_dashboard_action(
+        self, event_data: dict[str, Any]
+    ) -> ActionButton | None:
+        """Build the provider-specific dashboard link button.
+
+        Args:
+            event_data: Event data dictionary.
+
+        Returns:
+            ActionButton linking to the provider dashboard, or None when
+            the data needed to build a working link is missing.
+        """
+        provider = event_data.get("provider", "")
+        metadata = event_data.get("metadata", {})
+
+        if provider in ("stripe", "stripe_customer"):
+            # Parsers write the customer id at the top level of the
+            # event, not in metadata.
+            customer_id = event_data.get("customer_id")
+            if customer_id:
+                return ActionButton(
+                    text="View in Stripe",
+                    url=f"https://dashboard.stripe.com/customers/{customer_id}",
+                    style="primary",
+                )
+
+        elif provider == "chargify":
+            subscription_id = metadata.get("subscription_id")
+            # Chargify (Maxio) dashboards live on per-site subdomains;
+            # a hardcoded app.chargify.com URL does not resolve. Omit
+            # the button when the site subdomain is unknown.
+            subdomain = metadata.get("site_subdomain")
+            if subscription_id and subdomain:
+                return ActionButton(
+                    text="View in Chargify",
+                    url=(
+                        f"https://{subdomain}.chargify.com"
+                        f"/subscriptions/{subscription_id}"
+                    ),
+                    style="primary",
+                )
+
+        elif provider == "shopify":
+            order_id = metadata.get("order_id")
+            shop_domain = metadata.get("shop_domain")
+            if order_id and shop_domain:
+                return ActionButton(
+                    text="View Order",
+                    url=f"https://{shop_domain}/admin/orders/{order_id}",
+                    style="primary",
+                )
+
+        return None
+
     def _detect_recurring(self, event_data: dict[str, Any]) -> tuple[bool, str | None]:
         """Detect if payment is recurring and extract billing interval.
 
@@ -679,13 +719,12 @@ class NotificationBuilder:
         Returns:
             Tuple of (is_recurring, billing_interval).
         """
-        event_type = event_data.get("type", "")
         metadata = event_data.get("metadata", {})
 
-        # Renewal events are always recurring
-        if event_type in ("renewal_success", "renewal_failure"):
-            interval = metadata.get("billing_period", "monthly")
-            return True, interval
+        # Note: Chargify renewal_success/renewal_failure are normalized
+        # to payment_success/payment_failure by the parser (with
+        # billing_period defaulted to "monthly" in metadata), so no
+        # renewal-specific branch is needed here.
 
         # Check for subscription_id presence
         if metadata.get("subscription_id"):
@@ -764,6 +803,10 @@ class NotificationBuilder:
             return f"Since {created_date.strftime('%b %Y')}"
 
         except (ValueError, TypeError):
+            logger.warning(
+                "Could not parse customer created_at for tenure display",
+                extra={"created_at": repr(created_at)},
+            )
             return None
 
     def _format_ltv(self, total_spent: float, currency: str = "USD") -> str:

--- a/tests/test_event_processing.py
+++ b/tests/test_event_processing.py
@@ -181,6 +181,8 @@ def test_payment_failure_retry_headline() -> None:
     """Test payment failure with attempt_count > 1 shows retry in headline.
 
     Verifies the headline includes '(retry #N)' when attempt_count > 1.
+    Stripe's attempt_count includes the initial attempt, so
+    attempt_count=2 is the first retry.
     """
     processor = EventProcessor()
 
@@ -206,7 +208,7 @@ def test_payment_failure_retry_headline() -> None:
     notification = processor.build_rich_notification(event_data, customer_data)
     assert isinstance(notification, RichNotification)
     assert "$53.20" in notification.headline
-    assert "retry #2" in notification.headline
+    assert "retry #1" in notification.headline
     assert notification.severity == NotificationSeverity.ERROR
 
 

--- a/tests/test_notification_builder.py
+++ b/tests/test_notification_builder.py
@@ -4,10 +4,12 @@ This module tests the NotificationBuilder class that creates
 RichNotification objects from event and customer data.
 """
 
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
 from webhooks.models.rich_notification import (
+    EventCategory,
     NotificationSeverity,
     NotificationType,
     RichNotification,
@@ -27,6 +29,7 @@ def payment_success_event() -> dict:
     return {
         "type": "payment_success",
         "provider": "stripe",
+        "customer_id": "cus_abc123",
         "amount": 299.00,
         "currency": "USD",
         "metadata": {
@@ -35,7 +38,6 @@ def payment_success_event() -> dict:
             "billing_period": "monthly",
             "card_brand": "visa",
             "card_last4": "4242",
-            "stripe_customer_id": "cus_abc123",
         },
     }
 
@@ -489,8 +491,73 @@ class TestActionButtons:
         result = builder.build(payment_success_event, customer_data)
 
         assert len(result.actions) > 0
+        stripe_buttons = [a for a in result.actions if a.text == "View in Stripe"]
+        assert len(stripe_buttons) == 1
+        # URL must point at the customer the parser identified
+        # (event_data["customer_id"], not a metadata key).
+        assert (
+            stripe_buttons[0].url == "https://dashboard.stripe.com/customers/cus_abc123"
+        )
+
+    def test_stripe_button_omitted_without_customer_id(
+        self,
+        builder: NotificationBuilder,
+        payment_success_event: dict,
+        customer_data: dict,
+    ) -> None:
+        """Test Stripe button is omitted when customer_id is missing."""
+        del payment_success_event["customer_id"]
+        result = builder.build(payment_success_event, customer_data)
+
         action_texts = [a.text for a in result.actions]
-        assert "View in Stripe" in action_texts
+        assert "View in Stripe" not in action_texts
+
+    def test_chargify_button_with_site_subdomain(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test Chargify button links to the per-site dashboard subdomain."""
+        event = {
+            "type": "payment_success",
+            "provider": "chargify",
+            "customer_id": "12345",
+            "amount": 99.00,
+            "currency": "USD",
+            "metadata": {
+                "subscription_id": "sub_456",
+                "site_subdomain": "acme-billing",
+            },
+        }
+        result = builder.build(event, customer_data)
+
+        chargify_buttons = [a for a in result.actions if a.text == "View in Chargify"]
+        assert len(chargify_buttons) == 1
+        assert (
+            chargify_buttons[0].url
+            == "https://acme-billing.chargify.com/subscriptions/sub_456"
+        )
+
+    def test_chargify_button_omitted_without_subdomain(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test Chargify button is omitted when the site subdomain is unknown.
+
+        A hardcoded app.chargify.com URL would not resolve for per-site
+        Chargify (Maxio) subdomains, so no button is better than a
+        broken one.
+        """
+        event = {
+            "type": "payment_success",
+            "provider": "chargify",
+            "customer_id": "12345",
+            "amount": 99.00,
+            "currency": "USD",
+            "metadata": {"subscription_id": "sub_456"},
+        }
+        result = builder.build(event, customer_data)
+
+        action_texts = [a.text for a in result.actions]
+        assert "View in Chargify" not in action_texts
+        assert not any("chargify.com" in a.url for a in result.actions)
 
     def test_website_button_with_company(
         self,
@@ -590,3 +657,202 @@ class TestProviderInfo:
 
         assert result.provider == "shopify"
         assert result.provider_display == "Shopify"
+
+
+class TestUnknownEventType:
+    """Test handling of event types missing from EVENT_TYPE_MAP."""
+
+    def test_unknown_event_type_maps_to_custom(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test an unmapped event type produces a CUSTOM notification.
+
+        Unknown events (e.g. a future dispute.created) must never be
+        rendered as successful payments.
+        """
+        event = {"type": "dispute_created", "provider": "stripe"}
+        result = builder.build(event, customer_data)
+
+        assert result.type == NotificationType.CUSTOM
+        assert result.category == EventCategory.CUSTOM
+        assert result.type != NotificationType.PAYMENT_SUCCESS
+        assert result.is_payment_event is False
+
+
+class TestZeroAmountHeadlines:
+    """Test that zero amounts are treated as real amounts, not missing."""
+
+    @pytest.mark.parametrize("zero_amount", [0, 0.0, Decimal("0")])
+    def test_zero_amount_payment_success_headline(
+        self,
+        builder: NotificationBuilder,
+        customer_data: dict,
+        zero_amount: object,
+    ) -> None:
+        """Test a $0 payment renders '$0.00 received', not a bare headline."""
+        event = {
+            "type": "payment_success",
+            "provider": "stripe",
+            "customer_id": "cus_abc123",
+            "amount": zero_amount,
+            "currency": "USD",
+            "metadata": {},
+        }
+        result = builder.build(event, customer_data)
+
+        assert result.headline == "$0.00 received"
+
+    def test_zero_amount_payment_failure_retry_headline(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test a $0 payment failure keeps the retry suffix.
+
+        Stripe's attempt_count includes the initial attempt, so
+        attempt_count=3 is the second retry.
+        """
+        event = {
+            "type": "payment_failure",
+            "provider": "stripe",
+            "customer_id": "cus_abc123",
+            "amount": 0,
+            "currency": "USD",
+            "metadata": {"attempt_count": 3},
+        }
+        result = builder.build(event, customer_data)
+
+        assert result.headline == "$0.00 payment failed (retry #2)"
+
+    def test_downgrade_to_zero_keeps_amount_change_framing(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test a $299 -> $0 downgrade renders both amounts."""
+        event = {
+            "type": "subscription_updated",
+            "provider": "chargify",
+            "customer_id": "12345",
+            "amount": 0,
+            "currency": "USD",
+            "metadata": {
+                "change_direction": "downgrade",
+                "previous_amount": 299,
+                "billing_period": "monthly",
+            },
+        }
+        result = builder.build(event, customer_data)
+
+        assert result.headline == "Downgraded: $299.00/mo to $0.00/mo"
+
+    def test_upgrade_from_zero_keeps_amount_change_framing(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test a $0 -> $99 upgrade renders both amounts."""
+        event = {
+            "type": "subscription_updated",
+            "provider": "chargify",
+            "customer_id": "12345",
+            "amount": 99,
+            "currency": "USD",
+            "metadata": {
+                "change_direction": "upgrade",
+                "previous_amount": 0,
+                "billing_period": "monthly",
+            },
+        }
+        result = builder.build(event, customer_data)
+
+        assert result.headline == "Upgraded: $0.00/mo to $99.00/mo"
+
+
+class TestSubscriptionRenewedHeadline:
+    """Test the subscription_renewed headline branch."""
+
+    def test_renewed_headline_with_plan_and_amount(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test renewal headline includes plan, amount and interval."""
+        event = {
+            "type": "subscription_renewed",
+            "provider": "chargify",
+            "customer_id": "12345",
+            "amount": 299.00,
+            "currency": "USD",
+            "metadata": {
+                "plan_name": "Enterprise",
+                "subscription_id": "sub_123",
+                "billing_period": "annual",
+            },
+        }
+        result = builder.build(event, customer_data)
+
+        assert result.type == NotificationType.SUBSCRIPTION_RENEWED
+        assert result.headline == "Subscription renewed: Enterprise ($299.00/yr)"
+
+    def test_renewed_headline_with_amount_only(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test renewal headline with amount but no plan name."""
+        event = {
+            "type": "subscription_renewed",
+            "provider": "stripe",
+            "customer_id": "cus_abc123",
+            "amount": 49.00,
+            "currency": "USD",
+            "metadata": {"billing_period": "monthly"},
+        }
+        result = builder.build(event, customer_data)
+
+        assert result.headline == "Subscription renewed at $49.00/mo"
+
+    def test_renewed_headline_without_amount(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test renewal headline falls back gracefully without amount."""
+        event = {
+            "type": "subscription_renewed",
+            "provider": "stripe",
+            "customer_id": "cus_abc123",
+            "metadata": {},
+        }
+        result = builder.build(event, customer_data)
+
+        assert result.headline == "Subscription renewed"
+
+
+class TestSilentFallbackLogging:
+    """Test that parse fallbacks are logged instead of silently swallowed."""
+
+    def test_invalid_created_at_logs_warning(
+        self,
+        builder: NotificationBuilder,
+        payment_success_event: dict,
+        customer_data: dict,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test an unparseable created_at logs a warning and yields no tenure."""
+        customer_data["created_at"] = "not-a-date"
+
+        with caplog.at_level(
+            "WARNING", logger="webhooks.services.notification_builder"
+        ):
+            result = builder.build(payment_success_event, customer_data)
+
+        assert result.customer.tenure_display is None
+        assert any("tenure" in record.getMessage() for record in caplog.records)
+
+    def test_invalid_total_spent_logs_warning(
+        self,
+        builder: NotificationBuilder,
+        payment_success_event: dict,
+        customer_data: dict,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test an unparseable lifetime value logs a warning and defaults to 0."""
+        customer_data["total_spent"] = "not-a-number"
+
+        with caplog.at_level(
+            "WARNING", logger="webhooks.services.notification_builder"
+        ):
+            result = builder.build(payment_success_event, customer_data)
+
+        assert result.customer.total_spent is None
+        assert any("lifetime value" in record.getMessage() for record in caplog.records)

--- a/tests/test_notification_builder.py
+++ b/tests/test_notification_builder.py
@@ -856,3 +856,53 @@ class TestSilentFallbackLogging:
 
         assert result.customer.total_spent is None
         assert any("lifetime value" in record.getMessage() for record in caplog.records)
+
+    def test_zero_total_spent_is_not_missing(
+        self,
+        builder: NotificationBuilder,
+        payment_success_event: dict,
+        customer_data: dict,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test a legitimate zero total_spent parses cleanly.
+
+        A genuinely-zero-spend customer must not fall back to
+        lifetime_value and must not trigger a parse warning.
+        """
+        customer_data["total_spent"] = 0
+        customer_data["lifetime_value"] = 500.0
+
+        with caplog.at_level(
+            "WARNING", logger="webhooks.services.notification_builder"
+        ):
+            result = builder.build(payment_success_event, customer_data)
+
+        # Zero spend renders as no LTV display; a fallback to
+        # lifetime_value would have produced "$500" here.
+        assert result.customer.ltv_display is None
+        assert result.customer.total_spent is None
+        assert not any(
+            "lifetime value" in record.getMessage() for record in caplog.records
+        )
+
+    @pytest.mark.parametrize("zero_value", [0.0, Decimal("0")])
+    def test_zero_lifetime_value_variants_do_not_warn(
+        self,
+        builder: NotificationBuilder,
+        payment_success_event: dict,
+        customer_data: dict,
+        caplog: pytest.LogCaptureFixture,
+        zero_value: object,
+    ) -> None:
+        """Test 0.0 and Decimal('0') lifetime values parse without warning."""
+        customer_data["total_spent"] = zero_value
+
+        with caplog.at_level(
+            "WARNING", logger="webhooks.services.notification_builder"
+        ):
+            result = builder.build(payment_success_event, customer_data)
+
+        assert result.customer.ltv_display is None
+        assert not any(
+            "lifetime value" in record.getMessage() for record in caplog.records
+        )

--- a/tests/test_notification_builder.py
+++ b/tests/test_notification_builder.py
@@ -559,6 +559,74 @@ class TestActionButtons:
         assert "View in Chargify" not in action_texts
         assert not any("chargify.com" in a.url for a in result.actions)
 
+    @pytest.mark.parametrize(
+        "bad_subdomain",
+        [
+            "evil.example",  # dot: would change the registrable domain
+            "evil/path",  # slash: would break out of the host
+            "acme corp",  # interior whitespace
+            "-acme",  # invalid leading hyphen
+            "   ",  # whitespace only
+            12345,  # non-string
+        ],
+    )
+    def test_chargify_button_omitted_for_unsafe_subdomain(
+        self,
+        builder: NotificationBuilder,
+        customer_data: dict,
+        bad_subdomain: object,
+    ) -> None:
+        """Test unsafe site subdomains never reach the button URL.
+
+        The subdomain comes from webhook payload data and is
+        interpolated into the URL host, so anything that is not a
+        single valid DNS label must result in no button at all.
+        """
+        event = {
+            "type": "payment_success",
+            "provider": "chargify",
+            "customer_id": "12345",
+            "amount": 99.00,
+            "currency": "USD",
+            "metadata": {
+                "subscription_id": "sub_456",
+                "site_subdomain": bad_subdomain,
+            },
+        }
+        result = builder.build(event, customer_data)
+
+        action_texts = [a.text for a in result.actions]
+        assert "View in Chargify" not in action_texts
+        assert not any("chargify.com" in a.url for a in result.actions)
+
+    def test_chargify_subdomain_normalized_before_use(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test surrounding whitespace and case are normalized, not rejected.
+
+        Padding and uppercase are cosmetic - they normalize to a valid
+        DNS label, so the button is built with the cleaned value.
+        """
+        event = {
+            "type": "payment_success",
+            "provider": "chargify",
+            "customer_id": "12345",
+            "amount": 99.00,
+            "currency": "USD",
+            "metadata": {
+                "subscription_id": "sub_456",
+                "site_subdomain": "  ACME-Corp  ",
+            },
+        }
+        result = builder.build(event, customer_data)
+
+        chargify_buttons = [a for a in result.actions if a.text == "View in Chargify"]
+        assert len(chargify_buttons) == 1
+        assert (
+            chargify_buttons[0].url
+            == "https://acme-corp.chargify.com/subscriptions/sub_456"
+        )
+
     def test_website_button_with_company(
         self,
         builder: NotificationBuilder,


### PR DESCRIPTION
Fixes #83 — notification builder correctness (audit Group 9), the final group of the webhook-pipeline audit.

## Changes

1. **Unknown event types no longer render as successful payments** — `EVENT_TYPE_MAP` falls back to `NotificationType.CUSTOM` (CUSTOM category, `is_payment_event` False) instead of `PAYMENT_SUCCESS`.
2. **"View in Stripe" button works again** — the builder reads `event_data["customer_id"]` (which parsers actually write) instead of a metadata key nothing writes; Stripe/Chargify/Shopify dashboard buttons are folded into one `_build_provider_dashboard_action()` helper keyed on provider.
3. **`amount=0` handled as a value, not a missing field** — `is not None` guards across payment, upgrade/downgrade ($299→$0 and $0→$99 keep "from X to Y" framing), and order headlines.
4. **Retry count off-by-one fixed** — Stripe's `attempt_count=2` is the first retry; headlines now render `retry #{attempt_count - 1}`.
5. **`subscription_renewed` gets a real headline** (amount + plan + interval) instead of collapsing to a bare title; kept as a valid type with a comment documenting that Chargify currently acknowledges-and-skips it.
6. **Chargify dashboard links use the per-site subdomain** — threaded from the webhook payload's `payload[site][subdomain]` as metadata (no model change needed); the button is omitted when the subdomain is unknown (the old hardcoded `app.chargify.com` URL never resolved).
7. **Dead `renewal_success`/`renewal_failure` branch deleted** — the Chargify parser normalizes those before the builder runs (and already defaults `billing_period`).
8. **Silent `except (ValueError, TypeError)` clauses now log** — module logger added; tenure/LTV parser regressions surface as warnings (caplog-tested) while keeping the graceful fallback.
9. **Duplicate `metadata` reassignments removed** (one in `_build_payment_info`, six in the logistics branches).
10. **ARR currency mismatch** — verified already fixed by #93's `format_money` change; no further change needed.

## Tests

15 new tests covering all acceptance criteria: CUSTOM fallback, provider buttons (incl. omission without subdomain), $0 headlines, retry #2 for attempt_count=3, downgrade-to-zero framing, subscription_renewed headline, and caplog warnings.

`uv run pytest`: 1029 passed. ruff/mypy clean (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)