### PR TITLE
fix: require admin role for billing and workspace-settings views

### DIFF
--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -16,6 +16,7 @@ from webhooks.services.rate_limiter import rate_limiter
 
 from ..models import Plan
 from ..permissions import get_workspace_for_user
+from .integrations.base import require_admin_role
 
 logger = logging.getLogger(__name__)
 
@@ -124,9 +125,10 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
     """
     from core.services.dashboard import BillingService
 
-    workspace = _get_user_workspace(request.user)
-    if not workspace:
-        return redirect("core:create_workspace")
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
     billing_service = BillingService()
     available_plans = billing_service.get_available_plans(workspace.subscription_plan)
@@ -149,9 +151,10 @@ def payment_methods(request: HttpRequest) -> HttpResponse | HttpResponseRedirect
     Returns:
         Payment methods page or redirect to workspace creation.
     """
-    workspace = _get_user_workspace(request.user)
-    if not workspace:
-        return redirect("core:create_workspace")
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
     # In a real implementation, you would fetch payment methods from Stripe
     # using workspace.stripe_customer_id
@@ -183,9 +186,10 @@ def billing_history(request: HttpRequest) -> HttpResponse | HttpResponseRedirect
     from core.services.stripe import StripeAPI
     from webhooks.utils.currency import from_minor_units
 
-    workspace = _get_user_workspace(request.user)
-    if not workspace:
-        return redirect("core:create_workspace")
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
     # Fetch real invoices from Stripe
     invoices: list[dict[str, Any]] = []
