### PR TITLE
fix: sync_stripe_subscriptions honors stored subscription id and status=all

### DIFF
--- a/app/core/management/commands/sync_stripe_subscriptions.py
+++ b/app/core/management/commands/sync_stripe_subscriptions.py
@@ -12,7 +12,7 @@ import stripe
 from core.models import Workspace
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from webhooks.services.billing import BillingService, map_stripe_status
+from webhooks.services.billing import map_stripe_status
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,14 @@ class Command(BaseCommand):
         starting_after = None
 
         while True:
-            params: dict = {"limit": 100, "expand": ["data.items.data.price"]}
+            # status="all" so canceled subscriptions are returned too;
+            # otherwise a workspace whose only subscription was canceled is
+            # never seen here and stays "active" locally forever.
+            params: dict = {
+                "limit": 100,
+                "status": "all",
+                "expand": ["data.items.data.price"],
+            }
             if starting_after:
                 params["starting_after"] = starting_after
 
@@ -77,26 +84,78 @@ class Command(BaseCommand):
         self.stdout.write(f"Found {len(subscriptions)} subscription(s) in Stripe")
         return subscriptions
 
-    def _build_customer_subscription_map(
+    def _group_subscriptions_by_customer(
         self, subscriptions: list
-    ) -> dict[str, stripe.Subscription]:
-        """Build map of customer_id to most relevant subscription."""
-        customer_subscriptions: dict[str, stripe.Subscription] = {}
+    ) -> dict[str, list[stripe.Subscription]]:
+        """Group every subscription by its Stripe customer id.
+
+        All subscriptions are retained (not collapsed to one per customer)
+        so that per-workspace selection can honor a stored
+        ``stripe_subscription_id`` rather than an arbitrary heuristic.
+
+        Args:
+            subscriptions: Subscriptions fetched from Stripe.
+
+        Returns:
+            Mapping of customer id to its list of subscriptions, preserving
+            the order returned by Stripe.
+        """
+        customer_subscriptions: dict[str, list[stripe.Subscription]] = {}
 
         for sub in subscriptions:
             customer_id = sub.customer
             if isinstance(customer_id, stripe.Customer):
                 customer_id = customer_id.id
 
-            existing = customer_subscriptions.get(customer_id)
-
-            if existing is None:
-                customer_subscriptions[customer_id] = sub
-            elif sub.status in ("active", "trialing", "past_due"):
-                if existing.status not in ("active", "trialing"):
-                    customer_subscriptions[customer_id] = sub
+            customer_subscriptions.setdefault(customer_id, []).append(sub)
 
         return customer_subscriptions
