### PR TITLE
fix: block SSRF in logo download (private-IP + redirect guard)

### DIFF
--- a/app/core/services/logo_storage.py
+++ b/app/core/services/logo_storage.py
@@ -132,24 +132,32 @@ class LogoStorageService:
                     logger.warning("Invalid content type for logo: %r", content_type)
                     return None, ""
 
-                # Check content length if available
+                # Check content length if available. A malformed header is
+                # treated as unknown length rather than crashing; the streamed
+                # size cap below is the authoritative limit.
                 content_length = response.headers.get("Content-Length")
-                if content_length and int(content_length) > MAX_LOGO_SIZE:
-                    logger.warning("Logo too large: %s bytes", content_length)
-                    return None, ""
+                if content_length is not None:
+                    try:
+                        declared_size = int(content_length)
+                    except (ValueError, TypeError):
+                        declared_size = None
+                    if declared_size is not None and declared_size > MAX_LOGO_SIZE:
+                        logger.warning("Logo too large: %s bytes", content_length)
+                        return None, ""
 
-                # Download with size limit
-                data = b""
+                # Download with size limit. Accumulate into a bytearray to
+                # avoid quadratic-time repeated bytes concatenation.
+                buffer = bytearray()
                 for chunk in response.iter_content(chunk_size=8192):
-                    data += chunk
-                    if len(data) > MAX_LOGO_SIZE:
+                    buffer.extend(chunk)
+                    if len(buffer) > MAX_LOGO_SIZE:
                         logger.warning("Logo exceeded size limit during download")
                         return None, ""
 
-                if not data:
+                if not buffer:
                     return None, ""
 
-                return data, content_type
+                return bytes(buffer), content_type
 
         except requests.exceptions.Timeout:
             logger.warning("Timeout downloading logo from %r", url)

--- a/app/core/services/logo_storage.py
+++ b/app/core/services/logo_storage.py
@@ -8,7 +8,11 @@ import logging
 
 import requests
 from core.models import Company
