### PR TITLE
fix: reject empty secrets and header-based replay in Stripe/Shopify/Chargify webhooks

### DIFF
--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -148,6 +148,11 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         signed-content (body-hash) dedup at the router is tracked in
         https://github.com/Notipus/Notipus/issues/118.
 
+        This helper is side-effect-free: it returns a boolean and never
+        logs, so the single caller (``validate_webhook``) logs a failure
+        once. Logging here would let an unauthenticated caller emit two
+        warning lines per request and flood the logs.
+
         Args:
             request: The incoming HTTP request.
 
@@ -159,10 +164,6 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         if not timestamp_header:
             # Fail closed: a missing timestamp would bypass the replay
             # window, so reject rather than accept.
-            logger.warning(
-                "Missing X-Chargify-Webhook-Timestamp header; rejecting to "
-                "prevent replay of a captured signed body."
-            )
             return False
 
         try:
@@ -176,26 +177,11 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             # only a small clock-skew allowance in the future. A symmetric
             # abs() check would widen the replay window for future-dated
             # webhooks.
-            if age_seconds > self._TIMESTAMP_TOLERANCE_SECONDS or age_seconds < -(
-                self._FUTURE_TIMESTAMP_TOLERANCE_SECONDS
-            ):
-                logger.warning(
-                    "Webhook timestamp outside tolerance window",
-                    extra={
-                        "webhook_timestamp": timestamp_header,
-                        "age_seconds": age_seconds,
-                        "past_tolerance": self._TIMESTAMP_TOLERANCE_SECONDS,
-                        "future_tolerance": (self._FUTURE_TIMESTAMP_TOLERANCE_SECONDS),
-                    },
-                )
-                return False
-
-            return True
-        except (ValueError, TypeError) as e:
-            logger.warning(
-                "Invalid webhook timestamp format",
-                extra={"timestamp": timestamp_header, "error": str(e)},
+            return not (
+                age_seconds > self._TIMESTAMP_TOLERANCE_SECONDS
+                or age_seconds < -self._FUTURE_TIMESTAMP_TOLERANCE_SECONDS
             )
+        except (ValueError, TypeError):
             return False
 
     def validate_webhook(self, request: HttpRequest) -> bool:

--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -133,16 +133,29 @@ class ChargifySourcePlugin(BaseSourcePlugin):
     def _validate_webhook_timestamp(self, request: HttpRequest) -> bool:
         """Validate webhook timestamp to prevent replay attacks.
 
+        The timestamp header is required and fails closed when absent: the
+        signature only proves the body is authentic, not fresh, so a
+        captured signed body could otherwise be replayed indefinitely by
+        omitting the timestamp (and varying the unsigned webhook id). A
+        missing timestamp is treated as a validation failure so the
+        ±window always applies.
+
         Args:
             request: The incoming HTTP request.
 
         Returns:
-            True if timestamp is valid or not present, False if invalid.
+            True if the timestamp is present and within tolerance, False
+            if it is missing or invalid.
         """
         timestamp_header = request.headers.get("X-Chargify-Webhook-Timestamp")
         if not timestamp_header:
-            # Timestamp is optional, so continue if not present
-            return True
+            # Fail closed: a missing timestamp would bypass the replay
+            # window, so reject rather than accept.
+            logger.warning(
+                "Missing X-Chargify-Webhook-Timestamp header; rejecting to "
+                "prevent replay of a captured signed body."
+            )
+            return False
 
         try:
             webhook_time = datetime.fromisoformat(
@@ -429,11 +442,15 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             InvalidDataError: If webhook data is invalid or the
                 ``X-Chargify-Webhook-Id`` header is missing.
         """
+        # Never log the raw form body: it carries customer PII (email,
+        # name, card last-4) and revenue on every request. Log only
+        # non-sensitive metadata.
         logger.info(
             "Parsing Chargify webhook data",
             extra={
                 "content_type": request.content_type,
-                "form_data": (request.POST.dict() if request.POST else None),
+                "event_type": request.POST.get("event") if request.POST else None,
+                "webhook_id": request.headers.get("X-Chargify-Webhook-Id"),
                 "headers": mask_sensitive_headers(request.headers),
             },
         )

--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -140,6 +140,14 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         missing timestamp is treated as a validation failure so the
         ±window always applies.
 
+        NOTE: This is a window-narrowing mitigation, NOT full replay
+        prevention. Chargify's HMAC covers the body only, not the
+        timestamp header, so a captured (body, signature) pair can still be
+        replayed with a fresh in-tolerance timestamp within the ±window.
+        It layers with the existing webhook-id dedup at the router. Robust
+        signed-content (body-hash) dedup at the router is tracked in
+        https://github.com/Notipus/Notipus/issues/118.
+
         Args:
             request: The incoming HTTP request.
 

--- a/app/plugins/sources/shopify.py
+++ b/app/plugins/sources/shopify.py
@@ -538,6 +538,16 @@ class ShopifySourcePlugin(BaseSourcePlugin):
             True if signature is valid, False otherwise (including when
             the request body is not bytes and cannot be verified).
         """
+        # Never bypass validation: an empty webhook secret means the HMAC
+        # cannot be verified, so reject (even with DEBUG=True). Without this
+        # guard an attacker could forge a valid HMAC over arbitrary payloads.
+        if not self.webhook_secret:
+            logger.error(
+                "SECURITY: Webhook secret not configured! "
+                "Rejecting webhook to prevent unauthorized access."
+            )
+            return False
+
         hmac_header = request.headers.get("X-Shopify-Hmac-SHA256")
         if not hmac_header:
             return False

--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -1166,17 +1166,8 @@ class StripeSourcePlugin(BaseSourcePlugin):
             },
         )
 
