### PR TITLE
Scope email verification: trust Slack SSO, verify passkey users (+ fix passkey 500)

### DIFF
--- a/app/core/views/webauthn.py
+++ b/app/core/views/webauthn.py
@@ -7,6 +7,7 @@ import json
 import logging
 from typing import Any, cast
 
+from allauth.account.utils import setup_user_email
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
@@ -136,8 +137,10 @@ def webauthn_authenticate_complete(request: HttpRequest) -> JsonResponse:
         user = webauthn_service.verify_authentication(credential_data)
 
         if user:
-            # Log the user in
-            login(request, user)
+            # Log the user in. The backend must be named explicitly:
+            # with multiple AUTHENTICATION_BACKENDS configured, a bare
+            # login() raises and the passkey flow 500s.
+            login(request, user, backend="django.contrib.auth.backends.ModelBackend")
             return JsonResponse(
                 {
                     "success": True,
@@ -263,8 +266,20 @@ def webauthn_signup_complete(request: HttpRequest) -> JsonResponse:
         )
 
         if user:
-            # Log the user in
-            login(request, user)
+            # Log the user in (explicit backend - see authenticate_complete)
+            login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+
+            # Passkey signups are the one flow that needs outgoing email:
+            # unlike Slack SSO (whose emails are provider-verified), a
+            # passkey user typed their address unverified. Register it
+            # with allauth and send the verification email. Never fail
+            # the signup over email delivery.
+            try:
+                email_address = setup_user_email(request, user, [])
+                if email_address is not None:
+                    email_address.send_confirmation(request, signup=True)
+            except Exception:
+                logger.exception("Failed to send verification email for passkey signup")
 
             return JsonResponse(
                 {

--- a/app/core/views/webauthn.py
+++ b/app/core/views/webauthn.py
@@ -20,6 +20,13 @@ from ..services.webauthn import WebAuthnService
 
 logger = logging.getLogger(__name__)
 
+# Backend recorded on passkey-authenticated sessions. login() requires an
+# explicit backend when multiple AUTHENTICATION_BACKENDS are configured
+# (a bare call raises and the flow 500s). Deliberately a fixed constant
+# rather than AUTHENTICATION_BACKENDS[0]: WebAuthn verification is our
+# own, and reordering settings must not change its attribution.
+PASSKEY_LOGIN_BACKEND = "django.contrib.auth.backends.ModelBackend"
+
 
 @csrf_exempt
 @require_http_methods(["POST"])
@@ -137,10 +144,8 @@ def webauthn_authenticate_complete(request: HttpRequest) -> JsonResponse:
         user = webauthn_service.verify_authentication(credential_data)
 
         if user:
-            # Log the user in. The backend must be named explicitly:
-            # with multiple AUTHENTICATION_BACKENDS configured, a bare
-            # login() raises and the passkey flow 500s.
-            login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+            # Log the user in
+            login(request, user, backend=PASSKEY_LOGIN_BACKEND)
             return JsonResponse(
                 {
                     "success": True,
@@ -266,8 +271,8 @@ def webauthn_signup_complete(request: HttpRequest) -> JsonResponse:
         )
 
         if user:
-            # Log the user in (explicit backend - see authenticate_complete)
-            login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+            # Log the user in
+            login(request, user, backend=PASSKEY_LOGIN_BACKEND)
 
             # Passkey signups are the one flow that needs outgoing email:
             # unlike Slack SSO (whose emails are provider-verified), a

--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -391,6 +391,12 @@ SOCIALACCOUNT_PROVIDERS = {
         },
         "SCOPE": ["openid", "profile", "email"],
         "AUTH_PARAMS": {"approval_prompt": "force"},
+        # Slack workspace accounts require a verified email, so emails
+        # from Slack SSO are trusted as verified. This skips the
+        # verification email for SSO signups (outgoing email is only
+        # needed for passkey signups) and lets
+        # SOCIALACCOUNT_EMAIL_AUTHENTICATION match existing accounts.
+        "VERIFIED_EMAIL": True,
     },
     "shopify": {
         "APP": {

--- a/tests/test_email_verification_scoping.py
+++ b/tests/test_email_verification_scoping.py
@@ -13,7 +13,7 @@ from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
-from django.test import Client
+from django.test import Client, override_settings
 
 
 class TestSlackEmailTrust:
@@ -35,8 +35,14 @@ class TestSlackEmailTrust:
 
 
 @pytest.mark.django_db
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 class TestPasskeySignupEmailVerification:
-    """Test that passkey signups register and verify their email."""
+    """Test that passkey signups register and verify their email.
+
+    EMAIL_BACKEND is pinned to locmem explicitly so the mail.outbox
+    assertions don't depend on pytest-django's implicit test-environment
+    backend swap (test_settings itself configures the console backend).
+    """
 
     def _complete_signup(self, user: User) -> tuple[int, dict]:
         """POST a signup completion with the WebAuthn service mocked.

--- a/tests/test_email_verification_scoping.py
+++ b/tests/test_email_verification_scoping.py
@@ -13,7 +13,7 @@ from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
-from django.test import Client, override_settings
+from django.test import Client
 
 
 class TestSlackEmailTrust:
@@ -35,7 +35,6 @@ class TestSlackEmailTrust:
 
 
 @pytest.mark.django_db
-@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 class TestPasskeySignupEmailVerification:
     """Test that passkey signups register and verify their email.
 
@@ -43,6 +42,11 @@ class TestPasskeySignupEmailVerification:
     assertions don't depend on pytest-django's implicit test-environment
     backend swap (test_settings itself configures the console backend).
     """
+
+    @pytest.fixture(autouse=True)
+    def _locmem_email_backend(self, settings) -> None:
+        """Pin the locmem email backend for reliable outbox assertions."""
+        settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
     def _complete_signup(self, user: User) -> tuple[int, dict]:
         """POST a signup completion with the WebAuthn service mocked.

--- a/tests/test_email_verification_scoping.py
+++ b/tests/test_email_verification_scoping.py
@@ -1,0 +1,131 @@
+"""Tests for email-verification scoping across auth methods.
+
+Product rule: outgoing email is only needed for passkey signups. Slack
+SSO users' emails are trusted as verified (Slack requires a verified
+email for workspace accounts), so SSO must neither depend on nor
+trigger verification email delivery.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from allauth.account.models import EmailAddress
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core import mail
+from django.test import Client
+
+
+class TestSlackEmailTrust:
+    """Test that Slack SSO emails are treated as verified."""
+
+    def test_slack_provider_trusts_emails(self) -> None:
+        """Test that the Slack provider declares VERIFIED_EMAIL.
+
+        Without this, allauth records SSO emails unverified and sends a
+        verification email that SSO users must never depend on - and
+        SOCIALACCOUNT_EMAIL_AUTHENTICATION cannot match existing
+        accounts by email.
+        """
+        assert settings.SOCIALACCOUNT_PROVIDERS["slack"]["VERIFIED_EMAIL"] is True
+
+    def test_shopify_provider_does_not_trust_emails(self) -> None:
+        """Test that email trust is scoped to Slack, not all providers."""
+        assert "VERIFIED_EMAIL" not in settings.SOCIALACCOUNT_PROVIDERS["shopify"]
+
+
+@pytest.mark.django_db
+class TestPasskeySignupEmailVerification:
+    """Test that passkey signups register and verify their email."""
+
+    def _complete_signup(self, user: User) -> tuple[int, dict]:
+        """POST a signup completion with the WebAuthn service mocked.
+
+        Args:
+            user: The user the mocked service returns as newly created.
+
+        Returns:
+            Tuple of (status_code, parsed JSON body).
+        """
+        client = Client()
+        with patch(
+            "core.views.webauthn.WebAuthnService.complete_signup_registration",
+            return_value=user,
+        ):
+            response = client.post(
+                "/webauthn/signup/complete/",
+                data='{"credential": {"challenge": "x"}, '
+                '"username": "pat", "email": "pat@example.com"}',
+                content_type="application/json",
+            )
+        return response.status_code, response.json()
+
+    def test_signup_sends_verification_email(self) -> None:
+        """Test that completing a passkey signup emails a verification link."""
+        user = User.objects.create_user(
+            username="pat", email="pat@example.com", password=None
+        )
+
+        status, body = self._complete_signup(user)
+
+        assert status == 200
+        assert body["success"] is True
+        assert len(mail.outbox) == 1
+        assert "pat@example.com" in mail.outbox[0].to
+
+    def test_signup_registers_unverified_email_address(self) -> None:
+        """Test that the email lands in allauth as unverified.
+
+        Unlike Slack SSO (provider-verified), a passkey user typed the
+        address themselves - it must be recorded unverified until the
+        confirmation link is clicked.
+        """
+        user = User.objects.create_user(
+            username="pat", email="pat@example.com", password=None
+        )
+
+        self._complete_signup(user)
+
+        email_address = EmailAddress.objects.get(user=user)
+        assert email_address.email == "pat@example.com"
+        assert email_address.verified is False
+
+    def test_passkey_login_succeeds_with_multiple_auth_backends(self) -> None:
+        """Test that passkey authentication logs in without a 500.
+
+        With ModelBackend and allauth's backend both configured, a bare
+        login() raises "must provide the backend argument" - which the
+        broad except turned into a 500 for every passkey login/signup.
+        """
+        user = User.objects.create_user(
+            username="pat", email="pat@example.com", password=None
+        )
+        client = Client()
+
+        with patch(
+            "core.views.webauthn.WebAuthnService.verify_authentication",
+            return_value=user,
+        ):
+            response = client.post(
+                "/webauthn/authenticate/complete/",
+                data='{"credential": {"challenge": "x"}}',
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    def test_email_failure_does_not_fail_signup(self) -> None:
+        """Test that a broken email backend never blocks account creation."""
+        user = User.objects.create_user(
+            username="pat", email="pat@example.com", password=None
+        )
+
+        with patch(
+            "core.views.webauthn.setup_user_email",
+            side_effect=RuntimeError("smtp down"),
+        ):
+            status, body = self._complete_signup(user)
+
+        assert status == 200
+        assert body["success"] is True


### PR DESCRIPTION
## Summary

Product rule (Viktor): **outgoing email is only needed for passkey users, not SSO** — an email arriving via Slack login can be assumed verified, since Slack requires a verified email for workspace accounts.

### Slack SSO → trusted
- `VERIFIED_EMAIL: True` on the Slack provider: allauth records SSO emails as verified, sends no verification email, and `SOCIALACCOUNT_EMAIL_AUTHENTICATION` can now match existing accounts by email (it only matches *verified* addresses — previously broken).
- Shopify deliberately stays untrusted.

### Passkey signup → verified by email
- Passkey signups previously created **no** allauth `EmailAddress` record and sent nothing — the one flow that actually needs email verification didn't attempt it. Now the address is registered (unverified) and a confirmation email is sent via allauth (`setup_user_email` + `send_confirmation`; the modern allauth 65.x API — `send_email_confirmation` no longer exists). Email delivery failure never blocks the signup.

### Drive-by production bug found by the new tests
`login(request, user)` without a `backend=` argument **raises when multiple `AUTHENTICATION_BACKENDS` are configured** — which this app has (ModelBackend + allauth). The broad `except` handlers turned that into a 500, meaning every passkey login and passkey signup completion has been failing. Both call sites now pass the backend explicitly, with regression tests.

## Test plan

- [x] `uv run pytest` — 1648 passed (6 new tests: provider trust scoping, verification email sent + recorded unverified, email-failure resilience, passkey login/signup no longer 500)
- [x] `uv run mypy app/` clean, ruff clean
- [ ] Production still needs a real `EMAIL_BACKEND` for the passkey verification mail to actually deliver (console backend today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)