+
+    def _most_relevant_subscription(
+        self, subs: list[stripe.Subscription]
+    ) -> stripe.Subscription:
+        """Pick a subscription using the live-first fallback heuristic.
+
+        Prefers a live (active/trialing/past_due) subscription; otherwise
+        returns the first one so a customer whose only subscription was
+        canceled still downgrades the workspace instead of being skipped.
+
+        Args:
+            subs: Non-empty list of a customer's subscriptions.
+
+        Returns:
+            The selected subscription.
+        """
+        for sub in subs:
+            if sub.status in ("active", "trialing", "past_due"):
+                return sub
+        return subs[0]
+
+    def _select_subscription(
+        self, workspace: Workspace, subs: list[stripe.Subscription]
+    ) -> stripe.Subscription:
+        """Choose the subscription that reflects the workspace's billing.
+
+        When the workspace records a ``stripe_subscription_id``, the
+        subscription with that id wins so an add-on or duplicate
+        subscription on the same customer can't overwrite the plan billing
+        is actually tied to. The live-first heuristic is used only when no
+        id is stored or the stored id no longer matches any subscription.
+
+        Args:
+            workspace: Workspace being synced.
+            subs: Non-empty list of the customer's subscriptions.
+
+        Returns:
+            The selected subscription.
+        """
+        stored_id = workspace.stripe_subscription_id
+        if stored_id:
+            for sub in subs:
+                if sub.id == stored_id:
+                    return sub
+
+        return self._most_relevant_subscription(subs)
 
     def handle(self, *args, **options) -> None:
         """Execute the command.
@@ -125,13 +184,13 @@ class Command(BaseCommand):
         subscriptions = self._fetch_all_subscriptions()
         self.stdout.write("")
 
-        customer_subscriptions = self._build_customer_subscription_map(subscriptions)
+        customer_subscriptions = self._group_subscriptions_by_customer(subscriptions)
         customer_count = len(customer_subscriptions)
         self.stdout.write(f"Processing {customer_count} unique customer(s)")
         self.stdout.write("-" * 50)
 
-        for customer_id, sub in customer_subscriptions.items():
-            self._process_subscription(customer_id, sub, dry_run, results)
+        for customer_id, subs in customer_subscriptions.items():
+            self._process_customer(customer_id, subs, dry_run, results)
 
         self._print_summary(results, dry_run)
 
@@ -173,18 +232,18 @@ class Command(BaseCommand):
             return None
         return product_name.lower().replace("notipus ", "").replace(" plan", "").strip()
 
-    def _process_subscription(
+    def _process_customer(
         self,
         customer_id: str,
-        sub: stripe.Subscription,
+        subs: list[stripe.Subscription],
         dry_run: bool,
         results: dict,
     ) -> None:
-        """Process a single subscription and sync to workspace.
+        """Process a customer's subscriptions and sync to its workspace.
 
         Args:
             customer_id: Stripe customer ID.
-            sub: Stripe Subscription object.
+            subs: The customer's subscriptions (non-empty).
             dry_run: If True, don't make actual changes.
             results: Dictionary to track operation counts.
         """
@@ -196,6 +255,7 @@ class Command(BaseCommand):
                 results["skipped_no_workspace"] += 1
                 return
 
+            sub = self._select_subscription(workspace, subs)
             internal_status = map_stripe_status(sub.status)
             plan_name = self._normalize_plan_name(self._get_product_name(sub))
 
@@ -208,7 +268,9 @@ class Command(BaseCommand):
                 results["synced"] += 1
                 return
 
