### PR TITLE
fix: anchor billing cycle to subscription current_period_end on invoice paid

### DIFF
--- a/app/webhooks/services/billing.py
+++ b/app/webhooks/services/billing.py
@@ -554,6 +554,10 @@ class BillingService:
         per-customer lock so a late-retried paid-invoice event can't
         resurrect a workspace whose subscription has since been deleted
         (sync sees the canceled subscription and restores "cancelled").
+        The sync is also what advances billing_cycle_anchor: it reads the
+        subscription's current_period_end (the next renewal), whereas the
+        invoice's own period_end is the just-billed period's end, so the
+        anchor is intentionally not written from the invoice here.
 
         Args:
             invoice: Invoice data from Stripe webhook.
@@ -608,9 +612,14 @@ class BillingService:
                 update_data["subscription_status"] = "active"
                 update_data["payment_method_added"] = True
 
-            period_end = invoice.get("period_end")
-            if period_end:
-                update_data["billing_cycle_anchor"] = period_end
+            # Deliberately do NOT write billing_cycle_anchor here. The
+            # invoice's top-level ``period_end`` is the end of the
+            # just-billed period (≈ now for a renewal), not the NEXT
+            # renewal that _extract_billing_anchor's contract requires;
+            # writing it would regress the anchor a subscription handler
+            # already advanced to the subscription's current_period_end.
+            # The sync below reads the subscription and sets the anchor
+            # from current_period_end, keeping it on the next renewal.
 
             if update_data:
                 Workspace.objects.filter(id=workspace.id).update(**update_data)

--- a/tests/core/tests_services.py
+++ b/tests/core/tests_services.py
@@ -266,7 +266,10 @@ class BillingServiceTest(TestCase):
         self.workspace.refresh_from_db()
         self.assertEqual(self.workspace.subscription_status, "active")
         self.assertTrue(self.workspace.payment_method_added)
