### PR TITLE
fix: disable Sentry PII capture and scrub webhook data; warn on console email in prod

### DIFF
--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -10,13 +10,119 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
+import logging
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
 
 import sentry_sdk
 from django.utils.functional import SimpleLazyObject
+
+if TYPE_CHECKING:
+    from sentry_sdk._types import Event, Hint
+
+_settings_logger = logging.getLogger(__name__)
+
+# URL path fragments that identify tenant-facing webhook endpoints. Requests to
+# these routes carry raw payment payloads and provider signature headers, none
+# of which should ever be shipped to Sentry.
+_SENTRY_WEBHOOK_PATH_MARKERS = ("/webhook/",)
+
+# Substrings that, when found (case-insensitively) in a header name, request
+# data key, or environment key, mark the associated value as sensitive. Kept
+# deliberately broad and conservative: when in doubt, redact.
+_SENTRY_SENSITIVE_KEY_MARKERS = (
+    "authorization",
+    "cookie",
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "api-key",
+    "api_key",
+    "apikey",
+    "signature",
+    "x-shopify-hmac",
+    "x-hub-signature",
+    "stripe-signature",
+    "csrf",
+    "session",
+)
+
+_SENTRY_REDACTED = "[Filtered]"
+
+
+def _sentry_is_sensitive_key(key: str) -> bool:
+    """Return whether a header/data/env key name looks sensitive.
+
+    :param key: The key name to inspect (header, form field, or env var).
+    :returns: ``True`` if the key matches a known-sensitive marker.
+    """
+    lowered = key.lower()
+    return any(marker in lowered for marker in _SENTRY_SENSITIVE_KEY_MARKERS)
+
+
+def _sentry_redact_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``mapping`` with sensitive values redacted.
+
+    :param mapping: A dict of header/data/env key-value pairs.
+    :returns: A shallow copy where values under sensitive keys are replaced
+        with a filtered placeholder.
+    """
+    return {
+        key: (_SENTRY_REDACTED if _sentry_is_sensitive_key(str(key)) else value)
+        for key, value in mapping.items()
+    }
+
+
+def _sentry_before_send(event: "Event", hint: "Hint") -> "Event | None":
+    """Scrub sensitive data from a Sentry event before it is sent.
+
+    Conservative scrubbing hook applied to every outbound Sentry event:
+
+    * For requests to webhook routes, the raw request body/data is dropped
+      entirely since it may contain payment-payload PII for any tenant.
+    * Request headers, query strings, cookies, and environment variables are
+      redacted key-by-key whenever the key name looks like a credential,
+      secret, or signature (for webhook routes, headers are dropped wholesale).
+
+    :param event: The Sentry event payload (mutated in place and returned).
+    :param hint: Sentry-provided hint metadata (unused, kept for API contract).
+    :returns: The scrubbed event, or ``None`` to drop it entirely.
+    """
+    request = event.get("request")
+    if not isinstance(request, dict):
+        return event
+
+    url = str(request.get("url", ""))
+    is_webhook = any(marker in url for marker in _SENTRY_WEBHOOK_PATH_MARKERS)
+
+    # Drop request bodies wholesale for webhook routes (payment-payload PII).
+    if is_webhook:
+        request.pop("data", None)
+        request.pop("cookies", None)
+
+    # Headers: strip entirely for webhook routes (signature headers + more);
+    # otherwise redact only the sensitive ones.
+    headers = request.get("headers")
+    if isinstance(headers, dict):
+        request["headers"] = {} if is_webhook else _sentry_redact_mapping(headers)
+
+    # Query string and env: redact sensitive keys regardless of route.
+    for section in ("query_string", "env"):
+        value = request.get(section)
+        if isinstance(value, dict):
+            request[section] = _sentry_redact_mapping(value)
+
+    # Cookies elsewhere: redact rather than drop.
+    cookies = request.get("cookies")
+    if isinstance(cookies, dict):
+        request["cookies"] = _sentry_redact_mapping(cookies)
+
+    return event
+
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN", ""),
@@ -29,9 +135,12 @@ sentry_sdk.init(
         if os.environ.get("DEBUG", "False").lower() == "true"
         else "production",
     ),
-    # Add data like request headers and IP for users, see
-    # https://docs.sentry.io/platforms/python/data-management/data-collected/
-    send_default_pii=True,
+    # Privacy: never attach default PII (request bodies, headers, user IP).
+    # Webhook endpoints carry payment-payload PII and raw signature headers for
+    # all tenants, so this must stay False. See _sentry_before_send below for
+    # the belt-and-suspenders scrubbing applied to whatever remains.
+    send_default_pii=False,
+    before_send=_sentry_before_send,
 )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -160,9 +269,20 @@ AUTHENTICATION_BACKENDS = [
 SITE_ID = 1
 
 # Email configuration
-EMAIL_BACKEND = os.environ.get(
-    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
-)
+_console_email_backend = "django.core.mail.backends.console.EmailBackend"
+EMAIL_BACKEND = os.environ.get("EMAIL_BACKEND", _console_email_backend)
+
+# Guard: the console backend only writes emails to stdout. In production this
+# means invitation/verification emails silently vanish into the logs. Warn
+# loudly rather than raising so self-hosters who intentionally rely on the
+# console backend are not broken.
+if not DEBUG and EMAIL_BACKEND == _console_email_backend:
+    _settings_logger.warning(
+        "EMAIL_BACKEND is the console backend while DEBUG is False. "
+        "Outgoing emails (invitations, verification) will only be written to "
+        "logs and never delivered. Set the EMAIL_BACKEND environment variable "
+        "to an SMTP (or other real) backend for production."
+    )
 
 # SMTP settings for production (when EMAIL_BACKEND is smtp)
 EMAIL_HOST = os.environ.get("EMAIL_HOST", "localhost")

--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -83,8 +83,10 @@ def _sentry_redact_value(value: Any) -> Any:
             )
             for key, inner in value.items()
         }
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, list):
         return [_sentry_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sentry_redact_value(item) for item in value)
     return value
 
 

--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -15,7 +15,7 @@ import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlsplit
 
 import sentry_sdk
 from django.utils.functional import SimpleLazyObject
@@ -64,6 +64,30 @@ def _sentry_is_sensitive_key(key: str) -> bool:
     return any(marker in lowered for marker in _SENTRY_SENSITIVE_KEY_MARKERS)
 
 
+def _sentry_redact_value(value: Any) -> Any:
+    """Recursively redact sensitive values within nested structures.
+
+    Walks dicts and lists/tuples so that request bodies (which may be deeply
+    nested JSON) have any value under a sensitive-looking key replaced, while
+    non-sensitive structure is preserved.
+
+    :param value: An arbitrary value (dict, list, tuple, or scalar).
+    :returns: A redacted copy of ``value``.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (
+                _SENTRY_REDACTED
+                if _sentry_is_sensitive_key(str(key))
+                else _sentry_redact_value(inner)
+            )
+            for key, inner in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_sentry_redact_value(item) for item in value]
+    return value
+
+
 def _sentry_redact_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of ``mapping`` with sensitive values redacted.
 
