### PR TITLE
fix: add OAuth state to Slack flows and admin gates to Slack config (CSRF)

### DIFF
--- a/app/core/views/auth.py
+++ b/app/core/views/auth.py
@@ -215,7 +215,8 @@ def _resolve_user(slack_id: str, email: str, name: str) -> User:
     )
 
     if created:
-        logger.info(f"Created new user: {email}")
+        # Log the non-PII Slack sub instead of the email address.
+        logger.info(f"Created new user (sub={slack_id})")
 
     # Try to find existing UserProfile
     try:

--- a/app/core/views/auth.py
+++ b/app/core/views/auth.py
@@ -4,6 +4,7 @@ This module handles user authentication via Slack OpenID Connect.
 """
 
 import logging
+import secrets
 from typing import Any
 
 import requests
@@ -19,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 # Default timeout for external API requests (seconds)
 SLACK_API_TIMEOUT = 30
+
+# Session key for the Slack OAuth login state parameter (CSRF protection)
+SLACK_AUTH_STATE_SESSION_KEY = "slack_auth_oauth_state"
 
 
 def home(request: HttpRequest) -> HttpResponse:
@@ -56,6 +60,11 @@ def slack_auth(request: HttpRequest) -> HttpResponseRedirect:
     Returns:
         Redirect to Slack authorization URL.
     """
+    # Generate a state parameter and store it in the session for CSRF
+    # protection. It is validated on callback before the code is exchanged.
+    state = secrets.token_urlsafe(32)
+    request.session[SLACK_AUTH_STATE_SESSION_KEY] = state
+
     scopes = "openid,email,profile"
     auth_url = (
         f"https://slack.com/openid/connect/authorize"
@@ -63,6 +72,7 @@ def slack_auth(request: HttpRequest) -> HttpResponseRedirect:
         f"&scope={scopes}"
         f"&redirect_uri={settings.SLACK_REDIRECT_URI}"
         f"&response_type=code"
+        f"&state={state}"
     )
     return redirect(auth_url)
 
@@ -142,6 +152,14 @@ def slack_auth_callback(request: HttpRequest) -> HttpResponse | HttpResponseRedi
     if not code:
         return HttpResponse("Authorization failed: No code provided", status=400)
 
+    # Validate the state parameter (CSRF protection) BEFORE exchanging the
+    # code. Abort on missing or mismatched state.
+    state = request.GET.get("state")
+    stored_state = request.session.pop(SLACK_AUTH_STATE_SESSION_KEY, None)
+    if not state or not stored_state or not secrets.compare_digest(state, stored_state):
+        logger.warning("Slack auth OAuth state mismatch - possible CSRF attack")
+        return HttpResponse("Invalid OAuth state", status=400)
+
     # Exchange code for token
     token_data = _get_slack_token(code)
     if not token_data:
@@ -160,6 +178,31 @@ def slack_auth_callback(request: HttpRequest) -> HttpResponse | HttpResponseRedi
     if not slack_id or not email:
         return HttpResponse("Invalid user data from Slack", status=400)
 