-        self.assertEqual(self.workspace.billing_cycle_anchor, 1234567890)
+        # The invoice's period_end (the just-billed period) is NOT written
+        # as the anchor; the sync (mocked here) sets it from the
+        # subscription's current_period_end (next renewal).
+        self.assertNotEqual(self.workspace.billing_cycle_anchor, 1234567890)
 
         mock_logger.info.assert_called_once_with(
             "Applied payment_success for customer cus_test123 (amount_paid=2900)"

--- a/tests/core/tests_services.py
+++ b/tests/core/tests_services.py
@@ -254,6 +254,14 @@ class BillingServiceTest(TestCase):
         Workspace.objects.filter(id=self.workspace.id).update(
             stripe_subscription_id="sub_test123"
         )
+        # Seed a known anchor (a future renewal a subscription handler
+        # would have written) so we can assert the invoice handler leaves
+        # it untouched — the sync is what advances it, and it's mocked.
+        Workspace.objects.filter(id=self.workspace.id).update(
+            billing_cycle_anchor=1300000000
+        )
+        anchor_before = Workspace.objects.get(id=self.workspace.id).billing_cycle_anchor
+
         invoice_data = {
             "customer": "cus_test123",
             "subscription": "sub_test123",
@@ -266,10 +274,10 @@ class BillingServiceTest(TestCase):
         self.workspace.refresh_from_db()
         self.assertEqual(self.workspace.subscription_status, "active")
         self.assertTrue(self.workspace.payment_method_added)
-        # The invoice's period_end (the just-billed period) is NOT written
-        # as the anchor; the sync (mocked here) sets it from the
-        # subscription's current_period_end (next renewal).
-        self.assertNotEqual(self.workspace.billing_cycle_anchor, 1234567890)
+        # With sync mocked, the handler itself writes nothing into the
+        # anchor: it must be exactly what it was before the call (not the
+        # invoice's period_end, and not any other value).
+        self.assertEqual(self.workspace.billing_cycle_anchor, anchor_before)
 
         mock_logger.info.assert_called_once_with(
             "Applied payment_success for customer cus_test123 (amount_paid=2900)"

--- a/tests/test_billing_anchor.py
+++ b/tests/test_billing_anchor.py
@@ -1,0 +1,148 @@
+"""Tests for billing_cycle_anchor on paid invoices.
+
+Regression coverage for the invoice-paid handlers anchoring the billing
+cycle on the wrong timestamp. For a renewal ``invoice.paid``, the
+invoice's top-level ``period_end`` is the end of the just-billed period
+(≈ now), not the NEXT renewal. Per ``_extract_billing_anchor``'s
+contract, the anchor must track the subscription's
+``current_period_end`` (the next renewal), which the post-write sync
+supplies. These tests prove the stored anchor ends up on the next
+renewal, not the billed-period end.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core.models import Workspace
+from webhooks.services.billing import BillingService
+
+CUSTOMER_ID = "cus_anchor123"
+SUBSCRIPTION_ID = "sub_primary"
+
+# The just-billed period's end, sent as the invoice's top-level
+# period_end. This is roughly "now" for a renewal and must NOT become
+# the billing anchor.
+BILLED_PERIOD_END = 1704067200
+# The subscription's current_period_end: the NEXT renewal, ~30 days
+# after the billed period ended. This is the correct anchor.
+NEXT_RENEWAL = 1706745600
+
+
+@pytest.fixture
+def workspace(db: None) -> Workspace:
+    """Create a workspace whose billing rides on SUBSCRIPTION_ID.
+
+    The stored anchor starts on the just-billed period so a test can
+    observe whether the handler leaves it there (bug) or advances it to
+    the next renewal (fixed).
+
+    Args:
+        db: pytest-django database fixture.
+
+    Returns:
+        Persisted Workspace linked to the Stripe customer and subscription.
+    """
+    return Workspace.objects.create(
+        name="Anchor Workspace",
+        stripe_customer_id=CUSTOMER_ID,
+        stripe_subscription_id=SUBSCRIPTION_ID,
+        subscription_status="active",
+        subscription_plan="pro",
+        billing_cycle_anchor=BILLED_PERIOD_END,
+    )
+
+
+def _mock_stripe_api(subscriptions: list[dict[str, Any]]) -> Any:
+    """Patch billing.StripeAPI to return the given subscriptions.
+
+    Args:
+        subscriptions: Subscription dicts the fake API returns for
+            ``get_customer_subscriptions``.
+
+    Returns:
+        Context manager patching webhooks.services.billing.StripeAPI.
+    """
+    mock_api = MagicMock()
+    mock_api.get_customer_subscriptions.return_value = subscriptions
+    return patch("webhooks.services.billing.StripeAPI", return_value=mock_api)
+
+
+def _renewal_invoice() -> dict[str, Any]:
+    """Build a paid renewal invoice for the workspace's subscription.
+
+    Its top-level ``period_end`` is the just-billed period's end — the
+    value the old code wrongly wrote as the anchor.
+
+    Returns:
+        Invoice payload as delivered by Stripe's invoice.paid webhook.
+    """
+    return {
+        "customer": CUSTOMER_ID,
+        "subscription": SUBSCRIPTION_ID,
+        "amount_paid": 2900,
+        "period_end": BILLED_PERIOD_END,
+    }
+
+
+def _active_subscription() -> dict[str, Any]:
+    """Build the live subscription the sync reads back from Stripe.
+
+    Its ``current_period_end`` is the next renewal — the correct anchor.
+
+    Returns:
+        Subscription dict as returned by ``get_customer_subscriptions``.
+    """
+    return {
+        "id": SUBSCRIPTION_ID,
+        "status": "active",
+        "current_period_end": NEXT_RENEWAL,
+    }
+
+
+class TestInvoicePaidBillingAnchor:
+    """The paid-invoice handlers anchor on the subscription's next renewal."""
+
+    @pytest.mark.django_db
+    def test_invoice_paid_anchors_on_subscription_next_renewal(
+        self, workspace: Workspace
+    ) -> None:
+        """After a renewal invoice.paid, the stored anchor is the
+        subscription's current_period_end (next renewal), not the
+        invoice's just-billed period_end."""
+        with _mock_stripe_api([_active_subscription()]):
+            BillingService.handle_invoice_paid(_renewal_invoice())
+
+        workspace.refresh_from_db()
+        assert workspace.billing_cycle_anchor == NEXT_RENEWAL
+        assert workspace.billing_cycle_anchor != BILLED_PERIOD_END
+
+    @pytest.mark.django_db
+    def test_payment_success_anchors_on_subscription_next_renewal(
+        self, workspace: Workspace
+    ) -> None:
+        """handle_payment_success shares the same handler, so it too
+        advances the anchor to the next renewal rather than the billed
+        period end."""
+        with _mock_stripe_api([_active_subscription()]):
+            BillingService.handle_payment_success(_renewal_invoice())
+
+        workspace.refresh_from_db()
+        assert workspace.billing_cycle_anchor == NEXT_RENEWAL
+
+    @pytest.mark.django_db
+    def test_invoice_paid_does_not_regress_a_future_anchor(
+        self, workspace: Workspace
+    ) -> None:
+        """A subscription handler that already advanced the anchor to the
+        next renewal must not be regressed by a later invoice.paid whose
+        period_end is the just-billed (earlier) period."""
+        Workspace.objects.filter(id=workspace.id).update(
+            billing_cycle_anchor=NEXT_RENEWAL
+        )
+
+        with _mock_stripe_api([_active_subscription()]):
+            BillingService.handle_invoice_paid(_renewal_invoice())
+
+        workspace.refresh_from_db()
+        assert workspace.billing_cycle_anchor == NEXT_RENEWAL

--- a/tests/test_billing_anchor.py
+++ b/tests/test_billing_anchor.py
@@ -136,12 +136,22 @@ class TestInvoicePaidBillingAnchor:
     ) -> None:
         """A subscription handler that already advanced the anchor to the
         next renewal must not be regressed by a later invoice.paid whose
-        period_end is the just-billed (earlier) period."""
+        period_end is the just-billed (earlier) period.
+
+        The sync is deliberately made a no-op here (Stripe returns no
+        subscriptions) so it cannot repair the anchor. That isolates the
+        invoice handler's own writes: if it regressed the anchor to the
+        invoice's period_end, the stored value would drop from the
+        pre-set next renewal and this test would fail.
+        """
         Workspace.objects.filter(id=workspace.id).update(
             billing_cycle_anchor=NEXT_RENEWAL
         )
 
-        with _mock_stripe_api([_active_subscription()]):
+        # No live subscription for the sync to read: sync_workspace_from_stripe
+        # returns without writing an anchor, so only the invoice handler
+        # could touch billing_cycle_anchor.
+        with _mock_stripe_api([]):
             BillingService.handle_invoice_paid(_renewal_invoice())
 
         workspace.refresh_from_db()

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -850,10 +850,12 @@ class TestBillingServiceWebhooks:
 
             BillingService.handle_invoice_paid(invoice_data)
 
+            # The invoice's period_end (the just-billed period's end) is
+            # NOT written as the billing anchor; the sync below sets it
+            # from the subscription's current_period_end (next renewal).
             mock_filter.return_value.update.assert_called_once_with(
                 subscription_status="active",
                 payment_method_added=True,
-                billing_cycle_anchor=1704067200,
             )
             mock_sync.assert_called_once_with("cus_test123")
 


### PR DESCRIPTION
## Summary

The invoice-paid handlers `_apply_paid_subscription_invoice` (used by `handle_payment_success` and `handle_invoice_paid`) wrote the invoice's top-level `period_end` as `billing_cycle_anchor`. For a **renewal** invoice, `period_end` is the end of the just-billed period (≈ now), **not** the next renewal — so it regressed the anchor that a subscription handler had just advanced. This violated `_extract_billing_anchor`'s documented contract that every write site uses the subscription's `current_period_end` (the next renewal).

**Fix:** stop writing the anchor from the invoice in these handlers. `_apply_paid_subscription_invoice` already calls `sync_workspace_from_stripe` under the per-customer lock immediately after the direct write, and that sync sets `billing_cycle_anchor` from the subscription's `current_period_end`. So the anchor now always tracks the next renewal. Activation (`subscription_status="active"`, `payment_method_added=True`) and all other billing logic (dispatch gating, entitlement, one-off/$0 filtering, sync-lock) are unchanged.

Only `app/webhooks/services/billing.py` changed (plus tests).

## Existing tests updated

- `tests/test_stripe_billing.py::test_handle_invoice_paid_activates_matching_subscription` — asserted the old `billing_cycle_anchor=<invoice period_end>` in the direct write; now asserts the anchor is not written by the handler (the sync sets it).
- `tests/core/tests_services.py::test_handle_payment_success` — asserted the invoice `period_end` became the anchor; now asserts the invoice `period_end` is not written as the anchor (sync is mocked in that test).

## New tests

`tests/test_billing_anchor.py` — end-to-end (real workspace + faked `StripeAPI`) proof that after a renewal `invoice.paid`/`payment_succeeded`, the stored anchor equals the subscription's `current_period_end` (next renewal), not the invoice's billed-period end, and that a future anchor is not regressed.

## Test plan

- `uv run ruff check --fix . && uv run ruff format .` — clean
- `uv run mypy app/` — Success, no issues
- `uv run pytest -q` — 1487 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)