-from core.utils.url_safety import is_safe_public_url
+from core.utils.url_safety import (
+    UnsafeUrlError,
+    create_pinned_session,
+    is_safe_public_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -85,66 +89,73 @@ class LogoStorageService:
         Returns:
             Tuple of (logo_data, content_type) or (None, "") on failure.
         """
-        # Reject URLs that resolve to non-public hosts (SSRF guard).
-        if not is_safe_public_url(url):
-            logger.warning(f"Refusing to download logo from unsafe URL: {url}")
+        # Resolve and validate the host, then pin the connection to a
+        # validated public IP. This rejects non-public hosts (SSRF guard) and
+        # is resistant to DNS rebinding: requests cannot silently re-resolve
+        # the hostname to an internal address between validation and connect.
+        try:
+            session = create_pinned_session(url)
+        except UnsafeUrlError:
+            logger.warning("Refusing to download logo from unsafe URL: %r", url)
             return None, ""
 
         try:
-            # Make request with timeout and size limit. Redirects are disabled
-            # so an attacker cannot bypass the SSRF check by redirecting to an
-            # internal host after the initial validation.
-            response = requests.get(
-                url,
-                timeout=REQUEST_TIMEOUT,
-                stream=True,
-                allow_redirects=False,
-                headers={
-                    "User-Agent": "Notipus/1.0 (Logo Fetcher)",
-                    "Accept": "image/*",
-                },
-            )
-
-            # Treat any redirect as a failed download rather than following it.
-            if response.is_redirect or response.is_permanent_redirect:
-                logger.warning(
-                    f"Refusing to follow redirect while downloading logo from {url}"
+            with session:
+                # Redirects are disabled so an attacker cannot bypass the SSRF
+                # check by redirecting to an internal host after validation.
+                response = session.get(
+                    url,
+                    timeout=REQUEST_TIMEOUT,
+                    stream=True,
+                    allow_redirects=False,
+                    headers={
+                        "User-Agent": "Notipus/1.0 (Logo Fetcher)",
+                        "Accept": "image/*",
+                    },
                 )
-                return None, ""
 
-            response.raise_for_status()
-
-            # Check content type
-            raw_content_type = response.headers.get("Content-Type", "")
-            content_type = raw_content_type.split(";")[0].strip()
-            if content_type not in ALLOWED_CONTENT_TYPES:
-                logger.warning(f"Invalid content type for logo: {content_type}")
-                return None, ""
-
-            # Check content length if available
-            content_length = response.headers.get("Content-Length")
-            if content_length and int(content_length) > MAX_LOGO_SIZE:
-                logger.warning(f"Logo too large: {content_length} bytes")
-                return None, ""
-
-            # Download with size limit
-            data = b""
-            for chunk in response.iter_content(chunk_size=8192):
-                data += chunk
-                if len(data) > MAX_LOGO_SIZE:
-                    logger.warning("Logo exceeded size limit during download")
+                # Treat any 3xx redirect as a failed download rather than
+                # following it to a potentially internal host.
+                if 300 <= response.status_code < 400:
+                    logger.warning(
+                        "Refusing to follow redirect while downloading logo from %r",
+                        url,
+                    )
                     return None, ""
 
-            if not data:
-                return None, ""
+                response.raise_for_status()
 
-            return data, content_type
+                # Check content type
+                raw_content_type = response.headers.get("Content-Type", "")
+                content_type = raw_content_type.split(";")[0].strip()
+                if content_type not in ALLOWED_CONTENT_TYPES:
+                    logger.warning("Invalid content type for logo: %r", content_type)
+                    return None, ""
+
+                # Check content length if available
+                content_length = response.headers.get("Content-Length")
+                if content_length and int(content_length) > MAX_LOGO_SIZE:
+                    logger.warning("Logo too large: %s bytes", content_length)
+                    return None, ""
+
+                # Download with size limit
+                data = b""
+                for chunk in response.iter_content(chunk_size=8192):
+                    data += chunk
+                    if len(data) > MAX_LOGO_SIZE:
+                        logger.warning("Logo exceeded size limit during download")
+                        return None, ""
+
+                if not data:
+                    return None, ""
+
+                return data, content_type
 
         except requests.exceptions.Timeout:
-            logger.warning(f"Timeout downloading logo from {url}")
+            logger.warning("Timeout downloading logo from %r", url)
             return None, ""
         except requests.exceptions.RequestException as e:
-            logger.warning(f"Error downloading logo from {url}: {e}")
+            logger.warning("Error downloading logo from %r: %s", url, e)
             return None, ""
 
     def refresh_logo(self, company: Company) -> bool:
@@ -159,11 +170,14 @@ class LogoStorageService:
         if not company.logo_url:
             return False
 
-        # Reject URLs that resolve to non-public hosts (SSRF guard).
+        # Reject URLs that resolve to non-public hosts (SSRF guard). The
+        # authoritative, rebinding-safe check happens in _download_logo; this
+        # is a cheap early rejection.
         if not is_safe_public_url(company.logo_url):
             logger.warning(
-                f"Refusing to refresh logo for {company.domain} from "
-                f"unsafe URL: {company.logo_url}"
+                "Refusing to refresh logo for %r from unsafe URL: %r",
+                company.domain,
+                company.logo_url,
             )
             return False
 

--- a/app/core/services/logo_storage.py
+++ b/app/core/services/logo_storage.py
@@ -132,32 +132,11 @@ class LogoStorageService:
                     logger.warning("Invalid content type for logo: %r", content_type)
                     return None, ""
 
-                # Check content length if available. A malformed header is
-                # treated as unknown length rather than crashing; the streamed
-                # size cap below is the authoritative limit.
-                content_length = response.headers.get("Content-Length")
-                if content_length is not None:
-                    try:
-                        declared_size = int(content_length)
-                    except (ValueError, TypeError):
-                        declared_size = None
-                    if declared_size is not None and declared_size > MAX_LOGO_SIZE:
-                        logger.warning("Logo too large: %s bytes", content_length)
-                        return None, ""
-
-                # Download with size limit. Accumulate into a bytearray to
-                # avoid quadratic-time repeated bytes concatenation.
-                buffer = bytearray()
-                for chunk in response.iter_content(chunk_size=8192):
-                    buffer.extend(chunk)
-                    if len(buffer) > MAX_LOGO_SIZE:
-                        logger.warning("Logo exceeded size limit during download")
-                        return None, ""
-
-                if not buffer:
+                data = self._read_capped_body(response)
+                if not data:
                     return None, ""
 
-                return bytes(buffer), content_type
+                return data, content_type
 
         except requests.exceptions.Timeout:
             logger.warning("Timeout downloading logo from %r", url)
@@ -165,6 +144,41 @@ class LogoStorageService:
         except requests.exceptions.RequestException as e:
             logger.warning("Error downloading logo from %r: %s", url, e)
             return None, ""
+
+    def _read_capped_body(self, response: requests.Response) -> bytes | None:
+        """Read a response body, enforcing the maximum logo size.
+
+        Rejects up front if the Content-Length header declares a size over the
+        cap (a malformed header is treated as unknown length), then streams the
+        body into a bytearray and aborts if it exceeds the cap.
+
+        Args:
+            response: Streaming response to read from.
+
+        Returns:
+            The body bytes, or None if the size cap is exceeded.
+        """
+        # A malformed Content-Length is treated as unknown length rather than
+        # crashing; the streamed cap below is the authoritative limit.
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None:
+            try:
+                declared_size = int(content_length)
+            except (ValueError, TypeError):
+                declared_size = None
+            if declared_size is not None and declared_size > MAX_LOGO_SIZE:
+                logger.warning("Logo too large: %s bytes", content_length)
+                return None
+
+        # Accumulate into a bytearray to avoid quadratic-time concatenation.
+        buffer = bytearray()
+        for chunk in response.iter_content(chunk_size=8192):
+            buffer.extend(chunk)
+            if len(buffer) > MAX_LOGO_SIZE:
+                logger.warning("Logo exceeded size limit during download")
+                return None
+
+        return bytes(buffer)
 
     def refresh_logo(self, company: Company) -> bool:
         """Refresh logo from original URL.

--- a/app/core/services/logo_storage.py
+++ b/app/core/services/logo_storage.py
@@ -8,6 +8,7 @@ import logging
 
 import requests
 from core.models import Company
+from core.utils.url_safety import is_safe_public_url
 
 logger = logging.getLogger(__name__)
 
@@ -84,17 +85,33 @@ class LogoStorageService:
         Returns:
             Tuple of (logo_data, content_type) or (None, "") on failure.
         """
+        # Reject URLs that resolve to non-public hosts (SSRF guard).
+        if not is_safe_public_url(url):
+            logger.warning(f"Refusing to download logo from unsafe URL: {url}")
+            return None, ""
+
         try:
-            # Make request with timeout and size limit
+            # Make request with timeout and size limit. Redirects are disabled
+            # so an attacker cannot bypass the SSRF check by redirecting to an
+            # internal host after the initial validation.
             response = requests.get(
                 url,
                 timeout=REQUEST_TIMEOUT,
                 stream=True,
+                allow_redirects=False,
                 headers={
                     "User-Agent": "Notipus/1.0 (Logo Fetcher)",
                     "Accept": "image/*",
                 },
             )
+
+            # Treat any redirect as a failed download rather than following it.
+            if response.is_redirect or response.is_permanent_redirect:
+                logger.warning(
+                    f"Refusing to follow redirect while downloading logo from {url}"
+                )
+                return None, ""
+
             response.raise_for_status()
 
             # Check content type
@@ -140,6 +157,14 @@ class LogoStorageService:
             True if logo was refreshed successfully.
         """
         if not company.logo_url:
+            return False
+
+        # Reject URLs that resolve to non-public hosts (SSRF guard).
+        if not is_safe_public_url(company.logo_url):
+            logger.warning(
+                f"Refusing to refresh logo for {company.domain} from "
+                f"unsafe URL: {company.logo_url}"
+            )
             return False
 
         return self.download_and_store(company, company.logo_url)

--- a/app/core/utils/url_safety.py
+++ b/app/core/utils/url_safety.py
@@ -1,39 +1,76 @@
 """URL safety utilities for guarding against SSRF.
 
 This module provides helpers to validate that an outbound URL points at a
-public internet host before it is fetched. It resolves the hostname and
-rejects any URL that resolves to a private, loopback, link-local, reserved,
-multicast, or unspecified address, closing off server-side request forgery
-(SSRF) vectors against internal infrastructure (e.g. cloud metadata endpoints).
+public internet host before it is fetched, and to actually fetch it in a way
+that is resistant to DNS-rebinding (TOCTOU) attacks.
+
+The core guarantees are:
+
+* Only ``http``/``https`` schemes with a host are allowed.
+* The hostname is resolved and every resolved IP must be routable on the
+  public internet (rejecting private, loopback, link-local, reserved,
+  multicast, unspecified, and IPv4-mapped-IPv6 variants of those).
+* When fetching, the connection is *pinned* to a pre-validated IP so that
+  ``requests`` cannot silently re-resolve the hostname to an internal
+  address between validation and connection. The original hostname is kept
+  for TLS SNI and certificate verification, so certificate checking is not
+  weakened.
 """
 
 import ipaddress
 import logging
 import socket
-from urllib.parse import urlparse
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+from requests.adapters import HTTPAdapter
 
 logger = logging.getLogger(__name__)
 
 # URL schemes permitted for outbound fetches.
 ALLOWED_SCHEMES = frozenset({"http", "https"})
 
+# Default ports per scheme, used when reconstructing the Host header.
+DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+class UnsafeUrlError(ValueError):
+    """Raised when a URL is not safe to fetch from a server context."""
+
 
 def _is_public_ip(ip_str: str) -> bool:
-    """Return whether an IP address string is a routable public address.
+    """Return whether an IP address string is routable on the public internet.
+
+    IPv4-mapped IPv6 addresses (e.g. ``::ffff:127.0.0.1``) are normalized to
+    their embedded IPv4 address before evaluation, so they cannot be used to
+    smuggle an internal address past the check. The authoritative test is
+    ``ipaddress``'s global-reachability flag (``is_global``), which covers
+    unique-local (ULA), shared-address/CGNAT and similar ranges; explicit
+    category checks are kept as belt-and-suspenders.
 
     Args:
         ip_str: Textual IPv4 or IPv6 address.
 
     Returns:
-        True if the address is public (not private, loopback, link-local,
-        reserved, multicast, or unspecified). False for non-public or
-        unparseable addresses.
+        True if the address is public, False for non-public or unparseable
+        addresses.
     """
     try:
-        ip = ipaddress.ip_address(ip_str)
+        ip: ipaddress.IPv4Address | ipaddress.IPv6Address = ipaddress.ip_address(ip_str)
     except ValueError:
         return False
 
+    # Normalize IPv4-mapped IPv6 to the embedded IPv4 address so the real
+    # target is evaluated instead of the wrapper.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+
+    # is_global is the primary, authoritative reject condition.
+    if not ip.is_global:
+        return False
+
+    # Belt-and-suspenders: reject well-known non-public categories explicitly.
     if (
         ip.is_private
         or ip.is_loopback
@@ -47,14 +84,50 @@ def _is_public_ip(ip_str: str) -> bool:
     return True
 
 
+def _resolve_validated_ips(hostname: str) -> list[str]:
+    """Resolve a hostname once and return its validated public IPs.
+
+    The resolution is fail-closed: if resolution fails, or if ANY resolved
+    address is non-public, an empty list is returned so callers reject the
+    host entirely rather than gambling on address ordering.
+
+    Args:
+        hostname: The hostname to resolve.
+
+    Returns:
+        A list of validated public IP strings, or an empty list if the host
+        is unsafe or unresolvable.
+    """
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except (socket.gaierror, OSError, UnicodeError):
+        return []
+
+    if not addr_infos:
+        return []
+
+    ips: list[str] = []
+    for addr_info in addr_infos:
+        ip_str = str(addr_info[4][0])
+        if not _is_public_ip(ip_str):
+            return []
+        ips.append(ip_str)
+
+    return ips
+
+
 def is_safe_public_url(url: str) -> bool:
     """Return whether a URL is safe to fetch from a server context.
 
     The URL must use an http/https scheme and specify a host. The host is
-    resolved via DNS and every resolved IP address must be public; if any
-    resolved address is private, loopback, link-local, reserved, multicast,
-    or unspecified the URL is rejected. This guards against SSRF where an
-    attacker-controlled URL points at internal infrastructure.
+    resolved via DNS and every resolved IP address must be public. This
+    guards against SSRF where an attacker-controlled URL points at internal
+    infrastructure.
+
+    Note:
+        This performs a point-in-time check. To fetch safely, use
+        :func:`create_pinned_session`, which additionally pins the connection
+        to the validated IP and so is not vulnerable to DNS rebinding.
 
     Args:
         url: The URL to validate.
@@ -63,31 +136,17 @@ def is_safe_public_url(url: str) -> bool:
         True if the URL is safe to fetch, False otherwise.
     """
     try:
-        parsed = urlparse(url)
+        parsed = urlsplit(url)
     except ValueError:
         return False
 
     if parsed.scheme.lower() not in ALLOWED_SCHEMES:
         return False
 
-    hostname = parsed.hostname
-    if not hostname:
+    if not parsed.hostname:
         return False
 
-    try:
-        addr_infos = socket.getaddrinfo(hostname, None)
-    except (socket.gaierror, socket.error, UnicodeError):
-        return False
-
-    if not addr_infos:
-        return False
-
-    for addr_info in addr_infos:
-        ip_str = str(addr_info[4][0])
-        if not _is_public_ip(ip_str):
-            return False
-
-    return True
+    return bool(_resolve_validated_ips(parsed.hostname))
 
 
 def assert_safe_public_url(url: str) -> None:
@@ -97,7 +156,139 @@ def assert_safe_public_url(url: str) -> None:
         url: The URL to validate.
 
     Raises:
-        ValueError: If the URL fails the :func:`is_safe_public_url` check.
+        UnsafeUrlError: If the URL fails the :func:`is_safe_public_url` check.
     """
     if not is_safe_public_url(url):
-        raise ValueError(f"URL is not a safe public URL: {url!r}")
+        raise UnsafeUrlError(f"URL is not a safe public URL: {url!r}")
+
+
+class _PinnedIPAdapter(HTTPAdapter):
+    """Requests adapter that connects to a pre-validated public IP.
+
+    The connection target is pinned to an IP that was already validated as
+    public, closing the TOCTOU DNS-rebinding window: without this, ``requests``
+    would re-resolve the hostname when opening the socket, and an attacker
+    controlling DNS could return a public IP during validation and an internal
+    IP at fetch time. The original hostname is preserved for the ``Host``
+    header and (for TLS) for SNI and certificate verification, so certificate
+    checking is not weakened.
+    """
+
+    def __init__(self, hostname: str, validated_ip: str, use_tls: bool) -> None:
+        """Initialize the adapter.
+
+        Args:
+            hostname: Original hostname (used for Host header and TLS verify).
+            validated_ip: Pre-validated public IP to connect to.
+            use_tls: Whether the target scheme is https (enables SNI pinning).
+        """
+        self._hostname = hostname
+        self._validated_ip = validated_ip
+        self._use_tls = use_tls
+        super().__init__()
+
+    def init_poolmanager(self, *args: Any, **kwargs: Any) -> None:
+        """Force TLS SNI and hostname verification to use the real hostname.
+
+        Even though the socket connects to the pinned IP, SNI and certificate
+        verification must target the original hostname. These pool kwargs are
+        only meaningful for TLS, so they are set for https targets only.
+        """
+        if self._use_tls:
+            kwargs["server_hostname"] = self._hostname
+            kwargs["assert_hostname"] = self._hostname
+        super().init_poolmanager(*args, **kwargs)
+
+    def send(
+        self,
+        request: requests.PreparedRequest,
+        stream: Any = False,
+        timeout: Any = None,
+        verify: Any = True,
+        cert: Any = None,
+        proxies: Any = None,
+    ) -> requests.Response:
+        """Rewrite the request to connect to the pinned IP, then send.
+
+        Args:
+            request: The prepared request to send.
+            stream: Whether to stream the response body.
+            timeout: Request timeout.
+            verify: Whether/how to verify TLS certificates.
+            cert: Optional client certificate.
+            proxies: Optional proxy mapping.
+
+        Returns:
+            The HTTP response.
+
+        Raises:
+            UnsafeUrlError: If the request host no longer matches the pinned
+                hostname (e.g. an unexpected retarget).
+        """
+        parsed = urlsplit(request.url or "")
+        if parsed.hostname != self._hostname:
+            raise UnsafeUrlError(
+                f"Request host does not match pinned host: {request.url!r}"
+            )
+
+        conn_host = (
+            f"[{self._validated_ip}]"
+            if ":" in self._validated_ip
+            else self._validated_ip
+        )
+        netloc = conn_host if parsed.port is None else f"{conn_host}:{parsed.port}"
+        request.url = urlunsplit(parsed._replace(netloc=netloc))
+
+        # Preserve the original Host header so the origin server routes the
+        # request correctly despite the IP-based connection.
+        default_port = DEFAULT_PORTS.get(parsed.scheme.lower())
+        if parsed.port and parsed.port != default_port:
+            request.headers["Host"] = f"{self._hostname}:{parsed.port}"
+        else:
+            request.headers["Host"] = self._hostname
+
+        return super().send(
+            request,
+            stream=stream,
+            timeout=timeout,
+            verify=verify,
+            cert=cert,
+            proxies=proxies,
+        )
+
+
+def create_pinned_session(url: str) -> requests.Session:
+    """Return a requests Session pinned to a validated public IP for ``url``.
+
+    The hostname is resolved exactly once, every resolved IP is validated as
+    public, and the returned session is mounted with an adapter that connects
+    to a validated IP while preserving the hostname for TLS verification. This
+    is the DNS-rebinding-safe way to fetch an untrusted URL.
+
+    Args:
+        url: The URL that will be fetched with the returned session.
+
+    Returns:
+        A requests Session pinned to a validated public IP.
+
+    Raises:
+        UnsafeUrlError: If the scheme/host is invalid or the host resolves to
+            any non-public address.
+    """
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise UnsafeUrlError(f"Unsupported URL scheme: {url!r}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UnsafeUrlError(f"URL has no host: {url!r}")
+
+    ips = _resolve_validated_ips(hostname)
+    if not ips:
+        raise UnsafeUrlError(f"URL resolves to a non-public host: {url!r}")
+
+    adapter = _PinnedIPAdapter(hostname, ips[0], use_tls=(scheme == "https"))
+    session = requests.Session()
+    session.mount(f"{scheme}://", adapter)
+    return session

--- a/app/core/utils/url_safety.py
+++ b/app/core/utils/url_safety.py
@@ -275,7 +275,11 @@ def create_pinned_session(url: str) -> requests.Session:
         UnsafeUrlError: If the scheme/host is invalid or the host resolves to
             any non-public address.
     """
-    parsed = urlsplit(url)
+    try:
+        parsed = urlsplit(url)
+    except ValueError as e:
+        raise UnsafeUrlError(f"Malformed URL: {url!r}") from e
+
     scheme = parsed.scheme.lower()
     if scheme not in ALLOWED_SCHEMES:
         raise UnsafeUrlError(f"Unsupported URL scheme: {url!r}")

--- a/app/core/utils/url_safety.py
+++ b/app/core/utils/url_safety.py
@@ -314,5 +314,9 @@ def create_pinned_session(url: str) -> requests.Session:
 
     adapter = _PinnedIPAdapter(hostname, _prefer_ipv4(ips), use_tls=(scheme == "https"))
     session = requests.Session()
+    # Ignore environment proxy settings (HTTP_PROXY/HTTPS_PROXY/NO_PROXY):
+    # an env-configured proxy could route the request through an internal
+    # host, bypassing the validated/pinned connection (SSRF).
+    session.trust_env = False
     session.mount(f"{scheme}://", adapter)
     return session

--- a/app/core/utils/url_safety.py
+++ b/app/core/utils/url_safety.py
@@ -116,6 +116,26 @@ def _resolve_validated_ips(hostname: str) -> list[str]:
     return ips
 
 
+def _prefer_ipv4(ips: list[str]) -> str:
+    """Pick the connection IP, preferring IPv4 over IPv6.
+
+    Dual-stack hosts may return an IPv6 address first, which fails in
+    IPv4-only or broken-IPv6 environments even when a validated public IPv4
+    exists. Prefer the first IPv4 address and fall back to the first address
+    (IPv6) only if no IPv4 is present.
+
+    Args:
+        ips: Non-empty list of already-validated public IP strings.
+
+    Returns:
+        The IP string to pin the connection to.
+    """
+    for ip in ips:
+        if ":" not in ip:
+            return ip
+    return ips[0]
+
+
 def is_safe_public_url(url: str) -> bool:
     """Return whether a URL is safe to fetch from a server context.
 
@@ -292,7 +312,7 @@ def create_pinned_session(url: str) -> requests.Session:
     if not ips:
         raise UnsafeUrlError(f"URL resolves to a non-public host: {url!r}")
 
-    adapter = _PinnedIPAdapter(hostname, ips[0], use_tls=(scheme == "https"))
+    adapter = _PinnedIPAdapter(hostname, _prefer_ipv4(ips), use_tls=(scheme == "https"))
     session = requests.Session()
     session.mount(f"{scheme}://", adapter)
     return session

--- a/app/core/utils/url_safety.py
+++ b/app/core/utils/url_safety.py
@@ -1,0 +1,103 @@
+"""URL safety utilities for guarding against SSRF.
+
+This module provides helpers to validate that an outbound URL points at a
+public internet host before it is fetched. It resolves the hostname and
+rejects any URL that resolves to a private, loopback, link-local, reserved,
+multicast, or unspecified address, closing off server-side request forgery
+(SSRF) vectors against internal infrastructure (e.g. cloud metadata endpoints).
+"""
+
+import ipaddress
+import logging
+import socket
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# URL schemes permitted for outbound fetches.
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def _is_public_ip(ip_str: str) -> bool:
+    """Return whether an IP address string is a routable public address.
+
+    Args:
+        ip_str: Textual IPv4 or IPv6 address.
+
+    Returns:
+        True if the address is public (not private, loopback, link-local,
+        reserved, multicast, or unspecified). False for non-public or
+        unparseable addresses.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        return False
+
+    return True
+
+
+def is_safe_public_url(url: str) -> bool:
+    """Return whether a URL is safe to fetch from a server context.
+
+    The URL must use an http/https scheme and specify a host. The host is
+    resolved via DNS and every resolved IP address must be public; if any
+    resolved address is private, loopback, link-local, reserved, multicast,
+    or unspecified the URL is rejected. This guards against SSRF where an
+    attacker-controlled URL points at internal infrastructure.
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        True if the URL is safe to fetch, False otherwise.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        return False
+
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except (socket.gaierror, socket.error, UnicodeError):
+        return False
+
+    if not addr_infos:
+        return False
+
+    for addr_info in addr_infos:
+        ip_str = str(addr_info[4][0])
+        if not _is_public_ip(ip_str):
+            return False
+
+    return True
+
+
+def assert_safe_public_url(url: str) -> None:
+    """Raise if a URL is not safe to fetch from a server context.
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        ValueError: If the URL fails the :func:`is_safe_public_url` check.
+    """
+    if not is_safe_public_url(url):
+        raise ValueError(f"URL is not a safe public URL: {url!r}")

--- a/tests/core/test_logo_storage.py
+++ b/tests/core/test_logo_storage.py
@@ -1,0 +1,89 @@
+"""Tests for the logo storage service SSRF protections.
+
+Tests cover:
+- ``_download_logo`` refusing URLs that resolve to internal hosts
+- ``_download_logo`` disabling redirects and refusing redirect responses
+- ``_download_logo`` succeeding for a safe public URL
+
+All network access is mocked; the SSRF safety check is patched so tests
+never perform real DNS resolution (the suite runs with --disable-socket).
+"""
+
+from unittest.mock import Mock, patch
+
+from core.services.logo_storage import LogoStorageService
+
+
+class TestDownloadLogoSsrf:
+    """Tests for SSRF guards in ``LogoStorageService._download_logo``."""
+
+    def test_refuses_internal_url(self) -> None:
+        """An unsafe (internal) URL is refused before any request is made."""
+        service = LogoStorageService()
+
+        with (
+            patch(
+                "core.services.logo_storage.is_safe_public_url",
+                return_value=False,
+            ) as mock_safe,
+            patch("core.services.logo_storage.requests.get") as mock_get,
+        ):
+            data, content_type = service._download_logo(
+                "http://169.254.169.254/latest/meta-data/"
+            )
+
+        assert data is None
+        assert content_type == ""
+        mock_safe.assert_called_once_with("http://169.254.169.254/latest/meta-data/")
+        mock_get.assert_not_called()
+
+    def test_disables_redirects_and_refuses_redirect_response(self) -> None:
+        """Redirects are disabled and a redirect response is treated as failure."""
+        service = LogoStorageService()
+
+        response = Mock()
+        response.is_redirect = True
+        response.is_permanent_redirect = False
+
+        with (
+            patch(
+                "core.services.logo_storage.is_safe_public_url",
+                return_value=True,
+            ),
+            patch(
+                "core.services.logo_storage.requests.get", return_value=response
+            ) as mock_get,
+        ):
+            data, content_type = service._download_logo("https://example.com/logo.png")
+
+        assert data is None
+        assert content_type == ""
+        # Redirect following must be disabled at the request layer.
+        assert mock_get.call_args.kwargs["allow_redirects"] is False
+        response.raise_for_status.assert_not_called()
+
+    def test_downloads_safe_public_url(self) -> None:
+        """A safe public URL downloads and returns logo bytes."""
+        service = LogoStorageService()
+
+        response = Mock()
+        response.is_redirect = False
+        response.is_permanent_redirect = False
+        response.raise_for_status = Mock()
+        response.headers = {
+            "Content-Type": "image/png",
+            "Content-Length": "4",
+        }
+        response.iter_content = Mock(return_value=[b"dead"])
+
+        with (
+            patch(
+                "core.services.logo_storage.is_safe_public_url",
+                return_value=True,
+            ),
+            patch("core.services.logo_storage.requests.get", return_value=response),
+        ):
+            data, content_type = service._download_logo("https://example.com/logo.png")
+
+        assert data == b"dead"
+        assert content_type == "image/png"

--- a/tests/core/test_logo_storage.py
+++ b/tests/core/test_logo_storage.py
@@ -89,6 +89,30 @@ class TestDownloadLogoSsrf:
         assert content_type == ""
         response.raise_for_status.assert_not_called()
 
+    def test_malformed_content_length_does_not_crash(self) -> None:
+        """A malformed Content-Length is treated as unknown, not an error."""
+        service = LogoStorageService()
+
+        response = Mock()
+        response.status_code = 200
+        response.raise_for_status = Mock()
+        response.headers = {
+            "Content-Type": "image/png",
+            "Content-Length": "not-a-number",
+        }
+        response.iter_content = Mock(return_value=[b"dead"])
+        session = _mock_session(response)
+
+        with patch(
+            "core.services.logo_storage.create_pinned_session",
+            return_value=session,
+        ):
+            data, content_type = service._download_logo("https://example.com/logo.png")
+
+        # Falls back to the streamed size cap; the small body succeeds.
+        assert data == b"dead"
+        assert content_type == "image/png"
+
     def test_downloads_safe_public_url(self) -> None:
         """A safe public URL downloads and returns logo bytes."""
         service = LogoStorageService()

--- a/tests/core/test_logo_storage.py
+++ b/tests/core/test_logo_storage.py
@@ -2,16 +2,34 @@
 
 Tests cover:
 - ``_download_logo`` refusing URLs that resolve to internal hosts
-- ``_download_logo`` disabling redirects and refusing redirect responses
+- ``_download_logo`` disabling redirects and refusing any 3xx response
 - ``_download_logo`` succeeding for a safe public URL
 
-All network access is mocked; the SSRF safety check is patched so tests
-never perform real DNS resolution (the suite runs with --disable-socket).
+All network access is mocked; the pinned-session factory is patched so tests
+never perform real DNS resolution or open sockets (the suite runs with
+pytest-socket's --disable-socket).
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from core.services.logo_storage import LogoStorageService
+from core.utils.url_safety import UnsafeUrlError
+
+
+def _mock_session(response: Mock) -> MagicMock:
+    """Build a mock requests Session usable as a context manager.
+
+    Args:
+        response: The response its ``get`` should return.
+
+    Returns:
+        A MagicMock whose ``get`` returns ``response`` and which supports the
+        ``with session:`` protocol.
+    """
+    session = MagicMock()
+    session.__enter__.return_value = session
+    session.get.return_value = response
+    return session
 
 
 class TestDownloadLogoSsrf:
@@ -21,45 +39,54 @@ class TestDownloadLogoSsrf:
         """An unsafe (internal) URL is refused before any request is made."""
         service = LogoStorageService()
 
-        with (
-            patch(
-                "core.services.logo_storage.is_safe_public_url",
-                return_value=False,
-            ) as mock_safe,
-            patch("core.services.logo_storage.requests.get") as mock_get,
-        ):
+        with patch(
+            "core.services.logo_storage.create_pinned_session",
+            side_effect=UnsafeUrlError("unsafe"),
+        ) as mock_factory:
             data, content_type = service._download_logo(
                 "http://169.254.169.254/latest/meta-data/"
             )
 
         assert data is None
         assert content_type == ""
-        mock_safe.assert_called_once_with("http://169.254.169.254/latest/meta-data/")
-        mock_get.assert_not_called()
+        mock_factory.assert_called_once_with("http://169.254.169.254/latest/meta-data/")
 
     def test_disables_redirects_and_refuses_redirect_response(self) -> None:
-        """Redirects are disabled and a redirect response is treated as failure."""
+        """Redirects are disabled and any 3xx response is treated as failure."""
         service = LogoStorageService()
 
         response = Mock()
-        response.is_redirect = True
-        response.is_permanent_redirect = False
+        response.status_code = 302
+        session = _mock_session(response)
 
-        with (
-            patch(
-                "core.services.logo_storage.is_safe_public_url",
-                return_value=True,
-            ),
-            patch(
-                "core.services.logo_storage.requests.get", return_value=response
-            ) as mock_get,
+        with patch(
+            "core.services.logo_storage.create_pinned_session",
+            return_value=session,
         ):
             data, content_type = service._download_logo("https://example.com/logo.png")
 
         assert data is None
         assert content_type == ""
         # Redirect following must be disabled at the request layer.
-        assert mock_get.call_args.kwargs["allow_redirects"] is False
+        assert session.get.call_args.kwargs["allow_redirects"] is False
+        response.raise_for_status.assert_not_called()
+
+    def test_refuses_other_3xx_status(self) -> None:
+        """A 3xx status is refused across the whole range, not just is_redirect."""
+        service = LogoStorageService()
+
+        response = Mock()
+        response.status_code = 304  # Not an is_redirect status, still a 3xx.
+        session = _mock_session(response)
+
+        with patch(
+            "core.services.logo_storage.create_pinned_session",
+            return_value=session,
+        ):
+            data, content_type = service._download_logo("https://example.com/logo.png")
+
+        assert data is None
+        assert content_type == ""
         response.raise_for_status.assert_not_called()
 
     def test_downloads_safe_public_url(self) -> None:
@@ -67,21 +94,18 @@ class TestDownloadLogoSsrf:
         service = LogoStorageService()
 
         response = Mock()
-        response.is_redirect = False
-        response.is_permanent_redirect = False
+        response.status_code = 200
         response.raise_for_status = Mock()
         response.headers = {
             "Content-Type": "image/png",
             "Content-Length": "4",
         }
         response.iter_content = Mock(return_value=[b"dead"])
+        session = _mock_session(response)
 
-        with (
-            patch(
-                "core.services.logo_storage.is_safe_public_url",
-                return_value=True,
-            ),
-            patch("core.services.logo_storage.requests.get", return_value=response),
+        with patch(
+            "core.services.logo_storage.create_pinned_session",
+            return_value=session,
         ):
             data, content_type = service._download_logo("https://example.com/logo.png")
 

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -16,8 +16,15 @@ import socket
 from collections.abc import Callable
 
 import pytest
+import requests
 from core.utils import url_safety
-from core.utils.url_safety import assert_safe_public_url, is_safe_public_url
+from core.utils.url_safety import (
+    UnsafeUrlError,
+    _PinnedIPAdapter,
+    assert_safe_public_url,
+    create_pinned_session,
+    is_safe_public_url,
+)
 
 
 def _fake_getaddrinfo_for(ip: str) -> Callable[..., list]:
@@ -101,9 +108,13 @@ class TestIsSafePublicUrl:
         [
             "::1",  # loopback
             "fe80::1",  # link-local
-            "fc00::1",  # unique local (private)
+            "fc00::1",  # unique local (ULA / private)
+            "fd00::1",  # unique local (ULA / private)
             "::",  # unspecified
             "ff02::1",  # multicast
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback
+            "::ffff:169.254.169.254",  # IPv4-mapped link-local (metadata)
+            "::ffff:10.0.0.1",  # IPv4-mapped private
         ],
     )
     def test_private_ipv6_rejected(
@@ -154,3 +165,138 @@ class TestAssertSafePublicUrl:
             url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for("93.184.216.34")
         )
         assert_safe_public_url("https://example.com/logo.png")
+
+
+class TestCreatePinnedSession:
+    """Tests for :func:`create_pinned_session` (DNS-rebinding-safe fetch)."""
+
+    def test_pins_to_validated_ip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The session is mounted with an adapter pinned to the validated IP."""
+        monkeypatch.setattr(
+            url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for("93.184.216.34")
+        )
+        session = create_pinned_session("https://example.com/logo.png")
+        try:
+            adapter = session.get_adapter("https://example.com/logo.png")
+            assert isinstance(adapter, _PinnedIPAdapter)
+            assert adapter._hostname == "example.com"
+            assert adapter._validated_ip == "93.184.216.34"
+        finally:
+            session.close()
+
+    def test_refuses_private_resolution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A host resolving to a private IP raises UnsafeUrlError."""
+        monkeypatch.setattr(
+            url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for("127.0.0.1")
+        )
+        with pytest.raises(UnsafeUrlError):
+            create_pinned_session("https://internal.example.com/")
+
+    def test_refuses_non_http_scheme(self) -> None:
+        """A non-http(s) scheme raises without resolving."""
+        with pytest.raises(UnsafeUrlError):
+            create_pinned_session("ftp://example.com/")
+
+    def test_refuses_hostless_url(self) -> None:
+        """A hostless URL raises."""
+        with pytest.raises(UnsafeUrlError):
+            create_pinned_session("https://")
+
+    def test_resolves_only_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DNS is resolved exactly once so there is no re-resolution window."""
+        calls = {"n": 0}
+
+        def _fake(*_args: object, **_kwargs: object) -> list:
+            calls["n"] += 1
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake)
+        session = create_pinned_session("https://example.com/")
+        session.close()
+        assert calls["n"] == 1
+
+    def test_dns_rebinding_pins_first_public_ip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A host that is public at validation then private at fetch is pinned.
+
+        The resolver returns a public IP on the first (validation) call and a
+        private IP on any subsequent call. Because the session resolves once
+        and pins the connection to the validated public IP, the later private
+        answer is never used, closing the DNS-rebinding window.
+        """
+        results = iter(
+            [
+                [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))],
+                [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))],
+            ]
+        )
+
+        def _fake(*_args: object, **_kwargs: object) -> list:
+            return next(results)
+
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake)
+        session = create_pinned_session("https://example.com/")
+        try:
+            adapter = session.get_adapter("https://example.com/")
+            assert isinstance(adapter, _PinnedIPAdapter)
+            # Pinned to the public IP seen at validation, not the later private.
+            assert adapter._validated_ip == "93.184.216.34"
+        finally:
+            session.close()
+
+
+class TestPinnedIPAdapter:
+    """Tests for the connection-pinning behavior of :class:`_PinnedIPAdapter`."""
+
+    def test_send_rewrites_host_to_ip_and_preserves_host_header(self) -> None:
+        """send() connects to the pinned IP but keeps the original Host."""
+        adapter = _PinnedIPAdapter("example.com", "93.184.216.34", use_tls=True)
+        request = requests.Request("GET", "https://example.com/logo.png").prepare()
+
+        captured: dict[str, requests.PreparedRequest] = {}
+
+        def _fake_super_send(
+            self: object, req: requests.PreparedRequest, **_kwargs: object
+        ) -> str:
+            captured["request"] = req
+            return "sent"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(url_safety.HTTPAdapter, "send", _fake_super_send)
+            adapter.send(request)
+
+        sent = captured["request"]
+        assert sent.url == "https://93.184.216.34/logo.png"
+        assert sent.headers["Host"] == "example.com"
+
+    def test_send_brackets_ipv6_and_keeps_port(self) -> None:
+        """IPv6 pins are bracketed and non-default ports flow into Host."""
+        adapter = _PinnedIPAdapter(
+            "example.com", "2606:2800:220:1:248:1893:25c8:1946", use_tls=True
+        )
+        request = requests.Request("GET", "https://example.com:8443/logo.png").prepare()
+
+        captured: dict[str, requests.PreparedRequest] = {}
+
+        def _fake_super_send(
+            self: object, req: requests.PreparedRequest, **_kwargs: object
+        ) -> str:
+            captured["request"] = req
+            return "sent"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(url_safety.HTTPAdapter, "send", _fake_super_send)
+            adapter.send(request)
+
+        sent = captured["request"]
+        assert sent.url == "https://[2606:2800:220:1:248:1893:25c8:1946]:8443/logo.png"
+        assert sent.headers["Host"] == "example.com:8443"
+
+    def test_send_refuses_retargeted_host(self) -> None:
+        """send() refuses a request whose host differs from the pinned one."""
+        adapter = _PinnedIPAdapter("example.com", "93.184.216.34", use_tls=True)
+        request = requests.Request("GET", "https://evil.example/logo.png").prepare()
+
+        with pytest.raises(UnsafeUrlError):
+            adapter.send(request)

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -184,6 +184,48 @@ class TestCreatePinnedSession:
         finally:
             session.close()
 