-        # Fail closed on an empty secret: construct_event with an empty
-        # secret would let an attacker forge a valid signature over
-        # arbitrary payloads. Reject before any signature work (even with
-        # DEBUG=True).
-        if not self.webhook_secret:
-            logger.error(
-                "SECURITY: Webhook secret not configured! "
-                "Rejecting webhook to prevent unauthorized access."
-            )
-            raise InvalidDataError("Webhook secret not configured")
-
+        # Signature verification (and the fail-closed empty-secret guard)
+        # is owned by _construct_verified_event.
         event = self._construct_verified_event(request)
 
         # Extract idempotency_key from the event for cross-event deduplication

--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -124,6 +124,17 @@ class StripeSourcePlugin(BaseSourcePlugin):
             },
         )
 
+        # Never bypass validation: an empty webhook secret means we cannot
+        # verify the signature, so reject (even with DEBUG=True). Without
+        # this guard, Stripe's construct_event with an empty secret lets an
+        # attacker forge a valid signature over arbitrary payloads.
+        if not self.webhook_secret:
+            logger.error(
+                "SECURITY: Webhook secret not configured! "
+                "Rejecting webhook to prevent unauthorized access."
+            )
+            return False
+
         signature = request.headers.get("Stripe-Signature")
         payload = request.body
 
@@ -1091,6 +1102,46 @@ class StripeSourcePlugin(BaseSourcePlugin):
         ):
             metadata["billing_period"] = "monthly"
 
+    def _construct_verified_event(self, request: HttpRequest) -> Any:
+        """Verify the signature and construct the Stripe event object.
+
+        Fails closed on an empty secret: construct_event with an empty
+        secret would let an attacker forge a valid signature over arbitrary
+        payloads, so reject before any signature work (even with DEBUG).
+
+        Args:
+            request: The incoming HTTP request.
+
+        Returns:
+            The verified Stripe event object.
+
+        Raises:
+            InvalidDataError: If the secret is unconfigured, the signature
+                header is missing, or signature verification fails.
+        """
+        if not self.webhook_secret:
+            logger.error(
+                "SECURITY: Webhook secret not configured! "
+                "Rejecting webhook to prevent unauthorized access."
+            )
+            raise InvalidDataError("Webhook secret not configured")
+
+        signature = request.headers.get("Stripe-Signature")
+        payload = request.body
+
+        if not signature:
+            raise InvalidDataError("Missing Stripe signature")
+
+        try:
+            # Use Stripe SDK to construct and validate the event
+            return stripe.Webhook.construct_event(
+                payload, signature, self.webhook_secret
+            )
+        except stripe.SignatureVerificationError as e:
+            raise InvalidDataError(f"Invalid webhook signature: {e!s}") from e
+        except Exception as e:
+            raise InvalidDataError(f"Webhook parsing error: {e!s}") from e
+
     def parse_webhook(
         self, request: HttpRequest, **kwargs: Any
     ) -> dict[str, Any] | None:
