### PR TITLE
fix: make rate-limiter cache failures visible and bound the in-memory fallback

### DIFF
--- a/app/webhooks/services/rate_limiter.py
+++ b/app/webhooks/services/rate_limiter.py
@@ -10,6 +10,7 @@ import time
 from datetime import datetime
 from typing import Any, ClassVar, cast
 
+from django.conf import settings
 from django.core.cache import cache
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.utils import timezone
@@ -161,6 +162,10 @@ class RateLimiter:
         self.circuit_breaker = RedisCircuitBreaker()
         self._in_memory_fallback: dict[str, tuple[int, float]] = {}
         self._fallback_timeout = 300  # 5 minutes for in-memory cache
+        # Hard cap on the number of keys tracked by the in-memory fallback.
+        # The fallback is per-process, so during a prolonged Redis outage it
+        # would otherwise grow one entry per organization/month without bound.
+        self._max_fallback_keys = 10_000
 
     def get_cache_key(self, organization_uuid: str, month: str) -> str:
         """Generate cache key for organization monthly usage.
@@ -194,6 +199,37 @@ class RateLimiter:
         plan = organization.subscription_plan
         return self.PLAN_LIMITS.get(plan, 20)  # Default to free plan limit
 
+    def _cache_get_with_health(self, key: str, default: int = 0) -> tuple[int, bool]:
+        """Get a value from cache, reporting whether the cache path succeeded.
+
+        Args:
+            key: Cache key.
+            default: Default value if not found.
+
+        Returns:
+            Tuple of (value, cache_healthy). When ``cache_healthy`` is False
+            the value came from the bounded in-memory fallback and callers
+            must treat the count as unreliable rather than authoritative --
+            in particular it must not be assumed to mean "under limit".
+        """
+        try:
+            value = cast(
+                int,
+                self.circuit_breaker.call_with_circuit_breaker(cache.get, key, default),
+            )
+            return value, True
+        except (RedisUnavailableError, InvalidCacheBackendError, Exception) as e:
+            # Log at ERROR (not WARNING/silent) so cache outages that degrade
+            # quota enforcement are visible in monitoring instead of silently
+            # disabling rate limiting.
+            logger.error(
+                "Cache GET failed for key %s; rate-limit enforcement degraded "
+                "to in-memory fallback: %s",
+                key,
+                e,
+            )
+            return self._get_from_fallback(key, default), False
+
     def _safe_cache_get(self, key: str, default: int = 0) -> int:
         """Get value from cache with fallback to in-memory storage.
 
@@ -204,14 +240,8 @@ class RateLimiter:
         Returns:
             Cached value or default.
         """
-        try:
-            return cast(
-                int,
-                self.circuit_breaker.call_with_circuit_breaker(cache.get, key, default),
-            )
-        except (RedisUnavailableError, InvalidCacheBackendError, Exception) as e:
-            logger.warning(f"Cache GET failed for key {key}, using fallback: {e!s}")
-            return self._get_from_fallback(key, default)
+        value, _ = self._cache_get_with_health(key, default)
+        return value
 
     def _safe_cache_set(self, key: str, value: int, timeout: int | None = None) -> bool:
         """Set value in cache with fallback to in-memory storage.
@@ -232,7 +262,7 @@ class RateLimiter:
             self._set_to_fallback(key, value)
             return True
         except (RedisUnavailableError, InvalidCacheBackendError, Exception) as e:
-            logger.warning(f"Cache SET failed for key {key}, using fallback: {e!s}")
+            logger.error(f"Cache SET failed for key {key}, using fallback: {e!s}")
             self._set_to_fallback(key, value)
             return False
 
@@ -268,7 +298,7 @@ class RateLimiter:
             self._set_to_fallback(key, new_count)
             return new_count
         except (RedisUnavailableError, InvalidCacheBackendError, Exception) as e:
-            logger.warning(f"Cache INCR failed for key {key}, using fallback: {e!s}")
+            logger.error(f"Cache INCR failed for key {key}, using fallback: {e!s}")
             new_count = self._get_from_fallback(key, 0) + 1
             self._set_to_fallback(key, new_count)
             return new_count
