### PR TITLE
Rewrite README positioning; add self-hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
-# Notipus - Webhook to Slack Notifier
+# Notipus — Enriched Slack Notifications for Payment Events
 
-A webhook-driven notification service that sends enriched payment and subscription events from Shopify and Chargify to Slack. The service provides meaningful, actionable insights for customer success teams with a fun and engaging tone.
+Notipus turns payment and subscription webhooks from **Stripe**, **Shopify**, and **Maxio (formerly Chargify)** into enriched Slack notifications. It's more than a webhook relay: every alert tells you who the customer is, what they're worth, and whether they need attention — company background, contact name and role, lifetime value, tenure, and churn-risk flags, delivered where your team actually looks.
+
+Managed service: [notipus.com](https://notipus.com) · Self-hosting: [see below](#self-hosting)
 
 ## Features
 
-- 🎯 **Smart Event Processing**: Automatically categorizes and prioritizes events based on type and customer value
-- 💡 **Rich Context**: Enriches notifications with customer history, metrics, and actionable insights
-- 🎨 **Engaging Messages**: Uses whimsical language and emojis to make notifications fun and memorable
-- 📊 **Business Metrics**: Includes relevant business metrics like lifetime value and payment history
-- 🔄 **Event Analysis**: Analyzes events to provide actionable recommendations
-- ⚡ **Multiple Payment Providers**: Supports Shopify, Chargify, and Stripe webhooks
-- 🔗 **One-Click Integrations**: OAuth-based connections for Slack and Stripe (no manual token copying)
+- ⚡ **Three payment sources**: Stripe, Shopify, and Maxio (Chargify) webhooks, with signature validation on every request
+- 🔗 **One-click setup**: OAuth-based connections for Slack, Stripe (Stripe Connect creates the webhook endpoint for you), and Shopify — no manual token copying
+- 💡 **Automatic enrichment**: company data (logo, industry, size) via Brandfetch and person data (name, job title, seniority, LinkedIn) via Hunter.io
+- 📊 **Insight detection**: VIP and at-risk flags, lifetime-value milestones ($1k–$100k), trial start/conversion, upgrade and downgrade detection, payment-retry tracking, customer anniversaries
+- 🔄 **Noise reduction**: related events are consolidated and deduplicated into a single message instead of five pings
+- 🎯 **Full event coverage**: new subscriptions, payment success/failure, refunds, cancellations and reactivations, Shopify orders and fulfillment
+- 🎨 **Engaging messages**: Slack Block Kit formatting with action buttons that deep-link back to the originating dashboard
+
+## Self-Hosting
+
+Notipus is source-available and free to self-host. The full stack (Django, PostgreSQL, Redis) runs with Docker — follow the [Installation](#installation) steps below. Prefer not to run it yourself? Use the managed service at [notipus.com](https://notipus.com).
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Managed service: [notipus.com](https://notipus.com) · Self-hosting: [see below]
 
 ## Features
 
-- ⚡ **Three payment sources**: Stripe, Shopify, and Maxio (Chargify) webhooks, with signature validation on every request
-- 🔗 **One-click setup**: OAuth-based connections for Slack, Stripe (Stripe Connect creates the webhook endpoint for you), and Shopify — no manual token copying
-- 💡 **Automatic enrichment**: company data (logo, industry, size) via Brandfetch and person data (name, job title, seniority, LinkedIn) via Hunter.io
-- 📊 **Insight detection**: VIP and at-risk flags, lifetime-value milestones ($1k–$100k), trial start/conversion, upgrade and downgrade detection, payment-retry tracking, customer anniversaries
-- 🔄 **Noise reduction**: related events are consolidated and deduplicated into a single message instead of five pings
-- 🎯 **Full event coverage**: new subscriptions, payment success/failure, refunds, cancellations and reactivations, Shopify orders and fulfillment
-- 🎨 **Engaging messages**: Slack Block Kit formatting with action buttons that deep-link back to the originating dashboard
+- **Three payment sources**: Stripe, Shopify, and Maxio (Chargify) webhooks, with signature validation on every request
+- **One-click setup**: OAuth-based connections for Slack, Stripe (Stripe Connect creates the webhook endpoint for you), and Shopify — no manual token copying
+- **Automatic enrichment**: company data (logo, industry, size) via Brandfetch and person data (name, job title, seniority, LinkedIn) via Hunter.io
+- **Insight detection**: VIP and at-risk flags, lifetime-value milestones ($1k–$100k), trial start/conversion, upgrade and downgrade detection, payment-retry tracking, customer anniversaries
+- **Noise reduction**: related events are consolidated and deduplicated into a single message instead of five pings
+- **Full event coverage**: new subscriptions, payment success/failure, refunds, cancellations and reactivations, Shopify orders and fulfillment
+- **Engaging messages**: Slack Block Kit formatting with action buttons that deep-link back to the originating dashboard
 
 ## Self-Hosting
 


### PR DESCRIPTION
Part of the SEO/LLM audit follow-ups for notipus.com. The README is a primary source for both search engines and LLMs answering "how do I get payment notifications in Slack", and the old copy undersold the product:

- Headline said "Webhook to Slack Notifier"; the intro said "from Shopify and Chargify to Slack" and **omitted Stripe entirely**, even though Stripe is fully supported (with the best onboarding of the three — Stripe Connect OAuth auto-creates the webhook).
- Feature bullets were generic; the new list names the actual shipped capabilities: Brandfetch/Hunter.io enrichment, VIP/at-risk flags, LTV milestones, trial-conversion detection, event consolidation.
- Adds a `## Self-Hosting` section — the marketing site links to `#self-hosting`, which previously didn't exist.
- Standardizes on "Maxio (formerly Chargify)" naming, matching the website.

Repo metadata was also updated (description now mentions all three providers, homepage set to notipus.com, 13 topics added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)