@@ -1115,21 +1166,18 @@ class StripeSourcePlugin(BaseSourcePlugin):
             },
         )
 
-        signature = request.headers.get("Stripe-Signature")
-        payload = request.body
-
-        if not signature:
-            raise InvalidDataError("Missing Stripe signature")
-
-        try:
-            # Use Stripe SDK to construct and validate the event
-            event = stripe.Webhook.construct_event(
-                payload, signature, self.webhook_secret
+        # Fail closed on an empty secret: construct_event with an empty
+        # secret would let an attacker forge a valid signature over
+        # arbitrary payloads. Reject before any signature work (even with
+        # DEBUG=True).
+        if not self.webhook_secret:
+            logger.error(
+                "SECURITY: Webhook secret not configured! "
+                "Rejecting webhook to prevent unauthorized access."
             )
-        except stripe.SignatureVerificationError as e:
-            raise InvalidDataError(f"Invalid webhook signature: {e!s}") from e
-        except Exception as e:
-            raise InvalidDataError(f"Webhook parsing error: {e!s}") from e
+            raise InvalidDataError("Webhook secret not configured")
+
+        event = self._construct_verified_event(request)
 
         # Extract idempotency_key from the event for cross-event deduplication
         # All events triggered by the same Stripe API request share this key

--- a/tests/test_chargify_webhooks_comprehensive.py
+++ b/tests/test_chargify_webhooks_comprehensive.py
@@ -52,6 +52,8 @@ class TestChargifyWebhookValidation:
         """Test SHA-256 signature validation"""
         body = b"event=payment_success&payload[subscription][id]=12345"
         expected_signature = "a1b2c3d4e5f6"  # Mock signature
+        # A current timestamp header is now required (replay protection).
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
         request = request_factory.post(
             "/webhook/chargify/",
@@ -59,6 +61,7 @@ class TestChargifyWebhookValidation:
             content_type="application/x-www-form-urlencoded",
             HTTP_X_CHARGIFY_WEBHOOK_ID="webhook_123",
             HTTP_X_CHARGIFY_WEBHOOK_SIGNATURE_HMAC_SHA_256=expected_signature,
+            HTTP_X_CHARGIFY_WEBHOOK_TIMESTAMP=timestamp,
         )
 
         with patch("hmac.compare_digest", return_value=True):
@@ -68,6 +71,8 @@ class TestChargifyWebhookValidation:
         """Test MD5 signature fallback when SHA-256 not available"""
         body = b"event=payment_success&payload[subscription][id]=12345"
         md5_signature = "legacy_md5_signature"
+        # A current timestamp header is now required (replay protection).
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
         request = request_factory.post(
             "/webhook/chargify/",
@@ -75,6 +80,7 @@ class TestChargifyWebhookValidation:
             content_type="application/x-www-form-urlencoded",
             HTTP_X_CHARGIFY_WEBHOOK_ID="webhook_123",
             HTTP_X_CHARGIFY_WEBHOOK_SIGNATURE=md5_signature,
+            HTTP_X_CHARGIFY_WEBHOOK_TIMESTAMP=timestamp,
         )
 
         with patch("hmac.compare_digest", return_value=True):
@@ -467,12 +473,17 @@ class TestChargifyWebhookTimestampValidation:
 
         assert provider._validate_webhook_timestamp(mock_request) is True
 
-    def test_missing_timestamp_accepted(self, provider, request_factory):
-        """Test that missing timestamp is accepted (optional field)"""
+    def test_missing_timestamp_rejected(self, provider, request_factory):
+        """Test that a missing timestamp is rejected (fail closed).
+
+        The timestamp header is required: without it, a captured signed
+        body could be replayed indefinitely, so a missing timestamp must
+        fail validation rather than be accepted.
+        """
         mock_request = MagicMock()
         mock_request.headers = {}
 
-        assert provider._validate_webhook_timestamp(mock_request) is True
+        assert provider._validate_webhook_timestamp(mock_request) is False
 
     def test_invalid_timestamp_format_rejected(self, provider, request_factory):
         """Test that invalid timestamp format is rejected"""

--- a/tests/test_payment_providers.py
+++ b/tests/test_payment_providers.py
@@ -5,6 +5,7 @@ including signature validation, data parsing, and deduplication.
 """
 
 import json
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
@@ -177,6 +178,10 @@ def test_chargify_webhook_validation() -> None:
     mock_request.headers = {
         "X-Chargify-Webhook-Signature-Hmac-Sha-256": "1234567890abcdef",
         "X-Chargify-Webhook-Id": "webhook_123",
+        # A current timestamp header is now required (replay protection).
+        "X-Chargify-Webhook-Timestamp": (
+            datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        ),
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": "Chargify Webhooks",
     }

--- a/tests/test_webhook_source_hardening.py
+++ b/tests/test_webhook_source_hardening.py
@@ -1,0 +1,224 @@
+"""Security hardening tests for webhook source plugins.
+
+These tests lock in fail-closed behavior for the Stripe, Shopify, and
+Chargify source plugins:
+
+* An empty webhook secret must never validate a webhook (Stripe/Shopify),
+  even when the request otherwise looks valid and even under DEBUG.
+* A Chargify webhook missing its timestamp header must be rejected so a
+  captured signed body cannot be replayed indefinitely.
+* Chargify webhook parsing must not log customer PII (email, name, card
+  last-4) from the raw form body.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import RequestFactory
+from plugins.sources.base import InvalidDataError
+from plugins.sources.chargify import ChargifySourcePlugin
+from plugins.sources.shopify import ShopifySourcePlugin
+from plugins.sources.stripe import StripeSourcePlugin
+
+
+@pytest.fixture
+def request_factory() -> RequestFactory:
+    """Return a Django request factory for building test requests."""
+    return RequestFactory()
+
+
+class TestStripeEmptySecretRejected:
+    """Stripe must fail closed when no webhook secret is configured."""
+
+    def test_validate_webhook_rejects_empty_secret(self) -> None:
+        """validate_webhook returns False and never calls construct_event.
+
+        An empty secret means Stripe's signature check cannot be trusted,
+        so the guard must reject before any construct_event work.
+        """
+        provider = StripeSourcePlugin(webhook_secret="")
+        request = MagicMock()
+        request.headers = {"Stripe-Signature": "t=1,v1=deadbeef"}
+        request.body = b'{"id": "evt_1", "type": "invoice.paid"}'
+
+        with patch("stripe.Webhook.construct_event") as construct_event:
+            assert provider.validate_webhook(request) is False
+            construct_event.assert_not_called()
+
+    def test_validate_webhook_rejects_empty_secret_under_debug(
+        self, settings: Any
+    ) -> None:
+        """The empty-secret guard holds even when DEBUG is True."""
+        settings.DEBUG = True
+        provider = StripeSourcePlugin(webhook_secret="")
+        request = MagicMock()
+        request.headers = {"Stripe-Signature": "t=1,v1=deadbeef"}
+        request.body = b'{"id": "evt_1", "type": "invoice.paid"}'
+
+        with patch("stripe.Webhook.construct_event") as construct_event:
+            assert provider.validate_webhook(request) is False
+            construct_event.assert_not_called()
+
+    def test_parse_webhook_rejects_empty_secret(
+        self, request_factory: RequestFactory
+    ) -> None:
+        """parse_webhook raises before any construct_event work."""
+        provider = StripeSourcePlugin(webhook_secret="")
+        request = request_factory.post(
+            "/webhook/stripe/",
+            data=b'{"id": "evt_1", "type": "invoice.paid"}',
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="t=1,v1=deadbeef",
+        )
+
+        with patch("stripe.Webhook.construct_event") as construct_event:
+            with pytest.raises(InvalidDataError):
+                provider.parse_webhook(request)
+            construct_event.assert_not_called()
+
+
+class TestShopifyEmptySecretRejected:
+    """Shopify must fail closed when no webhook secret is configured."""
+
+    def test_validate_webhook_rejects_empty_secret(self) -> None:
+        """validate_webhook returns False even with a plausible HMAC header.
+
+        With an empty secret the HMAC cannot be verified, so an attacker
+        could otherwise forge a matching signature over any payload.
+        """
+        provider = ShopifySourcePlugin(webhook_secret="")
+        request = MagicMock()
+        request.headers = {"X-Shopify-Hmac-SHA256": "anything"}
+        request.body = b'{"id": 123}'
+
+        # Even if the underlying compare succeeded, the empty-secret guard
+        # must short-circuit to False first.
+        with patch("hmac.compare_digest", return_value=True):
+            assert provider.validate_webhook(request) is False
+
+    def test_validate_webhook_rejects_empty_secret_under_debug(
+        self, settings: Any
+    ) -> None:
+        """The empty-secret guard holds even when DEBUG is True."""
+        settings.DEBUG = True
+        provider = ShopifySourcePlugin(webhook_secret="")
+        request = MagicMock()
+        request.headers = {"X-Shopify-Hmac-SHA256": "anything"}
+        request.body = b'{"id": 123}'
+
+        with patch("hmac.compare_digest", return_value=True):
+            assert provider.validate_webhook(request) is False
+
+
+class TestChargifyMissingTimestampRejected:
+    """Chargify must reject webhooks without a timestamp header."""
+
+    def test_validate_timestamp_missing_header_rejected(self) -> None:
+        """_validate_webhook_timestamp fails closed on a missing header."""
+        provider = ChargifySourcePlugin(webhook_secret="test_secret")
+        request = MagicMock()
+        request.headers = {}
+
+        assert provider._validate_webhook_timestamp(request) is False
+
+    def test_validate_webhook_missing_timestamp_rejected(
+        self, request_factory: RequestFactory
+    ) -> None:
+        """validate_webhook rejects an otherwise-valid webhook with no timestamp.
+
+        The signature only proves the body is authentic, not fresh: without
+        a timestamp header a captured signed body could be replayed, so the
+        webhook must be rejected even when the signature would match.
+        """
+        provider = ChargifySourcePlugin(webhook_secret="test_secret")
+        request = request_factory.post(
+            "/webhook/chargify/",
+            data=b"event=payment_success&payload[subscription][id]=12345",
+            content_type="application/x-www-form-urlencoded",
+            HTTP_X_CHARGIFY_WEBHOOK_ID="webhook_123",
+            HTTP_X_CHARGIFY_WEBHOOK_SIGNATURE_HMAC_SHA_256="deadbeef",
+        )
+
+        # compare_digest would pass, but the missing timestamp must reject.
+        with patch("hmac.compare_digest", return_value=True):
+            assert provider.validate_webhook(request) is False
+
+    def test_validate_webhook_with_timestamp_accepted(
+        self, request_factory: RequestFactory
+    ) -> None:
+        """A current timestamp header allows an otherwise-valid webhook."""
+        provider = ChargifySourcePlugin(webhook_secret="test_secret")
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        request = request_factory.post(
+            "/webhook/chargify/",
+            data=b"event=payment_success&payload[subscription][id]=12345",
+            content_type="application/x-www-form-urlencoded",
+            HTTP_X_CHARGIFY_WEBHOOK_ID="webhook_123",
+            HTTP_X_CHARGIFY_WEBHOOK_SIGNATURE_HMAC_SHA_256="deadbeef",
+            HTTP_X_CHARGIFY_WEBHOOK_TIMESTAMP=timestamp,
+        )
+
+        with patch("hmac.compare_digest", return_value=True):
+            assert provider.validate_webhook(request) is True
+
+
+class TestChargifyParseWebhookDoesNotLogPII:
+    """Chargify webhook parsing must not log raw customer PII."""
+
+    def test_parse_webhook_omits_pii_from_logs(
+        self, request_factory: RequestFactory, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The parse-time log must not contain email, name, or card last-4.
+
+        Uses an acknowledged-but-unprocessed event so parsing returns None
+        without needing a full payload; the PII-bearing log line runs first
+        regardless.
+        """
+        provider = ChargifySourcePlugin(webhook_secret="test_secret")
+        email = "secret-customer@example.com"
+        first_name = "Topsecret"
+        card_last4 = "4242"
+        body = (
+            "event=customer_updated"
+            f"&payload[subscription][customer][email]={email}"
+            f"&payload[subscription][customer][first_name]={first_name}"
+            f"&payload[transaction][card_last_four]={card_last4}"
+        )
+        request = request_factory.post(
+            "/webhook/chargify/",
+            data=body,
+            content_type="application/x-www-form-urlencoded",
+            HTTP_X_CHARGIFY_WEBHOOK_ID="webhook_123",
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="plugins.sources.chargify"):
+            result = provider.parse_webhook(request)
+
+        assert result is None
+
+        # Inspect the specific parse-time record. PII previously leaked via
+        # the ``form_data`` extra (a LogRecord attribute, not the rendered
+        # message), so assert against the record attributes directly.
+        parse_records = [
+            record
+            for record in caplog.records
+            if record.getMessage() == "Parsing Chargify webhook data"
+        ]
+        assert len(parse_records) == 1
+        record = parse_records[0]
+
+        # The raw form body must no longer be attached to the log record.
+        assert not hasattr(record, "form_data")
+
+        # No PII value may appear anywhere in the record's attributes.
+        record_dump = repr(record.__dict__)
+        assert email not in record_dump
+        assert first_name not in record_dump
+        assert card_last4 not in record_dump
+
+        # Non-sensitive metadata is still logged for observability.
+        assert record.event_type == "customer_updated"
+        assert record.webhook_id == "webhook_123"


### PR DESCRIPTION
## Summary

Hardens the three webhook **source** plugins against forgeable and replayable webhooks. Chargify already had the empty-secret guard; this extends the same fail-closed posture to Stripe and Shopify and closes two Chargify gaps.

- **HIGH — Empty webhook secret forgeable (Stripe & Shopify).** `Integration.webhook_secret` is `blank=True`, so an active integration with a blank secret let an attacker forge a valid signature over arbitrary payloads. `StripeSourcePlugin` (both `validate_webhook` and the signature path used by `parse_webhook`) and `ShopifySourcePlugin.validate_webhook` now reject before any `construct_event`/HMAC work, even under `DEBUG`, mirroring Chargify's existing guard and `SECURITY` log line.
- **MEDIUM — Chargify replay via unsigned headers.** `_validate_webhook_timestamp` returned `True` when `X-Chargify-Webhook-Timestamp` was absent, so a captured signed body could be replayed indefinitely by omitting the timestamp (and varying the unsigned `X-Chargify-Webhook-Id`). The header is now required (fails closed); the one-sided ±window logic is unchanged.
- **MEDIUM — Chargify PII in logs.** `parse_webhook` logged the full form body (`request.POST.dict()`) at `INFO` on every request, exposing customer email/name/card-last4/revenue. It now logs only non-sensitive metadata (event type, webhook id, masked headers).
- **LOW — Chargify MD5 downgrade.** Verified: the code already prefers SHA-256 whenever that header is present and only falls back to MD5, already emitting a deprecation warning on the MD5 path. Left as-is (no behavior change).

The Stripe signature/verification block was extracted into `_construct_verified_event` to keep `parse_webhook` under the complexity limit after adding the guard.

## Existing tests updated

The old behavior of accept-on-missing was assumed by a few tests, now updated:
- `test_missing_timestamp_accepted` → `test_missing_timestamp_rejected` (now asserts `False`).
- `test_sha256_signature_validation` / `test_md5_signature_fallback` (Chargify) now send a current timestamp header.
- `test_chargify_webhook_validation` (test_payment_providers) now sends a current timestamp header.

## Test plan

New `tests/test_webhook_source_hardening.py` proves: Stripe & Shopify `validate_webhook` return `False` with an empty secret (even with a plausible signature/HMAC and under `DEBUG`) and never call the underlying verifier; Stripe `parse_webhook` raises before `construct_event`; Chargify rejects a webhook missing the timestamp header (and accepts one with a current timestamp); and the Chargify parse-time log record no longer carries the PII form body (asserted on the `LogRecord` attributes).

- `uv run ruff check --fix . && uv run ruff format .` — pass
- `uv run mypy app/` — Success, no issues in 115 source files
- `uv run pytest -q` — 1485 passed, 20 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)