@@ -300,9 +330,19 @@ class RateLimiter:
             value: Value to store.
         """
         self._in_memory_fallback[key] = (value, time.time())
+        self._prune_fallback()
 
-        # Clean up expired entries to prevent memory leaks
+    def _prune_fallback(self) -> None:
+        """Bound the in-memory fallback so it cannot grow without limit.
+
+        First drops expired entries, then enforces a hard cap on the number
+        of tracked keys by evicting the oldest entries. Without the cap a
+        prolonged Redis outage would let the per-process fallback grow one
+        entry per organization/month indefinitely.
+        """
         current_time = time.time()
+
+        # Clean up expired entries to prevent memory leaks.
         expired_keys = [
             k
             for k, (_, timestamp) in self._in_memory_fallback.items()
@@ -310,6 +350,23 @@ class RateLimiter:
         ]
         for expired_key in expired_keys:
             del self._in_memory_fallback[expired_key]
+
+        # Enforce the hard cap by evicting the oldest entries. Reaching this
+        # branch means the fallback is under sustained pressure (Redis is very
+        # likely unavailable), so surface it.
+        overflow = len(self._in_memory_fallback) - self._max_fallback_keys
+        if overflow > 0:
+            oldest = sorted(
+                self._in_memory_fallback.items(), key=lambda item: item[1][1]
+            )[:overflow]
+            for stale_key, _ in oldest:
+                del self._in_memory_fallback[stale_key]
+            logger.warning(
+                "In-memory rate-limit fallback exceeded %s keys; evicted %s "
+                "oldest entries. Redis is likely unavailable.",
+                self._max_fallback_keys,
+                overflow,
+            )
 
     def check_rate_limit(self, organization: Any) -> tuple[bool, dict[str, Any]]:
         """Check if organization is within rate limits.
@@ -325,12 +382,32 @@ class RateLimiter:
             current_month = self.get_current_month_key()
             cache_key = self.get_cache_key(organization_uuid, current_month)
 
-            # Get current usage using safe cache operations
-            current_usage = self._safe_cache_get(cache_key, 0)
+            # Get current usage, tracking whether the cache path is healthy.
+            current_usage, cache_healthy = self._cache_get_with_health(cache_key, 0)
             limit = self.get_organization_limit(organization)
 
             # Check if within limits
             is_allowed = current_usage < limit
+
+            if not cache_healthy:
+                # Deliberate availability tradeoff. The cache backing the quota
+                # counter is unavailable, so ``current_usage`` came from the
+                # bounded in-memory fallback and cannot be trusted -- we must
+                # not silently treat it as "under limit". By default we still
+                # fail OPEN (allow the webhook): a fail-closed default would
+                # reject every legitimate webhook during a Redis outage, which
+                # is worse than briefly under-enforcing quota. Operators who
+                # prefer to reject traffic under uncertainty can opt into
+                # fail-closed with RATE_LIMIT_FAIL_CLOSED = True.
+                fail_closed = getattr(settings, "RATE_LIMIT_FAIL_CLOSED", False)
+                is_allowed = not fail_closed
+                logger.error(
+                    "Rate-limit cache unavailable for org %s; enforcing %s "
+                    "(RATE_LIMIT_FAIL_CLOSED=%s). Usage count is unreliable.",
+                    organization_uuid,
+                    "fail-closed (deny)" if fail_closed else "fail-open (allow)",
+                    fail_closed,
+                )
 
             # Calculate reset time (first day of next month)
             now = timezone.now()
@@ -361,6 +438,7 @@ class RateLimiter:
                 "reset_time": reset_time,
                 "plan": organization.subscription_plan,
                 "fallback_mode": self.circuit_breaker.state != "CLOSED",
+                "cache_healthy": cache_healthy,
             }
 
             return is_allowed, rate_limit_info
@@ -369,14 +447,19 @@ class RateLimiter:
             logger.error(
                 f"Error checking rate limit for organization {organization.uuid}: {e!s}"
             )
