### PR TITLE
perf: precompile bytecode and skip uv run for ~3x faster container boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@
 FROM python:3.14-slim
 
 # Set environment variables
-ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+# Precompile dependencies to .pyc at build time so container boots skip
+# bytecode compilation (~1.1s saved per cold start)
+ENV UV_COMPILE_BYTECODE=1
 
 # Git SHA for Sentry release tracking (passed as build arg)
 ARG GIT_SHA=unknown
@@ -50,10 +52,15 @@ RUN mkdir -p static/dist/fonts static/webfonts && \
 # Collect static files
 RUN uv run --no-dev python manage.py collectstatic --noinput
 
+# Precompile application code to bytecode (deps are handled by UV_COMPILE_BYTECODE)
+RUN /app/.venv/bin/python -m compileall -q -x '(\.venv|node_modules)' /app
+
 # Port that the application will use
 EXPOSE 8080
 
 # Command to start the server
+# Invoke uvicorn from the venv directly: `uv run` re-validates the lockfile and
+# environment on every boot, which costs startup time and can mutate the env
 # --proxy-headers: Use X-Forwarded-* headers for client IP (from Fly.io/Cloudflare)
 # --forwarded-allow-ips='*': Trust proxy headers from any IP (we're behind Fly.io)
-CMD ["uv", "run", "--no-dev", "uvicorn", "--host", "0.0.0.0", "--port", "8080", "--lifespan", "off", "--proxy-headers", "--forwarded-allow-ips", "*", "django_notipus.asgi:application"]
+CMD ["/app/.venv/bin/uvicorn", "--host", "0.0.0.0", "--port", "8080", "--lifespan", "off", "--proxy-headers", "--forwarded-allow-ips", "*", "django_notipus.asgi:application"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,14 +107,14 @@ services:
   migration:
     <<: *django-service
     container_name: notipus_migration
-    command: ["uv", "run", "python", "manage.py", "migrate"]
+    command: ["/app/.venv/bin/python", "manage.py", "migrate"]
     depends_on: *app-dependencies
     restart: "no"  # Migration should run once and exit
 
   django:
     <<: *django-service
     container_name: notipus_django
-    command: ["uv", "run", "uvicorn", "--host", "0.0.0.0", "--port", "8080", "--workers", "3", "--lifespan", "off", "django_notipus.asgi:application"]
+    command: ["/app/.venv/bin/uvicorn", "--host", "0.0.0.0", "--port", "8080", "--workers", "3", "--lifespan", "off", "django_notipus.asgi:application"]
     ports:
       - "80:8080"
       - "8080:8080"
@@ -124,7 +124,7 @@ services:
         condition: service_completed_successfully
     healthcheck:
       <<: *healthcheck-defaults
-      test: ["CMD", "uv", "run", "python", "manage.py", "check"]
+      test: ["CMD", "/app/.venv/bin/python", "manage.py", "check"]
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

Container cold starts were spending ~1.1s recompiling all Python source to bytecode on every boot: `PYTHONDONTWRITEBYTECODE=1` suppressed the `.pyc` cache and `uv sync` doesn't compile bytecode by default, so the work was redone from scratch each start. Measured ASGI app import inside the built image drops from **~1.5s to 0.6s**.

## Changes

- **Dockerfile**: set `UV_COMPILE_BYTECODE=1` (dependencies compile to `.pyc` at build time), drop `PYTHONDONTWRITEBYTECODE=1`, and run `compileall` over the application code after `collectstatic`.
- **Dockerfile CMD**: invoke `/app/.venv/bin/uvicorn` directly instead of through `uv run`, which re-validates the lockfile/environment on every boot.
- **docker-compose.yml**: same switch for the `django`, `migration`, and healthcheck commands. This also fixes a latent bug: these ran `uv run` *without* `--no-dev` against an image synced `--no-dev`, so uv would try to install dev dependencies at container startup.

The dev override (`docker-compose.dev.yml`) replaces the command with the auto-reload dev server and is unaffected.

## Verification

- `docker build` succeeds; `.pyc` present for site-packages and app code in the image
- Timed `from django_notipus.asgi import application` in the container: 0.60s (was ~1.5s + `uv run` overhead)
- `docker compose config --quiet` passes

Trade-off: bytecode alongside source adds some image size — the standard exchange for fast cold starts on on-demand Fly.io machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)