-            self._apply_changes(workspace, customer_id, changes, dry_run, results)
+            self._apply_changes(
+                workspace, sub, internal_status, plan_name, changes, dry_run, results
+            )
 
         except Exception as e:
             self.stdout.write(
@@ -231,12 +293,29 @@ class Command(BaseCommand):
     def _apply_changes(
         self,
         workspace: Workspace,
-        customer_id: str,
+        sub: stripe.Subscription,
+        status: str,
+        plan: str | None,
         changes: list[str],
         dry_run: bool,
         results: dict,
     ) -> None:
-        """Apply sync changes to workspace."""
+        """Persist the state derived from the selected subscription.
+
+        The state from ``sub`` (the subscription chosen for this workspace)
+        is written directly, so honoring the stored ``stripe_subscription_id``
+        during selection actually takes effect instead of being re-derived
+        from an arbitrary subscription.
+
+        Args:
+            workspace: Workspace to update.
+            sub: The subscription selected for this workspace.
+            status: Internal subscription status derived from ``sub``.
+            plan: Normalized plan name derived from ``sub``, or None.
+            changes: Human-readable change descriptions for output.
+            dry_run: If True, don't make actual changes.
+            results: Dictionary to track operation counts.
+        """
         change_str = ", ".join(changes)
 
         if dry_run:
@@ -246,16 +325,17 @@ class Command(BaseCommand):
             results["synced"] += 1
             return
 
-        if BillingService.sync_workspace_from_stripe(customer_id):
-            self.stdout.write(
-                self.style.SUCCESS(f"  SYNCED: {workspace.name} - {change_str}")
-            )
-            results["synced"] += 1
-        else:
-            self.stdout.write(
-                self.style.ERROR(f"  ERROR: Failed to sync {workspace.name}")
-            )
-            results["errors"] += 1
+        update_data: dict[str, Any] = {"subscription_status": status}
+        if plan:
+            update_data["subscription_plan"] = plan
+        if sub.id:
+            update_data["stripe_subscription_id"] = sub.id
+
+        Workspace.objects.filter(id=workspace.id).update(**update_data)
+        self.stdout.write(
+            self.style.SUCCESS(f"  SYNCED: {workspace.name} - {change_str}")
+        )
+        results["synced"] += 1
 
     def _print_summary(self, results: dict, dry_run: bool) -> None:
         """Print a summary of operations performed.

--- a/app/core/management/commands/sync_stripe_subscriptions.py
+++ b/app/core/management/commands/sync_stripe_subscriptions.py
@@ -16,6 +16,11 @@ from webhooks.services.billing import map_stripe_status
 
 logger = logging.getLogger(__name__)
 
+# Plan keys accepted for Workspace.subscription_plan. Anything a Stripe
+# product name normalizes to that isn't in this set is rejected rather than
+# persisted, since QuerySet.update() bypasses model field-choice validation.
+_VALID_PLAN_KEYS = frozenset(key for key, _label in Workspace.STRIPE_PLANS)
+
 
 class Command(BaseCommand):
     """Django management command to sync Stripe subscriptions globally.
@@ -227,10 +232,31 @@ class Command(BaseCommand):
         return cast("str | None", self._safe_get(product, "name"))
 
     def _normalize_plan_name(self, product_name: str | None) -> str | None:
-        """Convert product name to internal plan name."""
+        """Convert a Stripe product name to a valid internal plan key.
+
+        Rejects anything that doesn't normalize to a known
+        ``Workspace.STRIPE_PLANS`` key (logging a warning) so a drifted
+        product name never reaches ``subscription_plan`` via the
+        validation-bypassing ``QuerySet.update()``.
+
+        Args:
+            product_name: Product display name from the subscription, or None.
+
+        Returns:
+            A valid plan key, or None when absent or unrecognized.
+        """
         if not product_name:
             return None
-        return product_name.lower().replace("notipus ", "").replace(" plan", "").strip()
+        normalized = (
+            product_name.lower().replace("notipus ", "").replace(" plan", "").strip()
+        )
+        if normalized in _VALID_PLAN_KEYS:
+            return normalized
+        logger.warning(
+            f"Unrecognized plan name {product_name!r} (normalized to "
+            f"{normalized!r}); leaving workspace plan unchanged"
+        )
+        return None
 
     def _process_customer(
         self,
@@ -330,6 +356,12 @@ class Command(BaseCommand):
             update_data["subscription_plan"] = plan
         if sub.id:
             update_data["stripe_subscription_id"] = sub.id
+
+        # Keep the billing cycle anchor in sync (the next renewal timestamp),
+        # matching the model contract; the prior BillingService path wrote it.
+        billing_anchor = self._safe_get(sub, "current_period_end")
+        if billing_anchor is not None:
+            update_data["billing_cycle_anchor"] = billing_anchor
 
         Workspace.objects.filter(id=workspace.id).update(**update_data)
         self.stdout.write(

--- a/tests/test_sync_stripe_subscriptions.py
+++ b/tests/test_sync_stripe_subscriptions.py
@@ -24,6 +24,43 @@ def workspace(db) -> Workspace:
     )
 
 
+def _make_mock_sub(
+    sub_id: str,
+    customer_id: str,
+    status: str,
+    product_name: str | None = None,
+) -> MagicMock:
+    """Build a MagicMock shaped like a Stripe Subscription object.
+
+    Args:
+        sub_id: Subscription id.
+        customer_id: Owning customer id.
+        status: Stripe subscription status.
+        product_name: Product name exposed via items.data[0].price.product,
+            or None to leave items empty.
+
+    Returns:
+        A MagicMock mimicking the attribute access the command performs.
+    """
+    sub = MagicMock()
+    sub.id = sub_id
+    sub.customer = customer_id
+    sub.status = status
+
+    items = MagicMock()
+    if product_name is None:
+        items.data = []
+    else:
+        price = MagicMock()
+        price.product = MagicMock()
+        price.product.name = product_name
+        item = MagicMock()
+        item.price = price
+        items.data = [item]
+    sub.items = items
+    return sub
+
+
 @pytest.fixture
 def mock_subscription_data() -> dict:
     """Create mock subscription data from Stripe API."""
@@ -398,3 +435,91 @@ class TestSyncStripeSubscriptionsCommand:
 
         output = out.getvalue()
         assert "SYNCED" in output or "already in sync" in output
+
+    def test_honors_stored_subscription_id(self, db) -> None:
+        """Verify the stored subscription is chosen over another live one.
+
+        A customer with two active subscriptions (e.g. a plan plus an
+        add-on) must sync from the subscription recorded on the workspace,
+        not from an arbitrary first-seen one.
+        """
+        workspace = Workspace.objects.create(
+            name="Stored Sub Workspace",
+            stripe_customer_id="cus_stored",
+            subscription_status="trial",
+            subscription_plan="pro",
+            stripe_subscription_id="sub_stored",
+        )
+
+        other = _make_mock_sub("sub_other", "cus_stored", "active")
+        stored = _make_mock_sub("sub_stored", "cus_stored", "active")
+
+        mock_response = MagicMock()
+        mock_response.data = [other, stored]  # other is first-seen
+        mock_response.has_more = False
+
+        with patch("stripe.api_key", "sk_test"):
+            with patch("stripe.api_version", "2025-01-01"):
+                with patch("stripe.Account.retrieve") as mock_account:
+                    mock_account.return_value = MagicMock(id="acct_test")
+                    with patch("stripe.Subscription.list") as mock_list:
+                        mock_list.return_value = mock_response
+
+                        out = StringIO()
+                        call_command("sync_stripe_subscriptions", stdout=out)
+
+        workspace.refresh_from_db()
+        assert workspace.subscription_status == "active"
+        # The stored subscription won, so its id is preserved (not "sub_other").
+        assert workspace.stripe_subscription_id == "sub_stored"
+
+    def test_downgrades_workspace_with_only_canceled_subscription(self, db) -> None:
+        """Verify a workspace whose only subscription is canceled downgrades.
+
+        Without status="all" the canceled subscription is never fetched and
+        the workspace stays "active" forever; it must be downgraded instead.
+        """
+        workspace = Workspace.objects.create(
+            name="Canceled Workspace",
+            stripe_customer_id="cus_canceled",
+            subscription_status="active",
+            subscription_plan="pro",
+        )
+
+        canceled = _make_mock_sub("sub_canceled", "cus_canceled", "canceled")
+
+        mock_response = MagicMock()
+        mock_response.data = [canceled]
+        mock_response.has_more = False
+
+        with patch("stripe.api_key", "sk_test"):
+            with patch("stripe.api_version", "2025-01-01"):
+                with patch("stripe.Account.retrieve") as mock_account:
+                    mock_account.return_value = MagicMock(id="acct_test")
+                    with patch("stripe.Subscription.list") as mock_list:
+                        mock_list.return_value = mock_response
+
+                        out = StringIO()
+                        call_command("sync_stripe_subscriptions", stdout=out)
+
+        workspace.refresh_from_db()
+        assert workspace.subscription_status == "cancelled"
+        assert workspace.subscription_status != "active"
+
+    def test_fetches_subscriptions_with_status_all(self, workspace: Workspace) -> None:
+        """Verify the Stripe list call passes status="all"."""
+        mock_response = MagicMock()
+        mock_response.data = []
+        mock_response.has_more = False
+
+        with patch("stripe.api_key", "sk_test"):
+            with patch("stripe.api_version", "2025-01-01"):
+                with patch("stripe.Account.retrieve") as mock_account:
+                    mock_account.return_value = MagicMock(id="acct_test")
+                    with patch("stripe.Subscription.list") as mock_list:
+                        mock_list.return_value = mock_response
+
+                        out = StringIO()
+                        call_command("sync_stripe_subscriptions", stdout=out)
+
+        assert mock_list.call_args.kwargs["status"] == "all"

--- a/tests/test_sync_stripe_subscriptions.py
+++ b/tests/test_sync_stripe_subscriptions.py
@@ -8,6 +8,7 @@ from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+import stripe
 from core.models import Workspace
 from django.core.management import call_command
 from webhooks.services.billing import STRIPE_STATUS_MAPPING, BillingService
@@ -24,13 +25,18 @@ def workspace(db) -> Workspace:
     )
 
 
-def _make_mock_sub(
+def _make_stripe_sub(
     sub_id: str,
     customer_id: str,
     status: str,
     product_name: str | None = None,
-) -> MagicMock:
-    """Build a MagicMock shaped like a Stripe Subscription object.
+    current_period_end: int | None = None,
+) -> stripe.Subscription:
+    """Build a real ``stripe.Subscription`` object for the command to parse.
+
+    A genuine Stripe object (not a MagicMock) is used so the command's
+    ``_get_product_name`` / plan-parsing logic is actually exercised;
+    MagicMock's auto-``.get`` would silently short-circuit that path.
 
     Args:
         sub_id: Subscription id.
@@ -38,27 +44,37 @@ def _make_mock_sub(
         status: Stripe subscription status.
         product_name: Product name exposed via items.data[0].price.product,
             or None to leave items empty.
+        current_period_end: Billing anchor timestamp, or None to omit.
 
     Returns:
-        A MagicMock mimicking the attribute access the command performs.
+        A ``stripe.Subscription`` mirroring the API's nested shape.
     """
-    sub = MagicMock()
-    sub.id = sub_id
-    sub.customer = customer_id
-    sub.status = status
+    data: dict = {
+        "id": sub_id,
+        "object": "subscription",
+        "customer": customer_id,
+        "status": status,
+    }
+    if current_period_end is not None:
+        data["current_period_end"] = current_period_end
 
-    items = MagicMock()
     if product_name is None:
-        items.data = []
+        item_data: list = []
     else:
-        price = MagicMock()
-        price.product = MagicMock()
-        price.product.name = product_name
-        item = MagicMock()
-        item.price = price
-        items.data = [item]
-    sub.items = items
-    return sub
+        item_data = [
+            {
+                "price": {
+                    "product": {
+                        "id": "prod_test",
+                        "object": "product",
+                        "name": product_name,
+                    }
+                }
+            }
+        ]
+    data["items"] = {"object": "list", "data": item_data}
+
+    return stripe.Subscription.construct_from(data, "sk_test")
 
 
 @pytest.fixture
@@ -447,12 +463,20 @@ class TestSyncStripeSubscriptionsCommand:
             name="Stored Sub Workspace",
             stripe_customer_id="cus_stored",
             subscription_status="trial",
-            subscription_plan="pro",
+            subscription_plan="basic",
             stripe_subscription_id="sub_stored",
         )
 
-        other = _make_mock_sub("sub_other", "cus_stored", "active")
-        stored = _make_mock_sub("sub_stored", "cus_stored", "active")
+        other = _make_stripe_sub(
+            "sub_other", "cus_stored", "active", "Notipus Enterprise Plan"
+        )
+        stored = _make_stripe_sub(
+            "sub_stored",
+            "cus_stored",
+            "active",
+            "Notipus Pro Plan",
+            current_period_end=1710000000,
+        )
 
         mock_response = MagicMock()
         mock_response.data = [other, stored]  # other is first-seen
@@ -470,8 +494,10 @@ class TestSyncStripeSubscriptionsCommand:
 
         workspace.refresh_from_db()
         assert workspace.subscription_status == "active"
-        # The stored subscription won, so its id is preserved (not "sub_other").
+        # The stored subscription won, so its plan/id/anchor win (not "sub_other").
         assert workspace.stripe_subscription_id == "sub_stored"
+        assert workspace.subscription_plan == "pro"
+        assert workspace.billing_cycle_anchor == 1710000000
 
     def test_downgrades_workspace_with_only_canceled_subscription(self, db) -> None:
         """Verify a workspace whose only subscription is canceled downgrades.
@@ -486,7 +512,9 @@ class TestSyncStripeSubscriptionsCommand:
             subscription_plan="pro",
         )
 
-        canceled = _make_mock_sub("sub_canceled", "cus_canceled", "canceled")
+        canceled = _make_stripe_sub(
+            "sub_canceled", "cus_canceled", "canceled", "Notipus Pro Plan"
+        )
 
         mock_response = MagicMock()
         mock_response.data = [canceled]
@@ -505,6 +533,43 @@ class TestSyncStripeSubscriptionsCommand:
         workspace.refresh_from_db()
         assert workspace.subscription_status == "cancelled"
         assert workspace.subscription_status != "active"
+
+    def test_invalid_plan_name_is_not_persisted(self, db) -> None:
+        """Verify an unrecognized plan name is skipped, not written.
+
+        ``QuerySet.update()`` bypasses field-choice validation, so a Stripe
+        product name that doesn't normalize to a known plan key must leave
+        the existing plan intact while other state still syncs.
+        """
+        workspace = Workspace.objects.create(
+            name="Bad Plan Workspace",
+            stripe_customer_id="cus_badplan",
+            subscription_status="trial",
+            subscription_plan="basic",
+        )
+
+        sub = _make_stripe_sub(
+            "sub_bad", "cus_badplan", "active", "Notipus Mystery Plan"
+        )
+
+        mock_response = MagicMock()
+        mock_response.data = [sub]
+        mock_response.has_more = False
+
+        with patch("stripe.api_key", "sk_test"):
+            with patch("stripe.api_version", "2025-01-01"):
+                with patch("stripe.Account.retrieve") as mock_account:
+                    mock_account.return_value = MagicMock(id="acct_test")
+                    with patch("stripe.Subscription.list") as mock_list:
+                        mock_list.return_value = mock_response
+
+                        out = StringIO()
+                        call_command("sync_stripe_subscriptions", stdout=out)
+
+        workspace.refresh_from_db()
+        # Status still synced, but the garbage plan was NOT persisted.
+        assert workspace.subscription_status == "active"
+        assert workspace.subscription_plan == "basic"
 
     def test_fetches_subscriptions_with_status_all(self, workspace: Workspace) -> None:
         """Verify the Stripe list call passes status="all"."""


### PR DESCRIPTION
## Summary

`sync_stripe_subscriptions` had two correctness bugs, both fixed here (only the command file + its tests are touched):

1. **Ignored the workspace's stored `stripe_subscription_id`.** The command collapsed each customer to one arbitrarily chosen subscription (first-seen wins when both are live) and delegated the write to `BillingService.sync_workspace_from_stripe`, which independently re-selects and also ignores the stored id. For a customer with a duplicate/add-on subscription this could overwrite the workspace's plan with the *wrong* subscription, contradicting the semantics documented on `Workspace.stripe_subscription_id`. Now all of a customer's subscriptions are grouped and the one matching the stored id is preferred, falling back to the live-first heuristic only when no id is stored or it no longer matches.

2. **Listed subscriptions without `status="all"`.** Canceled subscriptions were never fetched, so a workspace whose only subscription was canceled was silently skipped and stayed `active` locally forever. The list call now passes `status="all"`, and the command writes the selected subscription's state directly so such a workspace is correctly downgraded.

Dry-run behavior and the `--dry-run` flag are preserved.

## Test plan

Added `tests/test_sync_stripe_subscriptions.py` cases (Stripe API mocked) proving: the stored subscription is chosen even when another live subscription exists; a customer whose only subscription is canceled downgrades the workspace instead of staying active; and `status="all"` is passed to the list call.

- `uv run ruff check --fix . && uv run ruff format .` — pass
- `uv run mypy app/` — pass (no issues, 115 source files)
- `uv run pytest -q` — pass (1487 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)