-            # Fail open - allow request if rate limiting fails completely
-            return True, {
+            # Availability tradeoff (see check above): rate limiting failed
+            # completely, so default to fail-open to avoid rejecting all
+            # legitimate webhooks during an outage. Operators can opt into
+            # fail-closed via RATE_LIMIT_FAIL_CLOSED = True.
+            fail_closed = getattr(settings, "RATE_LIMIT_FAIL_CLOSED", False)
+            return not fail_closed, {
                 "limit": self.get_organization_limit(organization),
                 "current_usage": 0,
                 "remaining": self.get_organization_limit(organization),
                 "reset_time": timezone.now(),
                 "plan": organization.subscription_plan,
                 "fallback_mode": True,
+                "cache_healthy": False,
                 "error": str(e),
             }
 

--- a/app/webhooks/services/rate_limiter.py
+++ b/app/webhooks/services/rate_limiter.py
@@ -166,6 +166,13 @@ class RateLimiter:
         # The fallback is per-process, so during a prolonged Redis outage it
         # would otherwise grow one entry per organization/month without bound.
         self._max_fallback_keys = 10_000
+        # When over the cap, evict in a batch down to this low-water mark so
+        # pruning (and its sort) is amortized across many writes instead of
+        # firing on every write once at capacity.
+        self._fallback_low_water = 9_000
+        # Throttle the eviction WARNING so a sustained outage cannot spam logs.
+        self._eviction_warn_interval = 60.0  # seconds
+        self._last_eviction_warn = 0.0
 
     def get_cache_key(self, organization_uuid: str, month: str) -> str:
         """Generate cache key for organization monthly usage.
@@ -227,6 +234,7 @@ class RateLimiter:
                 "to in-memory fallback: %s",
                 key,
                 e,
+                exc_info=True,
             )
             return self._get_from_fallback(key, default), False
 
@@ -335,10 +343,12 @@ class RateLimiter:
     def _prune_fallback(self) -> None:
         """Bound the in-memory fallback so it cannot grow without limit.
 
-        First drops expired entries, then enforces a hard cap on the number
-        of tracked keys by evicting the oldest entries. Without the cap a
-        prolonged Redis outage would let the per-process fallback grow one
-        entry per organization/month indefinitely.
+        First drops expired entries. If the fallback still exceeds the hard
+        cap, evicts the oldest entries in a single batch down to the
+        low-water mark. Evicting in batches (rather than one entry per write
+        once at capacity) means the O(n log n) sort is amortized across many
+        writes, and the eviction WARNING is throttled so a sustained Redis
+        outage cannot spam the log.
         """
         current_time = time.time()
 
@@ -351,21 +361,30 @@ class RateLimiter:
         for expired_key in expired_keys:
             del self._in_memory_fallback[expired_key]
 
-        # Enforce the hard cap by evicting the oldest entries. Reaching this
-        # branch means the fallback is under sustained pressure (Redis is very
-        # likely unavailable), so surface it.
-        overflow = len(self._in_memory_fallback) - self._max_fallback_keys
-        if overflow > 0:
-            oldest = sorted(
-                self._in_memory_fallback.items(), key=lambda item: item[1][1]
-            )[:overflow]
-            for stale_key, _ in oldest:
-                del self._in_memory_fallback[stale_key]
+        # Only sort/evict when actually over the cap. Evicting down to the
+        # low-water mark leaves headroom so the next prune (and its sort) is
+        # deferred for many subsequent writes instead of firing per write.
+        if len(self._in_memory_fallback) <= self._max_fallback_keys:
+            return
+
+        evict_count = len(self._in_memory_fallback) - self._fallback_low_water
+        oldest = sorted(self._in_memory_fallback.items(), key=lambda item: item[1][1])[
+            :evict_count
+        ]
+        for stale_key, _ in oldest:
+            del self._in_memory_fallback[stale_key]
+
+        # Reaching this branch means the fallback is under sustained pressure
+        # (Redis is very likely unavailable), so surface it -- but throttle so
+        # we warn at most once per interval.
+        if current_time - self._last_eviction_warn >= self._eviction_warn_interval:
+            self._last_eviction_warn = current_time
             logger.warning(
                 "In-memory rate-limit fallback exceeded %s keys; evicted %s "
-                "oldest entries. Redis is likely unavailable.",
+                "oldest entries down to %s. Redis is likely unavailable.",
                 self._max_fallback_keys,
-                overflow,
+                evict_count,
+                self._fallback_low_water,
             )
 
     def check_rate_limit(self, organization: Any) -> tuple[bool, dict[str, Any]]:
@@ -388,6 +407,7 @@ class RateLimiter:
 
             # Check if within limits
             is_allowed = current_usage < limit
+            deny_reason: str | None = None
 
             if not cache_healthy:
                 # Deliberate availability tradeoff. The cache backing the quota
@@ -401,6 +421,10 @@ class RateLimiter:
                 # fail-closed with RATE_LIMIT_FAIL_CLOSED = True.
                 fail_closed = getattr(settings, "RATE_LIMIT_FAIL_CLOSED", False)
                 is_allowed = not fail_closed
+                # Distinguish a cache-outage denial from an actual quota breach
+                # so enforce_rate_limit can raise a truthful message.
+                if not is_allowed:
+                    deny_reason = "cache_unavailable"
                 logger.error(
                     "Rate-limit cache unavailable for org %s; enforcing %s "
                     "(RATE_LIMIT_FAIL_CLOSED=%s). Usage count is unreliable.",
@@ -439,6 +463,7 @@ class RateLimiter:
                 "plan": organization.subscription_plan,
                 "fallback_mode": self.circuit_breaker.state != "CLOSED",
                 "cache_healthy": cache_healthy,
+                "reason": deny_reason,
             }
 
             return is_allowed, rate_limit_info
@@ -460,6 +485,7 @@ class RateLimiter:
                 "plan": organization.subscription_plan,
                 "fallback_mode": True,
                 "cache_healthy": False,
+                "reason": "cache_unavailable" if fail_closed else None,
                 "error": str(e),
             }
 
@@ -510,6 +536,18 @@ class RateLimiter:
         is_allowed, rate_limit_info = self.check_rate_limit(organization)
 
         if not is_allowed:
+            if rate_limit_info.get("reason") == "cache_unavailable":
+                # The denial is a fail-closed reaction to a cache outage, not
+                # an actual quota breach. Raise a truthful message so the
+                # rejection is not misattributed to the customer's usage.
+                raise RateLimitException(
+                    "Rate limiting is failing closed because the cache backend "
+                    "is unavailable (RATE_LIMIT_FAIL_CLOSED is enabled); "
+                    "rejecting the request until the cache recovers.",
+                    limit=rate_limit_info["limit"],
+                    current_usage=rate_limit_info["current_usage"],
+                    reset_time=rate_limit_info["reset_time"],
+                )
             raise RateLimitException(
                 f"Rate limit exceeded for plan '{organization.subscription_plan}'. "
                 f"Limit: {rate_limit_info['limit']}, "

--- a/app/webhooks/services/rate_limiter.py
+++ b/app/webhooks/services/rate_limiter.py
@@ -270,7 +270,10 @@ class RateLimiter:
             self._set_to_fallback(key, value)
             return True
         except (RedisUnavailableError, InvalidCacheBackendError, Exception) as e:
-            logger.error(f"Cache SET failed for key {key}, using fallback: {e!s}")
+            logger.error(
+                f"Cache SET failed for key {key}, using fallback: {e!s}",
+                exc_info=True,
+            )
             self._set_to_fallback(key, value)
             return False
 
@@ -306,7 +309,10 @@ class RateLimiter:
             self._set_to_fallback(key, new_count)
             return new_count
         except (RedisUnavailableError, InvalidCacheBackendError, Exception) as e:
-            logger.error(f"Cache INCR failed for key {key}, using fallback: {e!s}")
+            logger.error(
+                f"Cache INCR failed for key {key}, using fallback: {e!s}",
+                exc_info=True,
+            )
             new_count = self._get_from_fallback(key, 0) + 1
             self._set_to_fallback(key, new_count)
             return new_count
@@ -455,10 +461,16 @@ class RateLimiter:
                     microsecond=0,
                 )
 
+            # When the cache is unhealthy the usage count is unreliable, so the
+            # true remaining quota is unknown. Report 0 (a safe sentinel) rather
+            # than a computed value that would mislead consumers into thinking
+            # quota remains.
+            remaining = max(0, limit - current_usage) if cache_healthy else 0
+
             rate_limit_info: dict[str, Any] = {
                 "limit": limit,
                 "current_usage": current_usage,
-                "remaining": max(0, limit - current_usage),
+                "remaining": remaining,
                 "reset_time": reset_time,
                 "plan": organization.subscription_plan,
                 "fallback_mode": self.circuit_breaker.state != "CLOSED",
@@ -480,7 +492,9 @@ class RateLimiter:
             return not fail_closed, {
                 "limit": self.get_organization_limit(organization),
                 "current_usage": 0,
-                "remaining": self.get_organization_limit(organization),
+                # Cache is unhealthy here too: remaining quota is unknown, so
+                # use the safe sentinel (0) rather than the full plan limit.
+                "remaining": 0,
                 "reset_time": timezone.now(),
                 "plan": organization.subscription_plan,
                 "fallback_mode": True,
@@ -560,7 +574,11 @@ class RateLimiter:
         # Increment usage if allowed
         new_usage = self.increment_usage(organization)
         rate_limit_info["current_usage"] = new_usage
-        rate_limit_info["remaining"] = max(0, rate_limit_info["limit"] - new_usage)
+        # Only recompute remaining when the count is trustworthy; on a cache
+        # outage the sentinel (0) set by check_rate_limit must be preserved so
+        # consumers are not misled about how much quota is left.
+        if rate_limit_info.get("cache_healthy", True):
+            rate_limit_info["remaining"] = max(0, rate_limit_info["limit"] - new_usage)
 
         return rate_limit_info
 

--- a/app/webhooks/services/rate_limiter.py
+++ b/app/webhooks/services/rate_limiter.py
@@ -226,12 +226,12 @@ class RateLimiter:
             )
             return value, True
         except (RedisUnavailableError, InvalidCacheBackendError, Exception) as e:
-            # Log at ERROR (not WARNING/silent) so cache outages that degrade
-            # quota enforcement are visible in monitoring instead of silently
-            # disabling rate limiting.
+            # Log at ERROR (not WARNING/silent) so cache outages are visible in
+            # monitoring. This helper is generic (also used by get_usage_stats),
+            # so the message stays generic; enforcement-specific context is
+            # logged by check_rate_limit.
             logger.error(
-                "Cache GET failed for key %s; rate-limit enforcement degraded "
-                "to in-memory fallback: %s",
+                "Cache GET failed for key %s; using in-memory fallback: %s",
                 key,
                 e,
                 exc_info=True,
@@ -482,7 +482,10 @@ class RateLimiter:
 
         except Exception as e:
             logger.error(
-                f"Error checking rate limit for organization {organization.uuid}: {e!s}"
+                "Error checking rate limit for organization %s: %s",
+                organization.uuid,
+                e,
+                exc_info=True,
             )
             # Availability tradeoff (see check above): rate limiting failed
             # completely, so default to fail-open to avoid rejecting all

--- a/tests/test_rate_limiter_fallback.py
+++ b/tests/test_rate_limiter_fallback.py
@@ -16,7 +16,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.test import override_settings
-from webhooks.services.rate_limiter import RateLimiter
+from webhooks.services.rate_limiter import RateLimiter, RateLimitException
 
 
 def _make_org(plan: str = "free", uuid: str = "org-abc") -> Mock:
@@ -61,13 +61,39 @@ class TestCacheFailureVisibility:
         assert error_records, "cache failure must be logged at ERROR"
         assert any("cache" in r.getMessage().lower() for r in error_records)
 
+    def test_cache_failure_log_captures_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The cache-failure ERROR log includes the exception traceback.
+
+        Using ``exc_info=True`` ensures the underlying error is not dropped
+        from an ERROR-level log.
+        """
+        limiter = RateLimiter()
+
+        with (
+            patch("webhooks.services.rate_limiter.cache") as mock_cache,
+            caplog.at_level(logging.ERROR, logger="webhooks.services.rate_limiter"),
+        ):
+            mock_cache.get.side_effect = Exception("redis down")
+            limiter._cache_get_with_health("some-key", 0)
+
+        get_failures = [
+            r for r in caplog.records if "cache get failed" in r.getMessage().lower()
+        ]
+        assert get_failures, "cache GET failure must be logged"
+        assert any(r.exc_info is not None for r in get_failures), (
+            "traceback must be captured via exc_info"
+        )
+
     @override_settings(RATE_LIMIT_FAIL_CLOSED=True)
     def test_fail_closed_setting_denies_on_cache_failure(self) -> None:
         """With RATE_LIMIT_FAIL_CLOSED, a cache failure denies the request.
 
         This proves the degraded reading is not silently treated as
         under-limit: operators can opt into rejecting traffic under
-        uncertainty.
+        uncertainty. The denial must carry a ``cache_unavailable`` reason so
+        it is distinguishable from a real quota breach.
         """
         limiter = RateLimiter()
         org = _make_org()
@@ -78,6 +104,7 @@ class TestCacheFailureVisibility:
 
         assert is_allowed is False
         assert info["cache_healthy"] is False
+        assert info["reason"] == "cache_unavailable"
 
     def test_healthy_cache_reports_cache_healthy(self) -> None:
         """A working cache reports ``cache_healthy=True`` on the happy path."""
@@ -99,17 +126,22 @@ class TestInMemoryFallbackBounded:
         """Writing many distinct keys never exceeds the configured cap."""
         limiter = RateLimiter()
         limiter._max_fallback_keys = 50
+        limiter._fallback_low_water = 45
 
         for i in range(500):
             limiter._set_to_fallback(f"key-{i}", i)
             assert len(limiter._in_memory_fallback) <= limiter._max_fallback_keys
 
-        assert len(limiter._in_memory_fallback) == limiter._max_fallback_keys
+        # After batch eviction the size settles between the low-water mark and
+        # the cap, never exceeding the cap.
+        assert len(limiter._in_memory_fallback) <= limiter._max_fallback_keys
+        assert len(limiter._in_memory_fallback) >= limiter._fallback_low_water
 
     def test_fallback_eviction_keeps_newest_keys(self) -> None:
         """Eviction drops the oldest entries, retaining the most recent keys."""
         limiter = RateLimiter()
         limiter._max_fallback_keys = 10
+        limiter._fallback_low_water = 8
 
         for i in range(100):
             limiter._set_to_fallback(f"key-{i}", i)
@@ -119,12 +151,38 @@ class TestInMemoryFallbackBounded:
         # The oldest key must have been evicted.
         assert "key-0" not in limiter._in_memory_fallback
 
+    def test_eviction_is_batched_not_per_write(self) -> None:
+        """Over-cap writes evict a batch, so the sort does not run every write.
+
+        After the fallback first fills to the cap, a single eviction drops it
+        to the low-water mark, leaving headroom so subsequent writes stay under
+        the cap without triggering another eviction until the headroom is used.
+        """
+        limiter = RateLimiter()
+        limiter._max_fallback_keys = 10
+        limiter._fallback_low_water = 8
+
+        # Fill exactly to the cap; no eviction yet.
+        for i in range(10):
+            limiter._set_to_fallback(f"key-{i}", i)
+        assert len(limiter._in_memory_fallback) == 10
+
+        # One more write exceeds the cap and triggers a batch eviction down to
+        # the low-water mark (8), not a single-entry trim back to 10.
+        limiter._set_to_fallback("key-10", 10)
+        assert len(limiter._in_memory_fallback) == limiter._fallback_low_water
+
+        # The next write stays within headroom and does not evict again.
+        limiter._set_to_fallback("key-11", 11)
+        assert len(limiter._in_memory_fallback) == limiter._fallback_low_water + 1
+
     def test_fallback_eviction_logs_warning(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Exceeding the cap logs a WARNING signalling a likely outage."""
         limiter = RateLimiter()
         limiter._max_fallback_keys = 5
+        limiter._fallback_low_water = 4
 
         with caplog.at_level(logging.WARNING, logger="webhooks.services.rate_limiter"):
             for i in range(20):
@@ -133,3 +191,60 @@ class TestInMemoryFallbackBounded:
         assert any(
             "fallback exceeded" in r.getMessage().lower() for r in caplog.records
         )
+
+    def test_eviction_warning_is_throttled(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A sustained outage warns at most once per throttle interval.
+
+        Writing far more keys than the cap must not emit a WARNING per
+        over-cap write; the throttle keeps it to a single message within the
+        interval.
+        """
+        limiter = RateLimiter()
+        limiter._max_fallback_keys = 5
+        limiter._fallback_low_water = 4
+        limiter._eviction_warn_interval = 3600.0  # effectively "once" in test
+
+        with caplog.at_level(logging.WARNING, logger="webhooks.services.rate_limiter"):
+            for i in range(200):
+                limiter._set_to_fallback(f"key-{i}", i)
+
+        eviction_warnings = [
+            r for r in caplog.records if "fallback exceeded" in r.getMessage().lower()
+        ]
+        assert len(eviction_warnings) == 1
+
+
+class TestEnforceDenyReason:
+    """enforce_rate_limit must distinguish cache outages from quota breaches."""
+
+    @override_settings(RATE_LIMIT_FAIL_CLOSED=True)
+    def test_cache_outage_raises_distinct_message(self) -> None:
+        """A fail-closed cache outage raises a cache-specific message.
+
+        The rejection must not be misattributed to the customer's usage.
+        """
+        limiter = RateLimiter()
+        org = _make_org()
+
+        with patch("webhooks.services.rate_limiter.cache") as mock_cache:
+            mock_cache.get.side_effect = Exception("redis down")
+            with pytest.raises(RateLimitException) as exc_info:
+                limiter.enforce_rate_limit(org)
+
+        message = str(exc_info.value).lower()
+        assert "cache" in message
+        assert "rate limit exceeded" not in message
+
+    def test_actual_quota_breach_raises_exceeded_message(self) -> None:
+        """A real quota breach still raises the standard exceeded message."""
+        limiter = RateLimiter()
+        org = _make_org(plan="free")  # free plan limit is 20
+
+        with patch("webhooks.services.rate_limiter.cache") as mock_cache:
+            mock_cache.get.return_value = 20  # at/over the limit, cache healthy
+            with pytest.raises(RateLimitException) as exc_info:
+                limiter.enforce_rate_limit(org)
+
+        assert "rate limit exceeded" in str(exc_info.value).lower()

--- a/tests/test_rate_limiter_fallback.py
+++ b/tests/test_rate_limiter_fallback.py
@@ -1,0 +1,135 @@
+"""Robustness tests for the rate limiter's cache-failure handling.
+
+These tests cover two deliberate robustness properties:
+
+1. When the cache path fails, the failure is logged at ERROR (so outages
+   are visible) and is recorded in the returned info as an unhealthy cache
+   rather than silently being treated as "under limit". By default the
+   limiter fails OPEN for availability, but ``RATE_LIMIT_FAIL_CLOSED`` lets
+   operators opt into fail-closed behaviour.
+2. The per-process in-memory fallback is bounded: it cannot grow without
+   limit even when many distinct keys are written during a Redis outage.
+"""
+
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+from django.test import override_settings
+from webhooks.services.rate_limiter import RateLimiter
+
+
+def _make_org(plan: str = "free", uuid: str = "org-abc") -> Mock:
+    """Build a minimal organization stub for rate-limit checks.
+
+    Args:
+        plan: Subscription plan name.
+        uuid: Organization UUID string.
+
+    Returns:
+        A mock exposing ``uuid`` and ``subscription_plan`` attributes.
+    """
+    return Mock(uuid=uuid, subscription_plan=plan)
+
+
+class TestCacheFailureVisibility:
+    """The cache path failing must be loud and must not read as under-limit."""
+
+    def test_cache_failure_logs_error_and_marks_unhealthy(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A cache GET failure logs at ERROR and records an unhealthy cache.
+
+        The degraded count must be surfaced via ``cache_healthy=False`` rather
+        than silently being trusted as an authoritative "under limit" reading.
+        """
+        limiter = RateLimiter()
+        org = _make_org()
+
+        with (
+            patch("webhooks.services.rate_limiter.cache") as mock_cache,
+            caplog.at_level(logging.ERROR, logger="webhooks.services.rate_limiter"),
+        ):
+            mock_cache.get.side_effect = Exception("redis down")
+            is_allowed, info = limiter.check_rate_limit(org)
+
+        # Fails open by default (availability), but the degradation is recorded.
+        assert is_allowed is True
+        assert info["cache_healthy"] is False
+
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert error_records, "cache failure must be logged at ERROR"
+        assert any("cache" in r.getMessage().lower() for r in error_records)
+
+    @override_settings(RATE_LIMIT_FAIL_CLOSED=True)
+    def test_fail_closed_setting_denies_on_cache_failure(self) -> None:
+        """With RATE_LIMIT_FAIL_CLOSED, a cache failure denies the request.
+
+        This proves the degraded reading is not silently treated as
+        under-limit: operators can opt into rejecting traffic under
+        uncertainty.
+        """
+        limiter = RateLimiter()
+        org = _make_org()
+
+        with patch("webhooks.services.rate_limiter.cache") as mock_cache:
+            mock_cache.get.side_effect = Exception("redis down")
+            is_allowed, info = limiter.check_rate_limit(org)
+
+        assert is_allowed is False
+        assert info["cache_healthy"] is False
+
+    def test_healthy_cache_reports_cache_healthy(self) -> None:
+        """A working cache reports ``cache_healthy=True`` on the happy path."""
+        limiter = RateLimiter()
+        org = _make_org()
+
+        with patch("webhooks.services.rate_limiter.cache") as mock_cache:
+            mock_cache.get.return_value = 0
+            is_allowed, info = limiter.check_rate_limit(org)
+
+        assert is_allowed is True
+        assert info["cache_healthy"] is True
+
+
+class TestInMemoryFallbackBounded:
+    """The in-memory fallback must never grow without limit."""
+
+    def test_fallback_does_not_exceed_cap(self) -> None:
+        """Writing many distinct keys never exceeds the configured cap."""
+        limiter = RateLimiter()
+        limiter._max_fallback_keys = 50
+
+        for i in range(500):
+            limiter._set_to_fallback(f"key-{i}", i)
+            assert len(limiter._in_memory_fallback) <= limiter._max_fallback_keys
+
+        assert len(limiter._in_memory_fallback) == limiter._max_fallback_keys
+
+    def test_fallback_eviction_keeps_newest_keys(self) -> None:
+        """Eviction drops the oldest entries, retaining the most recent keys."""
+        limiter = RateLimiter()
+        limiter._max_fallback_keys = 10
+
+        for i in range(100):
+            limiter._set_to_fallback(f"key-{i}", i)
+
+        # The most recently written key must survive eviction.
+        assert "key-99" in limiter._in_memory_fallback
+        # The oldest key must have been evicted.
+        assert "key-0" not in limiter._in_memory_fallback
+
+    def test_fallback_eviction_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Exceeding the cap logs a WARNING signalling a likely outage."""
+        limiter = RateLimiter()
+        limiter._max_fallback_keys = 5
+
+        with caplog.at_level(logging.WARNING, logger="webhooks.services.rate_limiter"):
+            for i in range(20):
+                limiter._set_to_fallback(f"key-{i}", i)
+
+        assert any(
+            "fallback exceeded" in r.getMessage().lower() for r in caplog.records
+        )

--- a/tests/test_rate_limiter_fallback.py
+++ b/tests/test_rate_limiter_fallback.py
@@ -118,6 +118,59 @@ class TestCacheFailureVisibility:
         assert is_allowed is True
         assert info["cache_healthy"] is True
 
+    def test_unhealthy_cache_reports_zero_remaining(self) -> None:
+        """An unhealthy cache reports ``remaining=0`` (unknown quota sentinel).
+
+        The count is unreliable during an outage, so ``remaining`` must not be
+        computed from it and mislead consumers into thinking quota is left.
+        """
+        limiter = RateLimiter()
+        org = _make_org()
+
+        with patch("webhooks.services.rate_limiter.cache") as mock_cache:
+            mock_cache.get.side_effect = Exception("redis down")
+            _, info = limiter.check_rate_limit(org)
+
+        assert info["cache_healthy"] is False
+        assert info["remaining"] == 0
+
+    def test_check_exception_path_reports_zero_remaining(self) -> None:
+        """The total-failure fallback path also reports ``remaining=0``.
+
+        Even the degraded exception branch must not advertise the full plan
+        limit as remaining when the cache count is unknown.
+        """
+        limiter = RateLimiter()
+        org = _make_org()
+
+        # Force the outer except branch by making the cache key derivation fail
+        # after the org uuid is accessed for the log message.
+        with patch.object(
+            limiter, "_cache_get_with_health", side_effect=RuntimeError("boom")
+        ):
+            _, info = limiter.check_rate_limit(org)
+
+        assert info["cache_healthy"] is False
+        assert info["remaining"] == 0
+
+    def test_enforce_preserves_zero_remaining_on_cache_outage(self) -> None:
+        """enforce_rate_limit keeps ``remaining=0`` when failing open on outage.
+
+        With the default fail-open behaviour a cache outage still allows the
+        webhook, but the returned info must preserve the unknown-quota sentinel
+        rather than recomputing a misleading remaining from the increment.
+        """
+        limiter = RateLimiter()
+        org = _make_org()
+
+        with patch("webhooks.services.rate_limiter.cache") as mock_cache:
+            mock_cache.get.side_effect = Exception("redis down")
+            mock_cache.incr.side_effect = Exception("redis down")
+            info = limiter.enforce_rate_limit(org)
+
+        assert info["cache_healthy"] is False
+        assert info["remaining"] == 0
+
 
 class TestInMemoryFallbackBounded:
     """The in-memory fallback must never grow without limit."""


### PR DESCRIPTION
## Summary

Fixes two MEDIUM robustness issues in `app/webhooks/services/rate_limiter.py`. The atomic-increment race was already fixed on master; this PR does not touch that logic.

### 1. Cache failures are now visible (no silent fail-open)
- Added `_cache_get_with_health()` which reports whether the cache path succeeded. Cache GET failures are now logged at **ERROR** (was WARNING) so Redis outages are visible in monitoring.
- `check_rate_limit()` no longer silently treats a degraded/fallback count as "under limit". It records `cache_healthy=False` and logs at ERROR when the cache is unavailable.
- **Deliberate availability tradeoff (documented in a code comment):** the limiter still defaults to **fail-OPEN** so a Redis outage does not reject every legitimate webhook. Operators who prefer to reject under uncertainty can opt into fail-closed with the new **`RATE_LIMIT_FAIL_CLOSED`** setting (default `False`).
- `_safe_cache_set` / `_safe_cache_incr` fallback logs bumped to ERROR for consistent outage visibility.

### 2. In-memory fallback is now bounded
- The per-process `_in_memory_fallback` could grow one entry per org/month without limit during a prolonged Redis outage. It is now capped at `_max_fallback_keys` (10k) via `_prune_fallback()`, which drops expired entries then evicts oldest-first, logging a WARNING when the cap is hit.

All existing public method signatures and happy-path behavior are unchanged.

## Test plan
- Added `tests/test_rate_limiter_fallback.py` (typed, docstring'd): proves a simulated cache failure logs at ERROR and surfaces `cache_healthy=False` (not silently under-limit), that `RATE_LIMIT_FAIL_CLOSED=True` denies on cache failure, and that the in-memory fallback never exceeds its cap after many distinct keys.
- `uv run ruff check .` — passes
- `uv run ruff format --check .` — passes
- `uv run mypy app/` — Success: no issues found in 115 source files
- `uv run pytest -q` — 1490 passed, 20 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)