### PR TITLE
feat: emit shipment_delivered when Shopify reports carrier delivery

### DIFF
--- a/app/plugins/sources/shopify.py
+++ b/app/plugins/sources/shopify.py
@@ -355,11 +355,14 @@ class ShopifySourcePlugin(BaseSourcePlugin):
         Returns:
             Standardized event data dictionary.
         """
-        # Extract fulfillment-specific fields
+        # Extract fulfillment-specific fields. ``status`` is Shopify's
+        # fulfillment status (e.g. "success") while ``shipment_status`` is
+        # the carrier's delivery status (e.g. "in_transit", "delivered").
         tracking_number = data.get("tracking_number")
         tracking_company = data.get("tracking_company")
         tracking_url = data.get("tracking_url")
-        fulfillment_status = data.get("status", data.get("shipment_status"))
+        fulfillment_status = data.get("status")
+        shipment_status = data.get("shipment_status")
 
         # Get line items from fulfillment
         line_items = []
@@ -386,8 +389,8 @@ class ShopifySourcePlugin(BaseSourcePlugin):
                     str(data.get("order_number")) if data.get("order_number") else None
                 ),
                 "fulfillment_id": data.get("id"),
-                "fulfillment_status": fulfillment_status,
-                "shipment_status": fulfillment_status,
+                "fulfillment_status": fulfillment_status or shipment_status,
+                "shipment_status": shipment_status or fulfillment_status,
                 "tracking_number": tracking_number,
                 "tracking_company": tracking_company,
                 "tracking_url": tracking_url,
@@ -469,6 +472,11 @@ class ShopifySourcePlugin(BaseSourcePlugin):
 
         # Handle fulfillment-specific topics differently
         if topic in self.FULFILLMENT_TOPICS:
+            # Shopify has no dedicated "delivered" webhook topic; carriers
+            # report delivery via ``shipment_status`` on fulfillment
+            # updates. Promote those to the shipment_delivered event type.
+            if data.get("shipment_status") == "delivered":
+                event_type = "shipment_delivered"
             fulfillment_customer_id = self._extract_customer_id_from_fulfillment(data)
             event = self._build_fulfillment_event_data(
                 event_type, fulfillment_customer_id, data, topic

--- a/tests/test_shopify_complete.py
+++ b/tests/test_shopify_complete.py
@@ -637,6 +637,62 @@ class TestFulfillmentWebhookParsing:
         assert result["customer_id"] == "12345"
         assert result["metadata"]["tracking_number"] == "1Z999AA10123456784"
 
+    def test_parse_webhook_shipment_delivered(self, provider: ShopifySourcePlugin):
+        """Test that a delivered shipment_status maps to shipment_delivered."""
+        mock_request = Mock()
+        mock_request.content_type = "application/json"
+        mock_request.headers = {
+            "X-Shopify-Topic": "fulfillments/update",
+            "X-Shopify-Test": "false",
+        }
+        mock_request.body = json.dumps(
+            {
+                "id": 123456,
+                "order_id": 789,
+                "order_number": "1001",
+                "status": "success",
+                "shipment_status": "delivered",
+                "tracking_number": "1Z999AA10123456784",
+                "customer": {"id": 12345},
+            }
+        ).encode()
+        mock_request.data = mock_request.body
+
+        result = provider.parse_webhook(mock_request)
+
+        assert result is not None
+        assert result["type"] == "shipment_delivered"
+        assert result["metadata"]["shipment_status"] == "delivered"
+        assert result["metadata"]["fulfillment_status"] == "success"
+
+    def test_parse_webhook_fulfillment_update_in_transit(
+        self, provider: ShopifySourcePlugin
+    ):
+        """Test that a non-delivered shipment_status stays fulfillment_updated."""
+        mock_request = Mock()
+        mock_request.content_type = "application/json"
+        mock_request.headers = {
+            "X-Shopify-Topic": "fulfillments/update",
+            "X-Shopify-Test": "false",
+        }
+        mock_request.body = json.dumps(
+            {
+                "id": 123456,
+                "order_id": 789,
+                "order_number": "1001",
+                "status": "success",
+                "shipment_status": "in_transit",
+                "customer": {"id": 12345},
+            }
+        ).encode()
+        mock_request.data = mock_request.body
+
+        result = provider.parse_webhook(mock_request)
+
+        assert result is not None
+        assert result["type"] == "fulfillment_updated"
+        assert result["metadata"]["shipment_status"] == "in_transit"
+
     def test_parse_webhook_order_fulfilled(self, provider: ShopifySourcePlugin):
         """Test parsing an orders/fulfilled webhook."""
         mock_request = Mock()


### PR DESCRIPTION
## Summary

The `shipment_delivered` notification type has been wired through the models, notification builder, and event processor since the logistics work landed — but no source plugin ever emitted it, so "Order delivered" notifications never fired.

Shopify has no dedicated "delivered" webhook topic; carriers report delivery via the `shipment_status` field on `fulfillments/update` webhooks. This PR:

- Promotes fulfillment webhooks with `shipment_status: "delivered"` to the `shipment_delivered` event type in the Shopify source plugin. Since this reuses the existing `fulfillments/update` subscription (part of the default `fulfillment` category), it works for already-connected stores with no re-subscription needed.
- Stops conflating Shopify's fulfillment `status` (e.g. `"success"`) with the carrier `shipment_status` in event metadata. Previously both metadata fields got the fulfillment status, discarding the carrier status entirely — so `fulfillment_updated` notifications rendered "Order #1001 - Success" instead of the actual carrier state (e.g. "In Transit"). Each field now carries its own value, falling back to the other when missing.

## Notes

- Shopify only populates `shipment_status` for tracking companies it recognizes (UPS, USPS, FedEx, DHL, etc.); orders shipped with unrecognized carriers won't produce delivery signals.
- Downstream rendering needed no changes: `shipment_delivered` already maps to "Order #N delivered", package icon, SUCCESS severity, LOGISTICS category.

## Testing

- Two new tests: `fulfillments/update` with `shipment_status: "delivered"` → `shipment_delivered`; with `"in_transit"` → stays `fulfillment_updated` and preserves the carrier status in metadata.
- Full suite passes (1132 passed), ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)