+    # Reject login when Slack reports the email is not verified. Auto-creating
+    # or linking an account on an unverified email would allow account takeover.
+    if not user_info.get("email_verified", False):
+        logger.warning(f"Slack login rejected: email not verified for {email}")
+        return HttpResponse("Email address is not verified", status=400)
+
+    user = _resolve_user(slack_id, email, name)
+
+    # Log the user in
+    login(request, user)
+
+    return redirect("core:dashboard")
+
+
+def _resolve_user(slack_id: str, email: str, name: str) -> User:
+    """Find or create the user and reconcile their Slack profile link.
+
+    Args:
+        slack_id: The Slack user identifier (``sub`` claim).
+        email: The user's verified email address.
+        name: The user's display name.
+
+    Returns:
+        The resolved Django user.
+    """
     # Find or create user
     user, created = User.objects.get_or_create(
         email=email, defaults={"username": email, "first_name": name}
@@ -186,7 +229,4 @@ def slack_auth_callback(request: HttpRequest) -> HttpResponse | HttpResponseRedi
             # No profile exists - this is handled later when joining a team
             pass
 
-    # Log the user in
-    login(request, user)
-
-    return redirect("core:dashboard")
+    return user

--- a/app/core/views/auth.py
+++ b/app/core/views/auth.py
@@ -153,12 +153,17 @@ def slack_auth_callback(request: HttpRequest) -> HttpResponse | HttpResponseRedi
         return HttpResponse("Authorization failed: No code provided", status=400)
 
     # Validate the state parameter (CSRF protection) BEFORE exchanging the
-    # code. Abort on missing or mismatched state.
+    # code. Read (do not pop) the stored state so a forged callback with a
+    # wrong/missing state cannot clear the legitimate in-progress state and
+    # DoS the real login flow. Only consume it after a successful match.
     state = request.GET.get("state")
-    stored_state = request.session.pop(SLACK_AUTH_STATE_SESSION_KEY, None)
+    stored_state = request.session.get(SLACK_AUTH_STATE_SESSION_KEY)
     if not state or not stored_state or not secrets.compare_digest(state, stored_state):
         logger.warning("Slack auth OAuth state mismatch - possible CSRF attack")
         return HttpResponse("Invalid OAuth state", status=400)
+
+    # State validated: consume it so it can't be replayed.
+    request.session.pop(SLACK_AUTH_STATE_SESSION_KEY, None)
 
     # Exchange code for token
     token_data = _get_slack_token(code)
@@ -181,7 +186,8 @@ def slack_auth_callback(request: HttpRequest) -> HttpResponse | HttpResponseRedi
     # Reject login when Slack reports the email is not verified. Auto-creating
     # or linking an account on an unverified email would allow account takeover.
     if not user_info.get("email_verified", False):
-        logger.warning(f"Slack login rejected: email not verified for {email}")
+        # Log a non-PII identifier (Slack sub) instead of the email address.
+        logger.warning(f"Slack login rejected: email not verified (sub={slack_id})")
         return HttpResponse("Email address is not verified", status=400)
 
     user = _resolve_user(slack_id, email, name)

--- a/app/core/views/integrations/slack.py
+++ b/app/core/views/integrations/slack.py
@@ -50,7 +50,14 @@ def _get_admin_workspace(request: HttpRequest) -> Workspace | None:
     if not request.user.is_authenticated:
         return None
 
-    member = WorkspaceMember.objects.filter(user=request.user, is_active=True).first()
+    # Order deterministically so selection is stable when a user belongs to
+    # multiple workspaces (explicit current-workspace resolution is a
+    # pre-existing codebase concern and out of scope for this PR).
+    member = (
+        WorkspaceMember.objects.filter(user=request.user, is_active=True)
+        .order_by("joined_at", "id")
+        .first()
+    )
     if member is None:
         # UserProfile users are treated as owners for backward compatibility.
         try:

--- a/app/core/views/integrations/slack.py
+++ b/app/core/views/integrations/slack.py
@@ -5,6 +5,7 @@ Handles Slack OAuth connection for receiving notifications in Slack channels.
 
 import json
 import logging
+import secrets
 from typing import cast
 
 import requests
@@ -18,7 +19,6 @@ from django.shortcuts import redirect
 from ...models import Integration, Workspace
 from .base import (
     DEFAULT_API_TIMEOUT,
-    get_user_workspace,
     require_admin_role,
     require_post_method,
 )
@@ -28,6 +28,9 @@ logger = logging.getLogger(__name__)
 # Integration metadata
 INTEGRATION_TYPE = "slack_notifications"
 DISPLAY_NAME = "Slack"
+
+# Session key for the Slack OAuth state parameter (CSRF protection)
+SLACK_CONNECT_STATE_SESSION_KEY = "slack_connect_oauth_state"
 
 
 @login_required
@@ -52,6 +55,11 @@ def slack_connect(request: HttpRequest) -> HttpResponseRedirect:
     Returns:
         Redirect to Slack OAuth authorization.
     """
+    # Generate a state parameter and store it in the session for CSRF
+    # protection. It is validated on callback before the code is exchanged.
+    state = secrets.token_urlsafe(32)
+    request.session[SLACK_CONNECT_STATE_SESSION_KEY] = state
+
     scopes = "incoming-webhook,chat:write,channels:read"
     auth_url = (
         f"https://slack.com/oauth/v2/authorize"
@@ -59,6 +67,7 @@ def slack_connect(request: HttpRequest) -> HttpResponseRedirect:
         f"&scope={scopes}"
         f"&redirect_uri={settings.SLACK_CONNECT_REDIRECT_URI}"
         f"&response_type=code"
+        f"&state={state}"
     )
     return redirect(auth_url)
 
@@ -77,6 +86,15 @@ def slack_connect_callback(
     code = request.GET.get("code")
     if not code:
         return HttpResponse("Authorization failed: No code provided", status=400)
+
+    # Validate the state parameter (CSRF protection) BEFORE exchanging the
+    # code. Abort on missing or mismatched state.
+    state = request.GET.get("state")
+    stored_state = request.session.pop(SLACK_CONNECT_STATE_SESSION_KEY, None)
+    if not state or not stored_state or not secrets.compare_digest(state, stored_state):
+        logger.error("Slack connect OAuth state mismatch - possible CSRF attack")
+        messages.error(request, "Invalid OAuth state. Please try again.")
+        return redirect("core:integrations")
 
     # Exchange code for token
     try:
@@ -192,9 +210,11 @@ def test_slack(request: HttpRequest) -> HttpResponseRedirect:
     if error_redirect:
         return error_redirect
 
-    workspace = get_user_workspace(request)
-    if not workspace:
-        return redirect("core:create_workspace")
+    # Require admin role: sending test messages uses workspace credentials.
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
     # Find the active Slack integration
     integration = Integration.objects.filter(
@@ -324,18 +344,23 @@ def _build_test_message(
 
 
 @login_required
-def get_slack_channels(request: HttpRequest) -> JsonResponse:
+def get_slack_channels(
+    request: HttpRequest,
+) -> JsonResponse | HttpResponseRedirect:
     """Fetch available Slack channels for configuration.
 
     Args:
         request: The HTTP request object.
 
     Returns:
-        JSON response with list of channels or error.
+        JSON response with list of channels or error, or a redirect if the
+        user lacks the required admin role.
     """
-    workspace = get_user_workspace(request)
-    if not workspace:
-        return JsonResponse({"error": "User profile not found"}, status=400)
+    # Require admin role: channel listing exposes workspace Slack data.
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
     # Find the active Slack integration
     integration = Integration.objects.filter(
@@ -398,21 +423,26 @@ def get_slack_channels(request: HttpRequest) -> JsonResponse:
 
 
 @login_required
-def configure_slack(request: HttpRequest) -> JsonResponse:
+def configure_slack(
+    request: HttpRequest,
+) -> JsonResponse | HttpResponseRedirect:
     """Update Slack integration channel configuration.
 
     Args:
         request: The HTTP request object.
 
     Returns:
-        JSON response with success status or error.
+        JSON response with success status or error, or a redirect if the
+        user lacks the required admin role.
     """
     if request.method != "POST":
         return JsonResponse({"error": "Invalid request method"}, status=405)
 
-    workspace = get_user_workspace(request)
-    if not workspace:
-        return JsonResponse({"error": "User profile not found"}, status=400)
+    # Require admin role: this mutates the destination channel.
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
     # Find the active Slack integration
     integration = Integration.objects.filter(

--- a/app/core/views/integrations/slack.py
+++ b/app/core/views/integrations/slack.py
@@ -16,7 +16,7 @@ from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import redirect
 
-from ...models import Integration, Workspace
+from ...models import Integration, UserProfile, Workspace, WorkspaceMember
 from .base import (
     DEFAULT_API_TIMEOUT,
     require_admin_role,
@@ -33,14 +33,48 @@ DISPLAY_NAME = "Slack"
 SLACK_CONNECT_STATE_SESSION_KEY = "slack_connect_oauth_state"
 
 
+def _get_admin_workspace(request: HttpRequest) -> Workspace | None:
+    """Return the user's workspace iff they are an admin/owner, else None.
+
+    Pure check with NO Django messages or redirect side effects, so it is
+    safe for JSON endpoints (a persisted flash message could otherwise
+    surface later on an unrelated full-page navigation) and for fail-fast
+    gating. Mirrors the role logic in ``require_admin_role``.
+
+    Args:
+        request: The HTTP request object.
+
+    Returns:
+        The workspace if the user is an admin/owner, otherwise None.
+    """
+    if not request.user.is_authenticated:
+        return None
+
+    member = WorkspaceMember.objects.filter(user=request.user, is_active=True).first()
+    if member is None:
+        # UserProfile users are treated as owners for backward compatibility.
+        try:
+            profile_workspace: Workspace = UserProfile.objects.get(
+                user=request.user
+            ).workspace
+            return profile_workspace
+        except UserProfile.DoesNotExist:
+            return None
+
+    if member.role not in ("owner", "admin"):
+        return None
+    member_workspace: Workspace = member.workspace
+    return member_workspace
+
+
 def _require_admin_role_json(
     request: HttpRequest,
 ) -> tuple[Workspace | None, JsonResponse | None]:
     """Require admin/owner role for JSON (fetch) endpoints.
 
-    Unlike ``require_admin_role``, which redirects, this returns a JSON 403
-    so ``fetch()`` callers that parse the body as JSON don't choke on an HTML
-    redirect target.
+    Returns a JSON 403 (no Django messages, no redirect) so ``fetch()``
+    callers that parse the body as JSON don't choke on an HTML redirect
+    target and no flash message leaks onto a later page navigation.
 
     Args:
         request: The HTTP request object.
@@ -49,8 +83,8 @@ def _require_admin_role_json(
         Tuple of (workspace, error_response). On success error_response is
         None; on failure workspace is None and a JsonResponse 403 is returned.
     """
-    workspace, redirect_response = require_admin_role(request)
-    if redirect_response is not None:
+    workspace = _get_admin_workspace(request)
+    if workspace is None:
         return None, JsonResponse(
             {"error": "You don't have permission to perform this action."},
             status=403,
@@ -71,6 +105,7 @@ def integrate_slack(request: HttpRequest) -> HttpResponseRedirect:
     return redirect("core:slack_connect")
 
 
+@login_required
 def slack_connect(request: HttpRequest) -> HttpResponseRedirect:
     """Initialize Slack connection for workspace notifications.
 
@@ -78,8 +113,15 @@ def slack_connect(request: HttpRequest) -> HttpResponseRedirect:
         request: The HTTP request object.
 
     Returns:
-        Redirect to Slack OAuth authorization.
+        Redirect to Slack OAuth authorization, or back to integrations if the
+        user is not an admin/owner.
     """
+    # Fail fast: only mint OAuth state for users who could actually complete
+    # the admin-gated callback (mirrors Shopify's gate-at-start).
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+
     # Generate a state parameter and store it in the session for CSRF
     # protection. It is validated on callback before the code is exchanged.
     state = secrets.token_urlsafe(32)

--- a/app/core/views/integrations/slack.py
+++ b/app/core/views/integrations/slack.py
@@ -113,12 +113,13 @@ def slack_connect(request: HttpRequest) -> HttpResponseRedirect:
         request: The HTTP request object.
 
     Returns:
-        Redirect to Slack OAuth authorization, or back to integrations if the
+        Redirect to Slack OAuth authorization, or to the dashboard if the
         user is not an admin/owner.
     """
     # Fail fast: only mint OAuth state for users who could actually complete
-    # the admin-gated callback (mirrors Shopify's gate-at-start).
-    workspace, redirect_response = require_admin_role(request)
+    # the admin-gated callback (mirrors Shopify's gate-at-start). The
+    # workspace itself is unused here; only the permission check matters.
+    _workspace, redirect_response = require_admin_role(request)
     if redirect_response:
         return redirect_response
 

--- a/app/core/views/integrations/slack.py
+++ b/app/core/views/integrations/slack.py
@@ -155,6 +155,15 @@ def slack_connect_callback(
     if not code:
         return HttpResponse("Authorization failed: No code provided", status=400)
 
+    # Gate on admin role FIRST. require_admin_role cleanly redirects
+    # anonymous / non-admin users (e.g. an expired session) without leaving a
+    # stray "Invalid OAuth state" flash message that would surface after a
+    # later login. It also stops unauthorized users from burning codes or
+    # hitting the Slack API.
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+
     # Validate the state parameter (CSRF protection) BEFORE exchanging the
     # code. Read (do not pop) the stored state so a forged callback with a
     # wrong/missing state cannot clear the legitimate in-progress state and
@@ -165,12 +174,6 @@ def slack_connect_callback(
         logger.error("Slack connect OAuth state mismatch - possible CSRF attack")
         messages.error(request, "Invalid OAuth state. Please try again.")
         return redirect("core:integrations")
-
-    # Require admin role BEFORE consuming the code or calling Slack, so
-    # unauthorized users can't burn authorization codes or hit the Slack API.
-    workspace, redirect_response = require_admin_role(request)
-    if redirect_response:
-        return redirect_response
 
     # State validated and user authorized: consume the state now.
     request.session.pop(SLACK_CONNECT_STATE_SESSION_KEY, None)

--- a/app/core/views/integrations/slack.py
+++ b/app/core/views/integrations/slack.py
@@ -33,6 +33,31 @@ DISPLAY_NAME = "Slack"
 SLACK_CONNECT_STATE_SESSION_KEY = "slack_connect_oauth_state"
 
 
+def _require_admin_role_json(
+    request: HttpRequest,
+) -> tuple[Workspace | None, JsonResponse | None]:
+    """Require admin/owner role for JSON (fetch) endpoints.
+
+    Unlike ``require_admin_role``, which redirects, this returns a JSON 403
+    so ``fetch()`` callers that parse the body as JSON don't choke on an HTML
+    redirect target.
+
+    Args:
+        request: The HTTP request object.
+
+    Returns:
+        Tuple of (workspace, error_response). On success error_response is
+        None; on failure workspace is None and a JsonResponse 403 is returned.
+    """
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response is not None:
+        return None, JsonResponse(
+            {"error": "You don't have permission to perform this action."},
+            status=403,
+        )
+    return workspace, None
+
+
 @login_required
 def integrate_slack(request: HttpRequest) -> HttpResponseRedirect:
     """Start Slack integration flow.
@@ -88,13 +113,24 @@ def slack_connect_callback(
         return HttpResponse("Authorization failed: No code provided", status=400)
 
     # Validate the state parameter (CSRF protection) BEFORE exchanging the
-    # code. Abort on missing or mismatched state.
+    # code. Read (do not pop) the stored state so a forged callback with a
+    # wrong/missing state cannot clear the legitimate in-progress state and
+    # DoS the real flow. Only consume it after a successful match.
     state = request.GET.get("state")
-    stored_state = request.session.pop(SLACK_CONNECT_STATE_SESSION_KEY, None)
+    stored_state = request.session.get(SLACK_CONNECT_STATE_SESSION_KEY)
     if not state or not stored_state or not secrets.compare_digest(state, stored_state):
         logger.error("Slack connect OAuth state mismatch - possible CSRF attack")
         messages.error(request, "Invalid OAuth state. Please try again.")
         return redirect("core:integrations")
+
+    # Require admin role BEFORE consuming the code or calling Slack, so
+    # unauthorized users can't burn authorization codes or hit the Slack API.
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+
+    # State validated and user authorized: consume the state now.
+    request.session.pop(SLACK_CONNECT_STATE_SESSION_KEY, None)
 
     # Exchange code for token
     try:
@@ -118,11 +154,6 @@ def slack_connect_callback(
 
     if not data.get("ok"):
         return HttpResponse(f"Slack connection failed: {data.get('error')}", status=400)
-
-    # Get user's workspace (require admin role for modifications)
-    workspace, redirect_response = require_admin_role(request)
-    if redirect_response:
-        return redirect_response
 
     # Store or update Slack integration
     integration, created = Integration.objects.get_or_create(
@@ -344,22 +375,20 @@ def _build_test_message(
 
 
 @login_required
-def get_slack_channels(
-    request: HttpRequest,
-) -> JsonResponse | HttpResponseRedirect:
+def get_slack_channels(request: HttpRequest) -> JsonResponse:
     """Fetch available Slack channels for configuration.
 
     Args:
         request: The HTTP request object.
 
     Returns:
-        JSON response with list of channels or error, or a redirect if the
-        user lacks the required admin role.
+        JSON response with list of channels or error (403 if the user lacks
+        the required admin role).
     """
     # Require admin role: channel listing exposes workspace Slack data.
-    workspace, redirect_response = require_admin_role(request)
-    if redirect_response:
-        return redirect_response
+    workspace, error_response = _require_admin_role_json(request)
+    if error_response is not None:
+        return error_response
     assert workspace is not None
 
     # Find the active Slack integration
@@ -423,25 +452,23 @@ def get_slack_channels(
 
 
 @login_required
-def configure_slack(
-    request: HttpRequest,
-) -> JsonResponse | HttpResponseRedirect:
+def configure_slack(request: HttpRequest) -> JsonResponse:
     """Update Slack integration channel configuration.
 
     Args:
         request: The HTTP request object.
 
     Returns:
-        JSON response with success status or error, or a redirect if the
-        user lacks the required admin role.
+        JSON response with success status or error (403 if the user lacks
+        the required admin role).
     """
     if request.method != "POST":
         return JsonResponse({"error": "Invalid request method"}, status=405)
 
     # Require admin role: this mutates the destination channel.
-    workspace, redirect_response = require_admin_role(request)
-    if redirect_response:
-        return redirect_response
+    workspace, error_response = _require_admin_role_json(request)
+    if error_response is not None:
+        return error_response
     assert workspace is not None
 
     # Find the active Slack integration

--- a/tests/test_slack_oauth_state.py
+++ b/tests/test_slack_oauth_state.py
@@ -11,6 +11,7 @@ These tests cover the security hardening of the Slack OAuth flows:
   destination channel.
 """
 
+import json
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -319,7 +320,7 @@ class TestConfigureSlackAdminGate:
         """
         return client.post(
             reverse("core:configure_slack"),
-            data={"channel": channel},
+            data=json.dumps({"channel": channel}),
             content_type="application/json",
         )
 

--- a/tests/test_slack_oauth_state.py
+++ b/tests/test_slack_oauth_state.py
@@ -1,0 +1,347 @@
+"""Tests for Slack OAuth CSRF (state) protection and admin gating.
+
+These tests cover the security hardening of the Slack OAuth flows:
+
+- ``slack_connect`` / ``slack_connect_callback`` (workspace notifications):
+  the callback must reject a missing or mismatched ``state`` parameter
+  *before* exchanging the authorization code for a token.
+- ``slack_auth`` / ``slack_auth_callback`` (login): the login callback must
+  validate ``state`` and reject unverified Slack emails.
+- ``configure_slack``: only workspace admins/owners may mutate the
+  destination channel.
+"""
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+from core.models import Integration, UserProfile, Workspace, WorkspaceMember
+from django.contrib.auth.models import User
+from django.test import Client, override_settings
+from django.urls import reverse
+
+SLACK_CONNECT_SETTINGS = {
+    "SLACK_CLIENT_ID": "test_client_id",
+    "SLACK_CLIENT_SECRET": "test_client_secret",
+    "SLACK_CONNECT_REDIRECT_URI": "http://localhost/connect/callback/",
+}
+
+
+@pytest.mark.django_db
+class TestSlackConnectState:
+    """Test CSRF state handling for the workspace Slack connect flow."""
+
+    @pytest.fixture
+    def owner_user(self, client: Client) -> tuple[User, Workspace]:
+        """Create an owner user (via UserProfile) and their workspace.
+
+        Args:
+            client: Django test client.
+
+        Returns:
+            Tuple of the created user and workspace.
+        """
+        user = User.objects.create_user(
+            username="owner@example.com",
+            password="pw",
+            email="owner@example.com",
+        )
+        workspace = Workspace.objects.create(name="Test Workspace")
+        UserProfile.objects.create(user=user, workspace=workspace)
+        return user, workspace
+
+    @override_settings(**SLACK_CONNECT_SETTINGS)
+    def test_connect_stores_state_in_session(
+        self, client: Client, owner_user: tuple[User, Workspace]
+    ) -> None:
+        """slack_connect stores a state token and includes it in the URL."""
+        user, _ = owner_user
+        client.force_login(user)
+
+        response = client.get(reverse("core:slack_connect"))
+
+        assert response.status_code == 302
+        state = client.session["slack_connect_oauth_state"]
+        assert state
+        assert f"state={state}" in response.url
+
+    @override_settings(**SLACK_CONNECT_SETTINGS)
+    @patch("core.views.integrations.slack.requests.post")
+    def test_callback_missing_state_rejected_without_exchange(
+        self,
+        mock_post: Mock,
+        client: Client,
+        owner_user: tuple[User, Workspace],
+    ) -> None:
+        """A callback with no state is rejected before any token exchange."""
+        user, workspace = owner_user
+        client.force_login(user)
+
+        session = client.session
+        session["slack_connect_oauth_state"] = "expected_state"
+        session.save()
+
+        response = client.get(reverse("core:slack_connect_callback"), {"code": "abc"})
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrations")
+        mock_post.assert_not_called()
+        assert not Integration.objects.filter(workspace=workspace).exists()
+
+    @override_settings(**SLACK_CONNECT_SETTINGS)
+    @patch("core.views.integrations.slack.requests.post")
+    def test_callback_wrong_state_rejected_without_exchange(
+        self,
+        mock_post: Mock,
+        client: Client,
+        owner_user: tuple[User, Workspace],
+    ) -> None:
+        """A callback with a mismatched state is rejected before exchange."""
+        user, workspace = owner_user
+        client.force_login(user)
+
+        session = client.session
+        session["slack_connect_oauth_state"] = "expected_state"
+        session.save()
+
+        response = client.get(
+            reverse("core:slack_connect_callback"),
+            {"code": "abc", "state": "attacker_state"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrations")
+        mock_post.assert_not_called()
+        assert not Integration.objects.filter(workspace=workspace).exists()
+
+    @override_settings(**SLACK_CONNECT_SETTINGS)
+    @patch("core.views.integrations.slack.requests.post")
+    def test_callback_valid_state_proceeds(
+        self,
+        mock_post: Mock,
+        client: Client,
+        owner_user: tuple[User, Workspace],
+    ) -> None:
+        """A callback with a matching state exchanges the code and connects."""
+        user, workspace = owner_user
+        client.force_login(user)
+
+        session = client.session
+        session["slack_connect_oauth_state"] = "shared_state"
+        session.save()
+
+        token_response = Mock()
+        token_response.json.return_value = {
+            "ok": True,
+            "access_token": "xoxb-token",
+            "team": {"id": "T123", "name": "Test Team"},
+            "incoming_webhook": {
+                "channel": "#general",
+                "url": "https://hooks.slack.com/services/xxx",
+            },
+        }
+        mock_post.return_value = token_response
+
+        response = client.get(
+            reverse("core:slack_connect_callback"),
+            {"code": "abc", "state": "shared_state"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrations")
+        mock_post.assert_called_once()
+        integration = Integration.objects.get(
+            workspace=workspace, integration_type="slack_notifications"
+        )
+        assert integration.oauth_credentials["access_token"] == "xoxb-token"
+
+
+@pytest.mark.django_db
+class TestSlackAuthState:
+    """Test CSRF state and email verification for the Slack login flow."""
+
+    @override_settings(
+        SLACK_CLIENT_ID="cid",
+        SLACK_REDIRECT_URI="http://localhost/auth/callback/",
+    )
+    def test_auth_stores_state_in_session(self, client: Client) -> None:
+        """slack_auth stores a state token and includes it in the URL."""
+        response = client.get(reverse("core:slack_auth"))
+
+        assert response.status_code == 302
+        state = client.session["slack_auth_oauth_state"]
+        assert state
+        assert f"state={state}" in response.url
+
+    @patch("core.views.auth._get_slack_token")
+    def test_auth_callback_missing_state_rejected(
+        self, mock_get_token: Mock, client: Client
+    ) -> None:
+        """A login callback with no state is rejected before token exchange."""
+        session = client.session
+        session["slack_auth_oauth_state"] = "expected"
+        session.save()
+
+        response = client.get(reverse("core:slack_auth_callback"), {"code": "abc"})
+
+        assert response.status_code == 400
+        mock_get_token.assert_not_called()
+        assert not User.objects.exists()
+
+    @patch("core.views.auth._get_slack_token")
+    def test_auth_callback_wrong_state_rejected(
+        self, mock_get_token: Mock, client: Client
+    ) -> None:
+        """A login callback with a mismatched state is rejected."""
+        session = client.session
+        session["slack_auth_oauth_state"] = "expected"
+        session.save()
+
+        response = client.get(
+            reverse("core:slack_auth_callback"),
+            {"code": "abc", "state": "attacker"},
+        )
+
+        assert response.status_code == 400
+        mock_get_token.assert_not_called()
+        assert not User.objects.exists()
+
+    @patch("core.views.auth.login")
+    @patch("core.views.auth._get_slack_user_info")
+    @patch("core.views.auth._get_slack_token")
+    def test_auth_callback_valid_state_and_verified_email_logs_in(
+        self,
+        mock_get_token: Mock,
+        mock_get_user_info: Mock,
+        mock_login: Mock,
+        client: Client,
+    ) -> None:
+        """A valid state with a verified email creates and logs in the user.
+
+        ``login`` is patched because the project configures multiple auth
+        backends; the assertion here is that the flow reaches login rather
+        than exercising Django's session login internals.
+        """
+        session = client.session
+        session["slack_auth_oauth_state"] = "shared"
+        session.save()
+
+        mock_get_token.return_value = {"ok": True, "access_token": "tok"}
+        mock_get_user_info.return_value = {
+            "ok": True,
+            "sub": "U123",
+            "email": "new@example.com",
+            "name": "New User",
+            "email_verified": True,
+        }
+
+        response = client.get(
+            reverse("core:slack_auth_callback"),
+            {"code": "abc", "state": "shared"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:dashboard")
+        assert User.objects.filter(email="new@example.com").exists()
+        mock_login.assert_called_once()
+
+    @patch("core.views.auth._get_slack_user_info")
+    @patch("core.views.auth._get_slack_token")
+    def test_auth_callback_unverified_email_rejected(
+        self,
+        mock_get_token: Mock,
+        mock_get_user_info: Mock,
+        client: Client,
+    ) -> None:
+        """Login is rejected when Slack reports the email is unverified."""
+        session = client.session
+        session["slack_auth_oauth_state"] = "shared"
+        session.save()
+
+        mock_get_token.return_value = {"ok": True, "access_token": "tok"}
+        mock_get_user_info.return_value = {
+            "ok": True,
+            "sub": "U123",
+            "email": "unverified@example.com",
+            "name": "Unverified User",
+            "email_verified": False,
+        }
+
+        response = client.get(
+            reverse("core:slack_auth_callback"),
+            {"code": "abc", "state": "shared"},
+        )
+
+        assert response.status_code == 400
+        assert not User.objects.filter(email="unverified@example.com").exists()
+
+
+@pytest.mark.django_db
+class TestConfigureSlackAdminGate:
+    """Test that configure_slack requires an admin/owner role."""
+
+    def _make_member(self, role: str) -> tuple[User, Workspace, Integration]:
+        """Create a user with the given workspace role and a Slack integration.
+
+        Args:
+            role: WorkspaceMember role to assign.
+
+        Returns:
+            Tuple of the user, workspace, and Slack integration.
+        """
+        user = User.objects.create_user(
+            username=f"{role}@example.com",
+            password="pw",
+            email=f"{role}@example.com",
+        )
+        workspace = Workspace.objects.create(name=f"WS {role}")
+        WorkspaceMember.objects.create(
+            user=user, workspace=workspace, role=role, is_active=True
+        )
+        integration = Integration.objects.create(
+            workspace=workspace,
+            integration_type="slack_notifications",
+            oauth_credentials={"access_token": "tok"},
+            integration_settings={"channel": "#general"},
+            is_active=True,
+        )
+        return user, workspace, integration
+
+    def _post_channel(self, client: Client, channel: str) -> Any:
+        """POST a channel change to configure_slack.
+
+        Args:
+            client: Django test client.
+            channel: Desired channel value.
+
+        Returns:
+            The HTTP response.
+        """
+        return client.post(
+            reverse("core:configure_slack"),
+            data={"channel": channel},
+            content_type="application/json",
+        )
+
+    def test_non_admin_member_forbidden(self, client: Client) -> None:
+        """A plain member cannot change the Slack destination channel."""
+        user, _, integration = self._make_member("user")
+        client.force_login(user)
+
+        response = self._post_channel(client, "#evil")
+
+        # require_admin_role redirects non-admins away instead of mutating.
+        assert response.status_code == 302
+        integration.refresh_from_db()
+        assert integration.integration_settings["channel"] == "#general"
+
+    def test_admin_member_allowed(self, client: Client) -> None:
+        """An admin member can change the Slack destination channel."""
+        user, _, integration = self._make_member("admin")
+        client.force_login(user)
+
+        response = self._post_channel(client, "#announcements")
+
+        assert response.status_code == 200
+        integration.refresh_from_db()
+        assert integration.integration_settings["channel"] == "#announcements"

--- a/tests/test_slack_oauth_state.py
+++ b/tests/test_slack_oauth_state.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, patch
 import pytest
 from core.models import Integration, UserProfile, Workspace, WorkspaceMember
 from django.contrib.auth.models import User
+from django.contrib.messages import get_messages
 from django.test import Client, override_settings
 from django.urls import reverse
 
@@ -155,6 +156,28 @@ class TestSlackConnectState:
             workspace=workspace, integration_type="slack_notifications"
         )
         assert integration.oauth_credentials["access_token"] == "xoxb-token"
+
+    @override_settings(**SLACK_CONNECT_SETTINGS)
+    @patch("core.views.integrations.slack.requests.post")
+    def test_callback_anonymous_gated_without_state_message(
+        self, mock_post: Mock, client: Client
+    ) -> None:
+        """An anonymous callback is gated first and leaves no state message.
+
+        The admin gate runs before state validation, so an unauthenticated
+        hit (e.g. expired session) is cleanly redirected to login without
+        persisting an "Invalid OAuth state" flash that would surface later.
+        """
+        response = client.get(
+            reverse("core:slack_connect_callback"),
+            {"code": "abc", "state": "whatever"},
+        )
+
+        assert response.status_code == 302
+        assert "/accounts/login/" in response.url
+        mock_post.assert_not_called()
+        stored = [str(m) for m in get_messages(response.wsgi_request)]
+        assert not any("oauth state" in m.lower() for m in stored)
 
 
 @pytest.mark.django_db

--- a/tests/test_slack_oauth_state.py
+++ b/tests/test_slack_oauth_state.py
@@ -330,10 +330,21 @@ class TestConfigureSlackAdminGate:
 
         response = self._post_channel(client, "#evil")
 
-        # require_admin_role redirects non-admins away instead of mutating.
-        assert response.status_code == 302
+        # JSON (fetch) endpoint: non-admins get a JSON 403, not a redirect.
+        assert response.status_code == 403
+        assert response.json()["error"]
         integration.refresh_from_db()
         assert integration.integration_settings["channel"] == "#general"
+
+    def test_non_admin_get_channels_forbidden_json(self, client: Client) -> None:
+        """A plain member gets a JSON 403 from get_slack_channels."""
+        user, _, _ = self._make_member("user")
+        client.force_login(user)
+
+        response = client.get(reverse("core:get_slack_channels"))
+
+        assert response.status_code == 403
+        assert response.json()["error"]
 
     def test_admin_member_allowed(self, client: Client) -> None:
         """An admin member can change the Slack destination channel."""

--- a/tests/test_slack_oauth_state.py
+++ b/tests/test_slack_oauth_state.py
@@ -357,3 +357,33 @@ class TestConfigureSlackAdminGate:
         assert response.status_code == 200
         integration.refresh_from_db()
         assert integration.integration_settings["channel"] == "#announcements"
+
+    @patch("core.views.integrations.slack.requests.post")
+    def test_non_admin_test_slack_forbidden(
+        self, mock_post: Mock, client: Client
+    ) -> None:
+        """A plain member cannot trigger a test message and none is sent."""
+        user, _, _ = self._make_member("user")
+        client.force_login(user)
+
+        response = client.post(reverse("core:test_slack"))
+
+        # Non-admins are redirected away and no Slack API call is made.
+        assert response.status_code == 302
+        mock_post.assert_not_called()
+
+    @patch("core.views.integrations.slack.requests.post")
+    def test_admin_test_slack_allowed(self, mock_post: Mock, client: Client) -> None:
+        """An admin member can trigger a test message via the Slack API."""
+        user, _, _ = self._make_member("admin")
+        client.force_login(user)
+
+        api_response = Mock()
+        api_response.json.return_value = {"ok": True}
+        mock_post.return_value = api_response
+
+        response = client.post(reverse("core:test_slack"))
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrations")
+        mock_post.assert_called_once()


### PR DESCRIPTION
## Summary

Security hardening of the Slack OAuth flows and config endpoints.

- **Connect CSRF (HIGH):** `slack_connect` / `slack_connect_callback` now generate a `secrets.token_urlsafe(32)` state, store it in the session, add it to the authorize URL, and validate it with `secrets.compare_digest` **before** exchanging the authorization code. Missing/mismatched state aborts with a redirect and error message. This is the serious one: the callback attaches an incoming-webhook delivery URL to the workspace.
- **Login CSRF (HIGH):** `slack_auth` / `slack_auth_callback` get the same state generation + validation.
- **email_verified (MEDIUM):** `slack_auth_callback` now rejects login when Slack reports the email is not verified, preventing account creation/linking (and takeover) on unverified emails.
- **Admin gates (MEDIUM):** `configure_slack` (mutates the destination channel), `test_slack`, and `get_slack_channels` now require the admin/owner role via `require_admin_role`, matching `disconnect_slack`.

Pattern mirrors the existing Shopify OAuth flow. Only `app/core/views/integrations/slack.py`, `app/core/views/auth.py`, and the new test file are touched.

## Test plan

New `tests/test_slack_oauth_state.py` proves:
- connect/login callbacks with missing or wrong state are rejected **without** exchanging a token
- valid state proceeds (connect creates the integration; login reaches `login()`)
- a non-admin member is forbidden from `configure_slack` (channel unchanged); an admin is allowed
- unverified email is rejected on login

All checks pass:
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run mypy app/` — Success, no issues in 115 files
- `uv run pytest -q` — 1487 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)