+    def test_dual_stack_prefers_validated_ipv4(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dual-stack host with IPv6-first resolution pins to the IPv4."""
+
+        def _fake(*_args: object, **_kwargs: object) -> list:
+            return [
+                (
+                    socket.AF_INET6,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("2606:2800:220:1:248:1893:25c8:1946", 0, 0, 0),
+                ),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+            ]
+
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake)
+        session = create_pinned_session("https://example.com/")
+        try:
+            adapter = session.get_adapter("https://example.com/")
+            assert isinstance(adapter, _PinnedIPAdapter)
+            # Prefers the validated IPv4 even though IPv6 resolved first.
+            assert adapter._validated_ip == "93.184.216.34"
+        finally:
+            session.close()
+
+    def test_ipv6_only_pins_ipv6(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An IPv6-only host still pins to the validated IPv6 address."""
+        monkeypatch.setattr(
+            url_safety.socket,
+            "getaddrinfo",
+            _fake_getaddrinfo_for("2606:2800:220:1:248:1893:25c8:1946"),
+        )
+        session = create_pinned_session("https://example.com/")
+        try:
+            adapter = session.get_adapter("https://example.com/")
+            assert isinstance(adapter, _PinnedIPAdapter)
+            assert adapter._validated_ip == "2606:2800:220:1:248:1893:25c8:1946"
+        finally:
+            session.close()
+
     def test_refuses_private_resolution(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A host resolving to a private IP raises UnsafeUrlError."""
         monkeypatch.setattr(

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -202,6 +202,12 @@ class TestCreatePinnedSession:
         with pytest.raises(UnsafeUrlError):
             create_pinned_session("https://")
 
+    def test_refuses_malformed_url(self) -> None:
+        """A malformed URL that fails to parse is rejected, not a 500."""
+        # Unbalanced IPv6 brackets make urlsplit raise ValueError.
+        with pytest.raises(UnsafeUrlError):
+            create_pinned_session("http://[::1")
+
     def test_resolves_only_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """DNS is resolved exactly once so there is no re-resolution window."""
         calls = {"n": 0}

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,0 +1,156 @@
+"""Tests for the URL safety (SSRF guard) utilities.
+
+Tests cover:
+- Rejection of non-http(s) schemes
+- Rejection of hostless URLs
+- Rejection of hosts resolving to private/loopback/link-local/reserved/
+  multicast/unspecified addresses (IPv4 and IPv6)
+- Acceptance of hosts resolving to public addresses
+- DNS resolution failures being treated as unsafe
+
+DNS resolution is monkeypatched so tests never touch the real network
+(the suite runs with pytest-socket's --disable-socket).
+"""
+
+import socket
+from collections.abc import Callable
+
+import pytest
+from core.utils import url_safety
+from core.utils.url_safety import assert_safe_public_url, is_safe_public_url
+
+
+def _fake_getaddrinfo_for(ip: str) -> Callable[..., list]:
+    """Build a getaddrinfo replacement resolving every host to ``ip``.
+
+    Args:
+        ip: The IP address string every lookup should resolve to.
+
+    Returns:
+        A callable with the signature of ``socket.getaddrinfo`` returning a
+        single address info tuple pointing at ``ip``.
+    """
+    family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+
+    def _fake(*_args: object, **_kwargs: object) -> list:
+        return [(family, socket.SOCK_STREAM, 6, "", (ip, 0))]
+
+    return _fake
+
+
+class TestIsSafePublicUrl:
+    """Tests for :func:`is_safe_public_url`."""
+
+    def test_public_https_url_is_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A public host over https is accepted."""
+        monkeypatch.setattr(
+            url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for("93.184.216.34")
+        )
+        assert is_safe_public_url("https://example.com/logo.png") is True
+
+    def test_public_http_url_is_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A public host over http is accepted."""
+        monkeypatch.setattr(
+            url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for("93.184.216.34")
+        )
+        assert is_safe_public_url("http://example.com/logo.png") is True
+
+    def test_public_ipv6_url_is_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A public IPv6 host is accepted."""
+        monkeypatch.setattr(
+            url_safety.socket,
+            "getaddrinfo",
+            _fake_getaddrinfo_for("2606:2800:220:1:248:1893:25c8:1946"),
+        )
+        assert is_safe_public_url("https://example.com/logo.png") is True
+
+    def test_non_http_scheme_rejected(self) -> None:
+        """A non-http(s) scheme is rejected without any DNS lookup."""
+        assert is_safe_public_url("ftp://example.com/logo.png") is False
+        assert is_safe_public_url("file:///etc/passwd") is False
+        assert is_safe_public_url("gopher://example.com/") is False
+
+    def test_hostless_url_rejected(self) -> None:
+        """A URL with no host is rejected."""
+        assert is_safe_public_url("http:///no-host") is False
+        assert is_safe_public_url("https://") is False
+        assert is_safe_public_url("not-a-url") is False
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "10.0.0.1",  # private
+            "192.168.1.1",  # private
+            "172.16.0.1",  # private
+            "127.0.0.1",  # loopback
+            "169.254.169.254",  # link-local (cloud metadata)
+            "0.0.0.0",  # unspecified
+            "240.0.0.1",  # reserved
+            "224.0.0.1",  # multicast
+        ],
+    )
+    def test_private_ipv4_rejected(
+        self, ip: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hosts resolving to non-public IPv4 addresses are rejected."""
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for(ip))
+        assert is_safe_public_url("https://internal.example.com/") is False
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "::1",  # loopback
+            "fe80::1",  # link-local
+            "fc00::1",  # unique local (private)
+            "::",  # unspecified
+            "ff02::1",  # multicast
+        ],
+    )
+    def test_private_ipv6_rejected(
+        self, ip: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hosts resolving to non-public IPv6 addresses are rejected."""
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for(ip))
+        assert is_safe_public_url("https://internal.example.com/") is False
+
+    def test_mixed_resolution_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If any resolved address is non-public the URL is rejected."""
+
+        def _fake(*_args: object, **_kwargs: object) -> list:
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+            ]
+
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake)
+        assert is_safe_public_url("https://example.com/") is False
+
+    def test_dns_failure_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A DNS resolution failure is treated as unsafe."""
+
+        def _fake(*_args: object, **_kwargs: object) -> list:
+            raise socket.gaierror("name resolution failed")
+
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake)
+        assert is_safe_public_url("https://does-not-resolve.example/") is False
+
+    def test_empty_resolution_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty resolution result is treated as unsafe."""
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", lambda *a, **k: [])
+        assert is_safe_public_url("https://example.com/") is False
+
+
+class TestAssertSafePublicUrl:
+    """Tests for :func:`assert_safe_public_url`."""
+
+    def test_raises_on_unsafe_url(self) -> None:
+        """An unsafe URL raises ValueError."""
+        with pytest.raises(ValueError):
+            assert_safe_public_url("ftp://example.com/")
+
+    def test_passes_on_safe_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A safe URL does not raise."""
+        monkeypatch.setattr(
+            url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for("93.184.216.34")
+        )
+        assert_safe_public_url("https://example.com/logo.png")

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -155,8 +155,8 @@ class TestAssertSafePublicUrl:
     """Tests for :func:`assert_safe_public_url`."""
 
     def test_raises_on_unsafe_url(self) -> None:
-        """An unsafe URL raises ValueError."""
-        with pytest.raises(ValueError):
+        """An unsafe URL raises the concrete UnsafeUrlError."""
+        with pytest.raises(UnsafeUrlError):
             assert_safe_public_url("ftp://example.com/")
 
     def test_passes_on_safe_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -181,6 +181,17 @@ class TestCreatePinnedSession:
             assert isinstance(adapter, _PinnedIPAdapter)
             assert adapter._hostname == "example.com"
             assert adapter._validated_ip == "93.184.216.34"
+        finally:
+            session.close()
+
+    def test_disables_env_proxies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The pinned session ignores env proxy vars (SSRF bypass guard)."""
+        monkeypatch.setattr(
+            url_safety.socket, "getaddrinfo", _fake_getaddrinfo_for("93.184.216.34")
+        )
+        session = create_pinned_session("https://example.com/logo.png")
+        try:
+            assert session.trust_env is False
         finally:
             session.close()
 


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity SSRF in the logo download path. `LogoStorageService._download_logo` fetched `logo_url` with no scheme/host validation and default redirect following. Because `logo_url` originates from Brandfetch (self-service, attacker-registerable) and the fetched bytes are served **unauthenticated** at `/logos/<domain>/`, this was an exfiltration primitive, not blind SSRF (e.g. `http://169.254.169.254/...` cloud metadata).

### Changes
- **New `app/core/utils/url_safety.py`**: `is_safe_public_url(url)` (and `assert_safe_public_url`) that requires an `http`/`https` scheme and a host, resolves the host via `socket.getaddrinfo`, and rejects if **any** resolved IP is private, loopback, link-local, reserved, multicast, or unspecified (IPv4 + IPv6, via `ipaddress`). Hostless URLs and DNS failures are rejected.
- **`app/core/services/logo_storage.py`**: validate the URL with the helper before fetching in both `_download_logo` and `refresh_logo` (log a warning and return the existing failure sentinel on rejection); pass `allow_redirects=False` and treat any redirect response as a failed download so redirects cannot bypass the check. Existing content-type allowlist, 500KB cap, and 10s timeout are unchanged.

## Test plan
- `tests/test_url_safety.py`: private/loopback/link-local/reserved/multicast/unspecified IPs (v4 + v6), non-http schemes, hostless URLs, DNS failures rejected; public https/http/IPv6 accepted (resolver monkeypatched, no real DNS).
- `tests/core/test_logo_storage.py`: `_download_logo` refuses an internal URL without issuing a request, disables redirects and refuses redirect responses, and downloads a safe public URL.
- `uv run ruff check` / `ruff format`: clean
- `uv run mypy app/`: Success, no issues in 116 source files
- `uv run pytest -q`: **1502 passed** (20 subtests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)