@@ -77,6 +101,28 @@ def _sentry_redact_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _sentry_redact_query_string(query: Any) -> Any:
+    """Redact sensitive keys in a query string, dict or raw-string form.
+
+    Sentry may represent ``query_string`` either as a dict or as a raw
+    ``"a=1&token=..."`` string. Both are handled: pairs whose key looks
+    sensitive have their value replaced with the filtered placeholder.
+
+    :param query: The query string as a dict or ``str``.
+    :returns: The redacted query string in the same form it was given.
+    """
+    if isinstance(query, dict):
+        return _sentry_redact_mapping(query)
+    if isinstance(query, str):
+        pairs = parse_qsl(query, keep_blank_values=True)
+        redacted = [
+            (key, _SENTRY_REDACTED if _sentry_is_sensitive_key(key) else value)
+            for key, value in pairs
+        ]
+        return urlencode(redacted)
+    return query
+
+
 def _sentry_before_send(event: "Event", hint: "Hint") -> "Event | None":
     """Scrub sensitive data from a Sentry event before it is sent.
 
@@ -84,6 +130,8 @@ def _sentry_before_send(event: "Event", hint: "Hint") -> "Event | None":
 
     * For requests to webhook routes, the raw request body/data is dropped
       entirely since it may contain payment-payload PII for any tenant.
+    * For all other routes the request body is walked recursively and values
+      under credential/PII-looking keys are redacted.
     * Request headers, query strings, cookies, and environment variables are
       redacted key-by-key whenever the key name looks like a credential,
       secret, or signature (for webhook routes, headers are dropped wholesale).
@@ -96,13 +144,19 @@ def _sentry_before_send(event: "Event", hint: "Hint") -> "Event | None":
     if not isinstance(request, dict):
         return event
 
+    # Match on the URL path only: substring-matching the full URL would
+    # misclassify routes whose query string merely contains "/webhook/".
     url = str(request.get("url", ""))
-    is_webhook = any(marker in url for marker in _SENTRY_WEBHOOK_PATH_MARKERS)
+    path = urlsplit(url).path
+    is_webhook = any(marker in path for marker in _SENTRY_WEBHOOK_PATH_MARKERS)
 
-    # Drop request bodies wholesale for webhook routes (payment-payload PII).
+    # Request body: drop wholesale for webhook routes (payment-payload PII);
+    # otherwise recursively redact sensitive keys within it.
     if is_webhook:
         request.pop("data", None)
         request.pop("cookies", None)
+    elif "data" in request:
+        request["data"] = _sentry_redact_value(request["data"])
 
     # Headers: strip entirely for webhook routes (signature headers + more);
     # otherwise redact only the sensitive ones.
@@ -110,11 +164,14 @@ def _sentry_before_send(event: "Event", hint: "Hint") -> "Event | None":
     if isinstance(headers, dict):
         request["headers"] = {} if is_webhook else _sentry_redact_mapping(headers)
 
-    # Query string and env: redact sensitive keys regardless of route.
-    for section in ("query_string", "env"):
-        value = request.get(section)
-        if isinstance(value, dict):
-            request[section] = _sentry_redact_mapping(value)
+    # Query string: handle both dict and raw-string forms.
+    if "query_string" in request:
+        request["query_string"] = _sentry_redact_query_string(request["query_string"])
+
+    # Environment variables: redact sensitive keys regardless of route.
+    env = request.get("env")
+    if isinstance(env, dict):
+        request["env"] = _sentry_redact_mapping(env)
 
     # Cookies elsewhere: redact rather than drop.
     cookies = request.get("cookies")

--- a/tests/test_settings_privacy.py
+++ b/tests/test_settings_privacy.py
@@ -11,15 +11,25 @@ from django.conf import settings
 from django_notipus.settings import _sentry_before_send
 
 
-def test_settings_source_disables_default_pii() -> None:
-    """The settings module must configure Sentry with send_default_pii=False."""
-    from pathlib import Path
+def test_settings_disables_default_pii() -> None:
+    """Sentry must be initialized with send_default_pii=False and the scrubber.
+
+    Spies on the real ``sentry_sdk.init`` call the settings module makes at
+    import time (by reloading it under a patch) and asserts on the runtime
+    keyword arguments, so comment/formatting changes cannot break it.
+    """
+    import importlib
+    from unittest.mock import patch
 
     from django_notipus import settings as settings_module
 
-    source = Path(settings_module.__file__ or "").read_text()
-    assert "send_default_pii=False" in source
-    assert "send_default_pii=True" not in source
+    with patch("sentry_sdk.init") as mock_init:
+        importlib.reload(settings_module)
+
+    assert mock_init.called
+    _, kwargs = mock_init.call_args
+    assert kwargs["send_default_pii"] is False
+    assert kwargs["before_send"] is settings_module._sentry_before_send
 
 
 def test_before_send_drops_webhook_request_body_and_headers() -> None:

--- a/tests/test_settings_privacy.py
+++ b/tests/test_settings_privacy.py
@@ -1,0 +1,94 @@
+"""Tests for privacy-related Django settings.
+
+Covers the Sentry ``before_send`` scrubbing hook and the guarantee that
+default PII capture is disabled, so payment-payload PII and provider
+signature headers never leave the app via error reporting.
+"""
+
+from typing import Any
+
+from django.conf import settings
+from django_notipus.settings import _sentry_before_send
+
+
+def test_settings_source_disables_default_pii() -> None:
+    """The settings module must configure Sentry with send_default_pii=False."""
+    from pathlib import Path
+
+    from django_notipus import settings as settings_module
+
+    source = Path(settings_module.__file__ or "").read_text()
+    assert "send_default_pii=False" in source
+    assert "send_default_pii=True" not in source
+
+
+def test_before_send_drops_webhook_request_body_and_headers() -> None:
+    """Webhook events must have their body dropped and headers stripped."""
+    event: dict[str, Any] = {
+        "request": {
+            "url": "https://notipus.com/webhook/customer/abc-123/stripe/",
+            "data": {"amount": 4200, "customer_email": "buyer@example.com"},
+            "headers": {
+                "Stripe-Signature": "t=1,v1=deadbeef",
+                "Content-Type": "application/json",
+            },
+            "cookies": {"sessionid": "secret-session"},
+        }
+    }
+
+    result = _sentry_before_send(event, {})
+
+    assert result is not None
+    request = result["request"]
+    # Raw payment payload dropped entirely.
+    assert "data" not in request
+    # Signature-bearing headers stripped wholesale for webhook routes.
+    assert request["headers"] == {}
+    # Cookies dropped for webhook routes.
+    assert "cookies" not in request
+
+
+def test_before_send_redacts_sensitive_headers_on_non_webhook_routes() -> None:
+    """Non-webhook events keep body but redact sensitive header/query keys."""
+    event: dict[str, Any] = {
+        "request": {
+            "url": "https://notipus.com/dashboard/",
+            "data": {"foo": "bar"},
+            "headers": {
+                "Authorization": "Bearer super-secret",
+                "Accept": "text/html",
+            },
+            "query_string": {"api_key": "leaky", "page": "2"},
+            "cookies": {"sessionid": "abc", "theme": "dark"},
+        }
+    }
+
+    result = _sentry_before_send(event, {})
+
+    assert result is not None
+    request = result["request"]
+    # Non-webhook body is preserved.
+    assert request["data"] == {"foo": "bar"}
+    # Sensitive header redacted, benign header preserved.
+    assert request["headers"]["Authorization"] == "[Filtered]"
+    assert request["headers"]["Accept"] == "text/html"
+    # Sensitive query key redacted, benign one preserved.
+    assert request["query_string"]["api_key"] == "[Filtered]"
+    assert request["query_string"]["page"] == "2"
+    # Session cookie redacted, benign cookie preserved.
+    assert request["cookies"]["sessionid"] == "[Filtered]"
+    assert request["cookies"]["theme"] == "dark"
+
+
+def test_before_send_passes_events_without_request() -> None:
+    """Events lacking a request section are returned unchanged."""
+    event: dict[str, Any] = {"message": "boom"}
+
+    result = _sentry_before_send(event, {})
+
+    assert result == {"message": "boom"}
+
+
+def test_email_backend_configured() -> None:
+    """The EMAIL_BACKEND setting is resolvable (console default under tests)."""
+    assert settings.EMAIL_BACKEND

--- a/tests/test_settings_privacy.py
+++ b/tests/test_settings_privacy.py
@@ -80,6 +80,76 @@ def test_before_send_redacts_sensitive_headers_on_non_webhook_routes() -> None:
     assert request["cookies"]["theme"] == "dark"
 
 
+def test_before_send_uses_path_only_for_webhook_detection() -> None:
+    """A "/webhook/" fragment in the query string must not trigger webhook mode."""
+    event: dict[str, Any] = {
+        "request": {
+            # Non-webhook path; "/webhook/" appears only in the query string.
+            "url": "https://notipus.com/dashboard/?next=/webhook/customer/x/",
+            "data": {"keep": "me"},
+            "headers": {"Accept": "text/html"},
+        }
+    }
+
+    result = _sentry_before_send(event, {})
+
+    assert result is not None
+    request = result["request"]
+    # Treated as non-webhook: body and benign headers are preserved, not dropped.
+    assert request["data"] == {"keep": "me"}
+    assert request["headers"] == {"Accept": "text/html"}
+
+
+def test_before_send_redacts_sensitive_keys_in_non_webhook_body() -> None:
+    """Non-webhook request bodies must have sensitive keys redacted recursively."""
+    event: dict[str, Any] = {
+        "request": {
+            "url": "https://notipus.com/dashboard/",
+            "data": {
+                "username": "alice",
+                "password": "hunter2",
+                "nested": {"api_token": "leaky", "keep": "ok"},
+                "items": [{"secret": "shh", "label": "one"}],
+            },
+        }
+    }
+
+    result = _sentry_before_send(event, {})
+
+    assert result is not None
+    data = result["request"]["data"]
+    # Top-level sensitive key redacted, benign preserved.
+    assert data["username"] == "alice"
+    assert data["password"] == "[Filtered]"
+    # Nested dict walked recursively.
+    assert data["nested"]["api_token"] == "[Filtered]"
+    assert data["nested"]["keep"] == "ok"
+    # Lists of dicts walked recursively.
+    assert data["items"][0]["secret"] == "[Filtered]"
+    assert data["items"][0]["label"] == "one"
+
+
+def test_before_send_redacts_string_query_string() -> None:
+    """A raw-string query_string must have sensitive keys redacted in place."""
+    event: dict[str, Any] = {
+        "request": {
+            "url": "https://notipus.com/dashboard/",
+            "query_string": "page=2&token=super-secret&api_key=leaky",
+        }
+    }
+
+    result = _sentry_before_send(event, {})
+
+    assert result is not None
+    query = result["request"]["query_string"]
+    assert isinstance(query, str)
+    # Benign key preserved; sensitive keys redacted.
+    assert "page=2" in query
+    assert "super-secret" not in query
+    assert "leaky" not in query
+    assert query.count("%5BFiltered%5D") == 2  # url-encoded "[Filtered]" twice
+
+
 def test_before_send_passes_events_without_request() -> None:
     """Events lacking a request section are returned unchanged."""
     event: dict[str, Any] = {"message": "boom"}


### PR DESCRIPTION
## Summary

Two privacy/config hardening fixes, scoped to `app/django_notipus/settings.py` (plus a new test file).

**1. Sentry PII (MEDIUM).** Sentry was initialized with `send_default_pii=True`, so its automatic request capture could record payment-payload PII and raw provider signature headers on webhook endpoints for all tenants.
- Set `send_default_pii=False`.
- Added a well-commented `_sentry_before_send(event, hint)` hook that conservatively scrubs outbound events:
  - For webhook routes (`/webhook/`): drops the request body and cookies wholesale and strips all headers (signature headers live here).
  - For all routes: redacts values under credential/secret/signature-looking keys (authorization, cookie, token, api-key, `*-signature`, session, csrf, ...) in headers, query strings, cookies, and env.
- Factored into an importable module-level function so it is unit-testable.

**2. Console email in prod (LOW).** `EMAIL_BACKEND` defaults to the console backend; if the env var is missing in production, invitation/verification emails silently vanish into logs. Now logs a loud startup warning when `not DEBUG` and the backend resolves to console. Kept the console default for DEBUG and chose a warning over raising so self-hosters are not broken.

## Test plan
- Added `tests/test_settings_privacy.py` asserting the scrubber redacts webhook request data/headers, redacts sensitive keys on non-webhook routes, passes through non-request events, and that `send_default_pii=False`.
- `uv run ruff check .` — all checks passed
- `uv run ruff format .` — clean
- `uv run mypy app/` — Success, no issues in 115 source files
- `uv run pytest -q` — 1489 passed (20 subtests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)