@@ -320,9 +324,10 @@ def checkout(
     from core.services.stripe import StripeAPI
     from django.conf import settings as django_settings
 
-    workspace = _get_user_workspace(request.user)
-    if not workspace:
-        return redirect("core:create_workspace")
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
     try:
         # Validate against the Plan model (single source of truth for
@@ -389,7 +394,7 @@ def checkout(
             customer_id=customer["id"],
             price_id=price_id,
             metadata={
-                "workspace_id": str(workspace.id),
+                "workspace_id": str(workspace.pk),
                 "plan_name": plan_name,
             },
             # No time-based component: any date bucket (local or UTC)
@@ -432,9 +437,10 @@ def billing_portal(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
     """
     from core.services.stripe import StripeAPI
 
-    workspace = _get_user_workspace(request.user)
-    if not workspace:
-        return redirect("core:create_workspace")
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
     try:
         # Check if workspace has a Stripe customer

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -121,7 +121,9 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
         request: The HTTP request object.
 
     Returns:
-        Upgrade plan page or redirect to workspace creation.
+        Upgrade plan page, redirect to workspace creation if the user has
+        no workspace, or redirect to the dashboard if the user is not an
+        owner/admin (permission denied).
     """
     from core.services.dashboard import BillingService
 
@@ -149,7 +151,9 @@ def payment_methods(request: HttpRequest) -> HttpResponse | HttpResponseRedirect
         request: The HTTP request object.
 
     Returns:
-        Payment methods page or redirect to workspace creation.
+        Payment methods page, redirect to workspace creation if the user
+        has no workspace, or redirect to the dashboard if the user is not
+        an owner/admin (permission denied).
     """
     workspace, redirect_response = require_admin_role(request)
     if redirect_response:
@@ -178,7 +182,9 @@ def billing_history(request: HttpRequest) -> HttpResponse | HttpResponseRedirect
         request: The HTTP request object.
 
     Returns:
-        Billing history page or redirect to workspace creation.
+        Billing history page, redirect to workspace creation if the user
+        has no workspace, or redirect to the dashboard if the user is not
+        an owner/admin (permission denied).
     """
     from datetime import datetime
     from datetime import timezone as dt_timezone
@@ -319,7 +325,9 @@ def checkout(
         plan_name: Name of the plan to checkout (basic, pro, enterprise).
 
     Returns:
-        Redirect to Stripe Checkout or error page.
+        Redirect to Stripe Checkout or error page. Redirects to workspace
+        creation if the user has no workspace, or to the dashboard if the
+        user is not an owner/admin (permission denied).
     """
     from core.services.stripe import StripeAPI
     from django.conf import settings as django_settings
@@ -434,6 +442,8 @@ def billing_portal(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
 
     Returns:
         Redirect to Stripe Customer Portal or billing dashboard on error.
+        Redirects to workspace creation if the user has no workspace, or to
+        the dashboard if the user is not an owner/admin (permission denied).
     """
     from core.services.stripe import StripeAPI
 

--- a/app/core/views/dashboard.py
+++ b/app/core/views/dashboard.py
@@ -191,7 +191,9 @@ def workspace_settings(request: HttpRequest) -> HttpResponse | HttpResponseRedir
         request: The HTTP request object.
 
     Returns:
-        Settings page or redirect to workspace creation.
+        Settings page, redirect to workspace creation if the user has no
+        workspace, or redirect to the dashboard if the user is not an
+        owner/admin (permission denied).
     """
     # Modifying workspace settings is an admin capability: shop_domain in
     # particular participates in webhook routing / tenant identity, so gate

--- a/app/core/views/dashboard.py
+++ b/app/core/views/dashboard.py
@@ -12,6 +12,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect, render
 
 from ..models import UserProfile, Workspace, WorkspaceMember
+from .integrations.base import require_admin_role
 
 logger = logging.getLogger(__name__)
 
@@ -192,29 +193,20 @@ def workspace_settings(request: HttpRequest) -> HttpResponse | HttpResponseRedir
     Returns:
         Settings page or redirect to workspace creation.
     """
-    try:
-        # Try to get workspace from WorkspaceMember first
-        member = WorkspaceMember.objects.filter(
-            user=request.user, is_active=True
-        ).first()
-        if member:
-            workspace = member.workspace
-        else:
-            # Fall back to UserProfile for backward compatibility
-            user_profile = UserProfile.objects.get(user=request.user)
-            workspace = user_profile.workspace
+    # Modifying workspace settings is an admin capability: shop_domain in
+    # particular participates in webhook routing / tenant identity, so gate
+    # the whole view behind the owner/admin role check.
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
 
-        if request.method == "POST":
-            workspace.name = request.POST.get("name", workspace.name)
-            workspace.shop_domain = request.POST.get(
-                "shop_domain", workspace.shop_domain
-            )
-            workspace.save()
-            messages.success(request, "Workspace settings updated!")
-            return redirect("core:workspace_settings")
+    if request.method == "POST":
+        workspace.name = request.POST.get("name", workspace.name)
+        workspace.shop_domain = request.POST.get("shop_domain", workspace.shop_domain)
+        workspace.save()
+        messages.success(request, "Workspace settings updated!")
+        return redirect("core:workspace_settings")
 
-        context = {"workspace": workspace}
-        return render(request, "core/workspace_settings.html.j2", context)
-
-    except UserProfile.DoesNotExist:
-        return redirect("core:create_workspace")
+    context = {"workspace": workspace}
+    return render(request, "core/workspace_settings.html.j2", context)

--- a/tests/core/test_billing_authz.py
+++ b/tests/core/test_billing_authz.py
@@ -1,0 +1,173 @@
+"""Authorization tests for billing and workspace-settings views.
+
+These tests prove that state-mutating and financial-data-exposing views are
+gated behind the owner/admin role:
+
+- Billing views (billing_portal, checkout, payment_methods, billing_history,
+  upgrade_plan) must reject a plain ``role="user"`` member.
+- workspace_settings must reject a plain ``role="user"`` member and must not
+  let one mutate the workspace name / shop_domain.
+- Owners and admins retain access to all of the above.
+
+Non-admins are redirected to the dashboard (the permission-denied UX used by
+``require_admin_role`` elsewhere in the codebase), never served the page.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+# Billing/settings views that only owners and admins may reach. ``args`` are
+# the reverse() positional arguments for views that take URL parameters.
+GATED_VIEWS: list[tuple[str, list[str]]] = [
+    ("core:billing_portal", []),
+    ("core:payment_methods", []),
+    ("core:billing_history", []),
+    ("core:upgrade_plan", []),
+    ("core:checkout", ["pro"]),
+    ("core:workspace_settings", []),
+]
+
+
+@pytest.mark.django_db
+class TestBillingAndSettingsRequireAdmin:
+    """Verify billing and workspace-settings views enforce the admin role."""
+
+    @pytest.mark.parametrize(("view_name", "args"), GATED_VIEWS)
+    def test_non_admin_member_is_denied(
+        self,
+        authenticated_user_client: Client,
+        view_name: str,
+        args: list[str],
+    ) -> None:
+        """A ``role="user"`` member is redirected to the dashboard, not served.
+
+        Args:
+            authenticated_user_client: Client logged in as a plain member.
+            view_name: The URL name of the gated view under test.
+            args: Positional reverse() arguments for the view.
+        """
+        response = authenticated_user_client.get(reverse(view_name, args=args))
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:dashboard")
+
+    @pytest.mark.parametrize(("view_name", "args"), GATED_VIEWS)
+    def test_admin_member_is_not_denied(
+        self,
+        authenticated_admin_client: Client,
+        view_name: str,
+        args: list[str],
+    ) -> None:
+        """An admin passes the role gate (never bounced to the dashboard).
+
+        Stripe is mocked so ``checkout`` exercises the authorization path
+        without making a network call; the assertion only proves the admin
+        cleared the permission gate.
+
+        Args:
+            authenticated_admin_client: Client logged in as an admin.
+            view_name: The URL name of the gated view under test.
+            args: Positional reverse() arguments for the view.
+        """
+        with patch(
+            "core.services.stripe.StripeAPI.get_or_create_customer",
+            return_value=None,
+        ):
+            response = authenticated_admin_client.get(reverse(view_name, args=args))
+
+        # The permission gate redirects denied users to the dashboard; an
+        # admin must land anywhere but there (200, or a redirect elsewhere
+        # such as the upgrade page when no Stripe customer exists yet).
+        if response.status_code == 302:
+            assert response.url != reverse("core:dashboard")
+        else:
+            assert response.status_code == 200
+
+    @pytest.mark.parametrize(("view_name", "args"), GATED_VIEWS)
+    def test_owner_member_is_not_denied(
+        self,
+        authenticated_owner_client: Client,
+        view_name: str,
+        args: list[str],
+    ) -> None:
+        """An owner passes the role gate (never bounced to the dashboard).
+
+        Args:
+            authenticated_owner_client: Client logged in as the owner.
+            view_name: The URL name of the gated view under test.
+            args: Positional reverse() arguments for the view.
+        """
+        with patch(
+            "core.services.stripe.StripeAPI.get_or_create_customer",
+            return_value=None,
+        ):
+            response = authenticated_owner_client.get(reverse(view_name, args=args))
+
+        if response.status_code == 302:
+            assert response.url != reverse("core:dashboard")
+        else:
+            assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestWorkspaceSettingsMutation:
+    """Verify workspace_settings mutations are gated behind the admin role."""
+
+    def test_non_admin_cannot_update_workspace(
+        self,
+        authenticated_user_client: Client,
+        workspace,  # noqa: ANN001 - fixture from tests/core/conftest.py
+        user_member,  # noqa: ANN001 - ensures the user is a plain member
+    ) -> None:
+        """A plain member's POST must not change the name or shop_domain.
+
+        shop_domain participates in webhook routing / tenant identity, so a
+        non-admin must not be able to change it.
+
+        Args:
+            authenticated_user_client: Client logged in as a plain member.
+            workspace: The workspace under test.
+            user_member: The plain-member membership for the logged-in user.
+        """
+        original_name = workspace.name
+        original_domain = workspace.shop_domain
+
+        response = authenticated_user_client.post(
+            reverse("core:workspace_settings"),
+            {"name": "Hijacked Name", "shop_domain": "evil.myshopify.com"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:dashboard")
+
+        workspace.refresh_from_db()
+        assert workspace.name == original_name
+        assert workspace.shop_domain == original_domain
+
+    def test_admin_can_update_workspace(
+        self,
+        authenticated_admin_client: Client,
+        workspace,  # noqa: ANN001 - fixture from tests/core/conftest.py
+        admin_member,  # noqa: ANN001 - ensures the user is an admin
+    ) -> None:
+        """An admin's POST updates the workspace name and shop_domain.
+
+        Args:
+            authenticated_admin_client: Client logged in as an admin.
+            workspace: The workspace under test.
+            admin_member: The admin membership for the logged-in user.
+        """
+        response = authenticated_admin_client.post(
+            reverse("core:workspace_settings"),
+            {"name": "Renamed Workspace", "shop_domain": "renamed.myshopify.com"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:workspace_settings")
+
+        workspace.refresh_from_db()
+        assert workspace.name == "Renamed Workspace"
+        assert workspace.shop_domain == "renamed.myshopify.com"


### PR DESCRIPTION
## Summary

Billing views enforced only `@login_required` + workspace membership, with no admin/owner role check. A `role="user"` member could open the Stripe customer portal (cancel the subscription — a workspace-wide downgrade/DoS — change plans and payment methods) and read all invoices (financial PII). Separately, `workspace_settings` let any active member rename the workspace and change `shop_domain`, which participates in webhook routing / tenant identity.

This gates the state-mutating and financial-data-exposing views behind the existing `require_admin_role()` check (owner/admin), the same mechanism the integration views use (e.g. the Slack disconnect view). Non-admins are redirected to the dashboard with a permission-denied message, matching the established UX. `require_admin_role` retains the `UserProfile` backward-compat fallback, so legacy single-profile users keep access.

### Views now gated (owner/admin only)
- `app/core/views/billing.py`: `billing_portal`, `checkout`, `payment_methods`, `billing_history`, `upgrade_plan`
- `app/core/views/dashboard.py`: `workspace_settings`

### Deliberately left ungated
Onboarding / no financial PII / no mutation: `select_plan`, `plan_selected`, `billing_dashboard`, `checkout_success`, `checkout_cancel`.

### Note
`checkout` metadata now uses `str(workspace.pk)` instead of `str(workspace.id)` — identical value (implicit AutoField pk), matches the sibling `_create_stripe_checkout_for_plan`, and satisfies mypy now that `workspace` flows from a precisely-typed `Workspace`.

## Test plan
- Added `tests/core/test_billing_authz.py` (placed alongside the other permission tests so it can reuse the `authenticated_{owner,admin,user}_client` fixtures from `tests/core/conftest.py`). It parametrizes every gated view and proves a `role="user"` member is redirected to the dashboard, while owners/admins clear the gate; it also proves a non-admin cannot mutate `name`/`shop_domain` via `workspace_settings` and that an admin can.
- No existing tests needed updating: the `checkout` guard tests already log in as an owner, `test_billing_history_renders` uses an owner, and `test_workspace_settings_renders` uses a `UserProfile`-only user (still allowed via the backward-compat fallback).
- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — all formatted
- `uv run mypy app/` — Success, no issues (115 files)
- `uv run pytest -q` — 1502 passed, 20 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)