### PR TITLE
fix: repair icon fonts and clean up UI/UX issues found in visual review

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,7 @@ COPY postcss.config.js /app/
 COPY ./app/ .
 
 # Build frontend assets
-RUN mkdir -p static/dist/fonts static/webfonts && \
-    cp -r /app/node_modules/@fortawesome/fontawesome-free/webfonts/* static/webfonts/ && \
+RUN mkdir -p static/dist/fonts && \
     cp /app/node_modules/@tabler/icons-webfont/dist/fonts/tabler-icons.woff2 static/dist/fonts/ && \
     cp /app/node_modules/@tabler/icons-webfont/dist/fonts/tabler-icons.woff static/dist/fonts/ && \
     cp /app/node_modules/@tabler/icons-webfont/dist/fonts/tabler-icons.ttf static/dist/fonts/ && \

--- a/app/core/context_processors.py
+++ b/app/core/context_processors.py
@@ -25,9 +25,15 @@ def workspace_role(request: HttpRequest) -> dict[str, Any]:
     if user is None or not user.is_authenticated:
         return {}
 
-    member = (
-        WorkspaceMember.objects.filter(user=request.user, is_active=True)
-        .only("role")
-        .first()
-    )
+    # Permission decorators already attach the resolved membership on
+    # most workspace views — reuse it instead of querying again.
+    member = getattr(request, "workspace_member", None)
+    if member is not None:
+        return {"nav_workspace_role": member.role}
+
+    memberships = WorkspaceMember.objects.filter(user=user, is_active=True)
+    workspace = getattr(request, "workspace", None)
+    if workspace is not None:
+        memberships = memberships.filter(workspace=workspace)
+    member = memberships.only("role").first()
     return {"nav_workspace_role": member.role if member else None}

--- a/app/core/context_processors.py
+++ b/app/core/context_processors.py
@@ -1,0 +1,33 @@
+"""Template context processors for core app."""
+
+from typing import Any
+
+from django.http import HttpRequest
+
+from .models import WorkspaceMember
+
+
+def workspace_role(request: HttpRequest) -> dict[str, Any]:
+    """Expose the current user's workspace role to all templates.
+
+    Lets shared chrome (the nav in base.html.j2) hide links to
+    admin-gated views like the members page for regular members.
+
+    Args:
+        request: The current HTTP request.
+
+    Returns:
+        Dict with ``nav_workspace_role`` ("owner"/"admin"/"user" or None).
+    """
+    # Error handlers can render before AuthenticationMiddleware ran,
+    # so request.user may be absent entirely.
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
+        return {}
+
+    member = (
+        WorkspaceMember.objects.filter(user=request.user, is_active=True)
+        .only("role")
+        .first()
+    )
+    return {"nav_workspace_role": member.role if member else None}

--- a/app/core/services/dashboard.py
+++ b/app/core/services/dashboard.py
@@ -297,16 +297,21 @@ class DashboardService:
             Dictionary with trial status and remaining days.
         """
         trial_days_remaining = 0
+        trial_has_ended = False
         is_trial = workspace.subscription_status == "trial"
 
         if is_trial and workspace.trial_end_date:
             trial_days_remaining = max(
                 0, (workspace.trial_end_date - timezone.now()).days
             )
+            # Distinct from trial_days_remaining == 0, which is also true
+            # during the final <24h of an active trial.
+            trial_has_ended = workspace.trial_end_date <= timezone.now()
 
         return {
             "is_trial": is_trial,
             "trial_days_remaining": trial_days_remaining,
+            "trial_has_ended": trial_has_ended,
             "trial_end_date": workspace.trial_end_date,
         }
 

--- a/app/core/templates/account/login.html.j2
+++ b/app/core/templates/account/login.html.j2
@@ -43,7 +43,7 @@
                     <form method="post" action="{% provider_login_url 'slack' %}">
                         {% csrf_token %}
                         <button type="submit" class="btn-secondary w-full touch-target">
-                            <i class="fab fa-slack mr-2" aria-hidden="true"></i>
+                            <i class="ti ti-brand-slack mr-2" aria-hidden="true"></i>
                             Continue with Slack
                         </button>
                     </form>

--- a/app/core/templates/account/signup.html.j2
+++ b/app/core/templates/account/signup.html.j2
@@ -44,7 +44,7 @@
                     <form method="post" action="{% provider_login_url 'slack' %}">
                         {% csrf_token %}
                         <button type="submit" class="btn-secondary w-full touch-target">
-                            <i class="fab fa-slack mr-2" aria-hidden="true"></i>
+                            <i class="ti ti-brand-slack mr-2" aria-hidden="true"></i>
                             Continue with Slack
                         </button>
                     </form>

--- a/app/core/templates/core/base.html.j2
+++ b/app/core/templates/core/base.html.j2
@@ -45,9 +45,13 @@
                             {% if user.is_authenticated %}
                                 <a href="{% url 'core:dashboard' %}" class="btn-ghost touch-target">Dashboard</a>
                                 <a href="{% url 'core:integrations' %}" class="btn-ghost touch-target">Integrations</a>
-                                <a href="{% url 'core:billing_dashboard' %}" class="btn-ghost touch-target">Billing</a>
-                                <a href="{% url 'core:members_list' %}" class="btn-ghost touch-target">Members</a>
-                                <a href="{% url 'core:workspace_settings' %}" class="btn-ghost touch-target">Settings</a>
+                                <a href="{% url 'core:billing_dashboard' %}"
+                                   class="btn-ghost touch-target">Billing</a>
+                                {% if nav_workspace_role == 'owner' or nav_workspace_role == 'admin' %}
+                                    <a href="{% url 'core:members_list' %}" class="btn-ghost touch-target">Members</a>
+                                {% endif %}
+                                <a href="{% url 'core:workspace_settings' %}"
+                                   class="btn-ghost touch-target">Settings</a>
                                 <span class="mx-2 h-6 border-l border-gray-200" aria-hidden="true"></span>
                                 <span class="text-sm text-gray-700 px-2">Welcome, {{ user.get_short_name|default:user.username|title }}</span>
                                 <a href="{% url 'account_logout' %}" class="btn-ghost touch-target">Logout</a>
@@ -108,10 +112,12 @@
                                 <i class="ti ti-credit-card w-5 mr-3 text-gray-400"></i>
                                 Billing
                             </a>
-                            <a href="{% url 'core:members_list' %}" class="mobile-menu-item">
-                                <i class="ti ti-users w-5 mr-3 text-gray-400"></i>
-                                Members
-                            </a>
+                            {% if nav_workspace_role == 'owner' or nav_workspace_role == 'admin' %}
+                                <a href="{% url 'core:members_list' %}" class="mobile-menu-item">
+                                    <i class="ti ti-users w-5 mr-3 text-gray-400"></i>
+                                    Members
+                                </a>
+                            {% endif %}
                             <a href="{% url 'core:workspace_settings' %}" class="mobile-menu-item">
                                 <i class="ti ti-settings w-5 mr-3 text-gray-400"></i>
                                 Settings

--- a/app/core/templates/core/base.html.j2
+++ b/app/core/templates/core/base.html.j2
@@ -41,9 +41,15 @@
                         </div>
 
                         <!-- Desktop Navigation -->
-                        <div class="hidden md:flex md:items-center md:space-x-4">
+                        <div class="hidden md:flex md:items-center md:space-x-1">
                             {% if user.is_authenticated %}
-                                <span class="text-sm text-gray-700">Welcome, {{ user.get_short_name|default:user.username|title }}</span>
+                                <a href="{% url 'core:dashboard' %}" class="btn-ghost touch-target">Dashboard</a>
+                                <a href="{% url 'core:integrations' %}" class="btn-ghost touch-target">Integrations</a>
+                                <a href="{% url 'core:billing_dashboard' %}" class="btn-ghost touch-target">Billing</a>
+                                <a href="{% url 'core:members_list' %}" class="btn-ghost touch-target">Members</a>
+                                <a href="{% url 'core:workspace_settings' %}" class="btn-ghost touch-target">Settings</a>
+                                <span class="mx-2 h-6 border-l border-gray-200" aria-hidden="true"></span>
+                                <span class="text-sm text-gray-700 px-2">Welcome, {{ user.get_short_name|default:user.username|title }}</span>
                                 <a href="{% url 'account_logout' %}" class="btn-ghost touch-target">Logout</a>
                             {% else %}
                                 <a href="{% url 'account_login' %}" class="btn-ghost touch-target">Login</a>
@@ -101,6 +107,10 @@
                             <a href="{% url 'core:billing_dashboard' %}" class="mobile-menu-item">
                                 <i class="ti ti-credit-card w-5 mr-3 text-gray-400"></i>
                                 Billing
+                            </a>
+                            <a href="{% url 'core:members_list' %}" class="mobile-menu-item">
+                                <i class="ti ti-users w-5 mr-3 text-gray-400"></i>
+                                Members
                             </a>
                             <a href="{% url 'core:workspace_settings' %}" class="mobile-menu-item">
                                 <i class="ti ti-settings w-5 mr-3 text-gray-400"></i>

--- a/app/core/templates/core/billing_dashboard.html.j2
+++ b/app/core/templates/core/billing_dashboard.html.j2
@@ -69,7 +69,7 @@
 
                 <!-- Plan Details -->
                 <div class="p-6">
-                    {% if workspace.subscription_status == "trial" and trial_days_remaining == 0 %}
+                    {% if trial_has_ended %}
                         <div class="mb-6 p-4 bg-amber-50 rounded-xl border border-amber-100">
                             <div class="flex items-start gap-3">
                                 <div class="p-1.5 bg-amber-100 rounded-lg">

--- a/app/core/templates/core/billing_dashboard.html.j2
+++ b/app/core/templates/core/billing_dashboard.html.j2
@@ -69,28 +69,15 @@
 
                 <!-- Plan Details -->
                 <div class="p-6">
-                    <!-- Trial Warning -->
-                    {% if workspace.subscription_status == "trial" %}
+                    {% if workspace.subscription_status == "trial" and trial_days_remaining == 0 %}
                         <div class="mb-6 p-4 bg-amber-50 rounded-xl border border-amber-100">
                             <div class="flex items-start gap-3">
                                 <div class="p-1.5 bg-amber-100 rounded-lg">
                                     <i class="ti ti-clock text-amber-600"></i>
                                 </div>
                                 <div class="flex-1">
-                                    <h3 class="text-sm font-medium text-amber-800">
-                                        {% if trial_days_remaining > 0 %}
-                                            {{ trial_days_remaining }} day{{ trial_days_remaining|pluralize }} left in your trial
-                                        {% else %}
-                                            Your trial has ended
-                                        {% endif %}
-                                    </h3>
-                                    <p class="mt-1 text-sm text-amber-700">
-                                        {% if trial_days_remaining > 0 %}
-                                            Upgrade anytime to keep your notifications flowing.
-                                        {% else %}
-                                            Upgrade now to restore your notifications.
-                                        {% endif %}
-                                    </p>
+                                    <h3 class="text-sm font-medium text-amber-800">Your trial has ended</h3>
+                                    <p class="mt-1 text-sm text-amber-700">Upgrade now to restore your notifications.</p>
                                 </div>
                             </div>
                         </div>
@@ -123,12 +110,8 @@
                                 <div class="text-2xl font-bold text-gray-900">
                                     {% if workspace.subscription_plan == "free" %}
                                         Free
-                                    {% elif workspace.subscription_plan == "basic" %}
-                                        $29
-                                    {% elif workspace.subscription_plan == "pro" %}
-                                        $99
-                                    {% elif workspace.subscription_plan == "enterprise" %}
-                                        $299
+                                    {% elif current_plan_obj %}
+                                        ${{ current_plan_obj.price_monthly|floatformat:0 }}
                                     {% else %}
                                         --
                                     {% endif %}

--- a/app/core/templates/core/billing_history.html.j2
+++ b/app/core/templates/core/billing_history.html.j2
@@ -8,21 +8,20 @@
 {% block content %}
     <div class="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
         <!-- Header -->
-        <div class="bg-white shadow-sm">
-            <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                <div class="md:flex md:items-center md:justify-between">
-                    <div class="flex-1 min-w-0">
-                        <h2 class="text-3xl font-bold leading-7 text-gray-900 sm:text-4xl flex items-center gap-3">
-                            <i class="ti ti-file-invoice text-primary-600"></i> Billing History
-                        </h2>
-                        <p class="mt-1 text-lg text-gray-600">View your invoices, payments, and billing activity</p>
-                    </div>
-                    <div class="mt-4 flex md:mt-0 md:ml-4">
-                        <a href="{% url 'core:billing_dashboard' %}"
-                           class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-all duration-200">
-                            ← Back to Billing
-                        </a>
-                    </div>
+        <div class="max-w-6xl mx-auto pt-8 px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center">
+                <a href="{% url 'core:billing_dashboard' %}"
+                   class="mr-4 p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-all duration-200">
+                    <i class="ti ti-arrow-left text-xl"></i>
+                </a>
+                <div>
+                    <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 flex items-center gap-3">
+                        <span class="p-2 bg-primary-100 rounded-xl">
+                            <i class="ti ti-file-invoice text-primary-600 text-xl"></i>
+                        </span>
+                        Billing History
+                    </h1>
+                    <p class="mt-1 text-gray-500">View your invoices, payments, and billing activity</p>
                 </div>
             </div>
         </div>
@@ -204,17 +203,23 @@
                             </svg>
                         </div>
                         <div class="ml-3">
-                            <h3 class="text-lg font-semibold text-gray-900">Next Payment</h3>
+                            <h3 class="text-lg font-semibold text-gray-900">
+                                {% if workspace.subscription_status == "trial" %}
+                                    Trial Ends
+                                {% else %}
+                                    Next Payment
+                                {% endif %}
+                            </h3>
                             <p class="text-2xl font-bold text-gray-900">
                                 {% if workspace.subscription_status == "trial" %}
-                                    {{ trial_days_remaining }}
+                                    {{ trial_days_remaining }} day{{ trial_days_remaining|pluralize }}
                                 {% else %}
                                     {{ rate_limit_info.reset_time|date:"j" }}
                                 {% endif %}
                             </p>
                             <p class="text-sm text-gray-500">
                                 {% if workspace.subscription_status == "trial" %}
-                                    days until trial ends
+                                    until your first invoice
                                 {% else %}
                                     days until billing
                                 {% endif %}

--- a/app/core/templates/core/create_workspace.html.j2
+++ b/app/core/templates/core/create_workspace.html.j2
@@ -1,14 +1,14 @@
 {% extends "core/base.html.j2" %}
 
 {% block title %}
-    Create Organization - Notipus
+    Create Workspace - Notipus
 {% endblock title %}
 
 {% block content %}
     <div class="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
             <div class="text-center">
-                <h2 class="mt-6 text-3xl font-extrabold text-gray-900">Create Your Organization</h2>
+                <h2 class="mt-6 text-3xl font-extrabold text-gray-900">Create Your Workspace</h2>
                 <p class="mt-2 text-sm text-gray-600">Set up your workspace to get started with Notipus</p>
             </div>
         </div>
@@ -29,9 +29,9 @@
                 <form class="space-y-6" method="post">
                     {% csrf_token %}
 
-                    <!-- Organization Name Field -->
+                    <!-- Workspace Name Field -->
                     <div>
-                        <label for="name" class="block text-sm font-medium text-gray-700">Organization Name</label>
+                        <label for="name" class="block text-sm font-medium text-gray-700">Workspace Name</label>
                         <div class="mt-1">
                             <input id="name"
                                    name="name"
@@ -62,7 +62,7 @@
                     <div>
                         <button type="submit"
                                 class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition duration-150 ease-in-out">
-                            Create Organization
+                            Create Workspace
                         </button>
                     </div>
                 </form>
@@ -70,7 +70,7 @@
                 <!-- Additional Info -->
                 <div class="mt-6">
                     <div class="text-center">
-                        <p class="text-xs text-gray-500">You can update these details later in your organization settings</p>
+                        <p class="text-xs text-gray-500">You can update these details later in your workspace settings</p>
                     </div>
                 </div>
             </div>

--- a/app/core/templates/core/dashboard.html.j2
+++ b/app/core/templates/core/dashboard.html.j2
@@ -10,49 +10,11 @@
         <!-- Simplified Header -->
         <div class="bg-white shadow-sm">
             <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                <div class="md:flex md:items-center md:justify-between">
-                    <div class="flex-1 min-w-0">
-                        <h2 class="text-3xl font-bold leading-7 text-gray-900 sm:text-4xl flex items-center gap-2">
-                            Welcome back! <i class="ti ti-hand-wave text-primary-500"></i>
-                        </h2>
-                        <p class="mt-1 text-lg text-gray-600">Ready to manage your webhooks</p>
-                    </div>
-                    <div class="mt-4 flex md:mt-0 md:ml-4 space-x-3">
-                        <a href="{% url 'core:billing_dashboard' %}"
-                           class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-all duration-200">
-                            <svg class="mr-2 h-4 w-4"
-                                 fill="none"
-                                 stroke="currentColor"
-                                 viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z">
-                                </path>
-                            </svg>
-                            Billing
-                        </a>
-                        <a href="{% url 'core:integrations' %}"
-                           class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-all duration-200">
-                            <svg class="mr-2 h-4 w-4"
-                                 fill="none"
-                                 stroke="currentColor"
-                                 viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1">
-                                </path>
-                            </svg>
-                            Integrations
-                        </a>
-                        <a href="{% url 'core:workspace_settings' %}"
-                           class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-gradient-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 transition-all duration-200">
-                            <svg class="mr-2 h-4 w-4"
-                                 fill="none"
-                                 stroke="currentColor"
-                                 viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z">
-                                </path>
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-                            </svg>
-                            Settings
-                        </a>
-                    </div>
+                <div class="flex-1 min-w-0">
+                    <h2 class="text-3xl font-bold leading-7 text-gray-900 sm:text-4xl flex items-center gap-2">
+                        Welcome back{% if user.first_name %}, {{ user.first_name }}{% endif %}! <i class="ti ti-hand-wave text-primary-500"></i>
+                    </h2>
+                    <p class="mt-1 text-lg text-gray-600">Here's what's happening across {{ organization.name }}</p>
                 </div>
             </div>
         </div>
@@ -88,12 +50,12 @@
                             <div class="mt-4 flex flex-wrap gap-3">
                                 <a href="{% url 'core:integrate_slack' %}"
                                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 transition-all duration-200">
-                                    <i class="fas fa-comments mr-2"></i>
+                                    <i class="ti ti-brand-slack mr-2"></i>
                                     Connect Slack
                                 </a>
                                 <a href="{% url 'core:integrate_shopify' %}"
                                    class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 transition-all duration-200">
-                                    <i class="fas fa-shopping-cart mr-2"></i>
+                                    <i class="ti ti-shopping-cart mr-2"></i>
                                     Connect Shopify
                                 </a>
                                 <a href="{% url 'core:integrations' %}"
@@ -330,23 +292,41 @@
                                                         </path>
                                                     </svg>
                                                 </div>
-                                            {% elif activity.severity == "success" %}
-                                                <div class="h-10 w-10 bg-green-100 rounded-lg flex items-center justify-center">
-                                                    <svg class="h-5 w-5 text-green-600"
+                                            {% elif activity.company_domain %}
+                                                <img src="{% url 'core:company-logo' domain=activity.company_domain %}"
+                                                     alt="{{ activity.company_name|default:activity.company_domain }}"
+                                                     width="40"
+                                                     height="40"
+                                                     loading="lazy"
+                                                     class="h-10 w-10 rounded-lg object-cover bg-white border border-gray-200"
+                                                     onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                                                <!-- Fallback icon shown when no logo is stored -->
+                                                <div class="h-10 w-10 bg-gray-100 rounded-lg items-center justify-center hidden">
+                                                    <svg class="h-5 w-5 text-gray-400"
                                                          fill="none"
                                                          stroke="currentColor"
                                                          viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4">
                                                         </path>
                                                     </svg>
                                                 </div>
-                                            {% elif activity.severity == "error" %}
+                                            {% elif activity.status == "failed" or activity.status == "declined" or activity.status == "error" or activity.severity == "error" or activity.severity == "critical" %}
                                                 <div class="h-10 w-10 bg-red-100 rounded-lg flex items-center justify-center">
                                                     <svg class="h-5 w-5 text-red-600"
                                                          fill="none"
                                                          stroke="currentColor"
                                                          viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z">
+                                                        </path>
+                                                    </svg>
+                                                </div>
+                                            {% elif activity.status == "cancelled" %}
+                                                <div class="h-10 w-10 bg-gray-100 rounded-lg flex items-center justify-center">
+                                                    <svg class="h-5 w-5 text-gray-500"
+                                                         fill="none"
+                                                         stroke="currentColor"
+                                                         viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636">
                                                         </path>
                                                     </svg>
                                                 </div>
@@ -437,7 +417,7 @@
 
                                                     <!-- Insight Banner -->
                                                     {% if activity.insight_text %}
-                                                        <div class="mt-2 inline-flex items-center gap-1 px-2 py-1 rounded-md bg-primary-50 text-primary-700 text-xs font-medium">
+                                                        <div class="mt-2 inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium {% if activity.severity == 'error' or activity.severity == 'critical' %}bg-red-50 text-red-700{% elif activity.severity == 'warning' %}bg-amber-50 text-amber-700{% else %}bg-green-50 text-green-700{% endif %}">
                                                             {% if activity.insight_icon == "celebration" %}
                                                                 <i class="ti ti-confetti"></i>
                                                             {% elif activity.insight_icon == "trophy" %}

--- a/app/core/templates/core/integrate_shopify.html.j2
+++ b/app/core/templates/core/integrate_shopify.html.j2
@@ -18,7 +18,7 @@
                     </a>
                     <div class="flex items-center">
                         <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mr-4">
-                            <i class="fas fa-shopping-cart text-3xl text-green-600"></i>
+                            <i class="ti ti-shopping-cart text-3xl text-green-600"></i>
                         </div>
                         <div>
                             <h1 class="text-3xl font-bold text-gray-900">Connect Shopify</h1>

--- a/app/core/templates/core/integrate_stripe.html.j2
+++ b/app/core/templates/core/integrate_stripe.html.j2
@@ -7,25 +7,22 @@
 {% block content %}
     <div class="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
         <!-- Header -->
-        <div class="bg-white shadow-sm">
-            <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                <div class="md:flex md:items-center md:justify-between">
-                    <div class="flex-1 min-w-0">
-                        <h2 class="text-3xl font-bold leading-7 text-gray-900 sm:text-4xl flex items-center gap-3">
-                            <svg class="w-10 h-10" viewBox="0 0 24 24" fill="#635bff">
+        <div class="max-w-4xl mx-auto pt-8 px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center">
+                <a href="{% url 'core:integrations' %}"
+                   class="mr-4 p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-all duration-200">
+                    <i class="ti ti-arrow-left text-xl"></i>
+                </a>
+                <div>
+                    <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 flex items-center gap-3">
+                        <span class="p-2 bg-[#635bff]/10 rounded-xl">
+                            <svg class="w-6 h-6" viewBox="0 0 24 24" fill="#635bff">
                                 <path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z" />
                             </svg>
-                            Connect Stripe
-                        </h2>
-                        <p class="mt-1 text-lg text-gray-600">Receive payment and subscription webhooks from your Stripe account</p>
-                    </div>
-                    <div class="mt-4 flex md:mt-0 md:ml-4">
-                        <a href="{% url 'core:integrations' %}"
-                           class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-all duration-200">
-                            <i class="ti ti-arrow-left mr-2"></i>
-                            Back to Integrations
-                        </a>
-                    </div>
+                        </span>
+                        Connect Stripe
+                    </h1>
+                    <p class="mt-1 text-gray-500">Receive payment and subscription webhooks from your Stripe account</p>
                 </div>
             </div>
         </div>
@@ -263,31 +260,28 @@
                                     6
                                 </div>
                             </div>
-                            <div class="ml-3">
+                            <div class="ml-3 flex-1">
                                 <h4 class="text-sm font-medium text-gray-900">Complete the connection</h4>
                                 <p class="text-sm text-gray-500">Click the button below to complete the setup.</p>
+                                <button type="submit"
+                                        class="mt-4 inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-white bg-[#635bff] hover:bg-[#5851db] transition-all duration-200 shadow-lg">
+                                    <svg class="mr-2 h-5 w-5"
+                                         fill="none"
+                                         stroke="currentColor"
+                                         viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1">
+                                        </path>
+                                    </svg>
+                                    {% if existing_integration %}
+                                        Update
+                                    {% else %}
+                                        Connect
+                                    {% endif %}
+                                    Stripe
+                                </button>
                             </div>
                         </div>
                     </div>
-                </div>
-
-                <div class="flex justify-end mb-8">
-                    <button type="submit"
-                            class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-white bg-[#635bff] hover:bg-[#5851db] transition-all duration-200 shadow-lg">
-                        <svg class="mr-2 h-5 w-5"
-                             fill="none"
-                             stroke="currentColor"
-                             viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1">
-                            </path>
-                        </svg>
-                        {% if existing_integration %}
-                            Update
-                        {% else %}
-                            Connect
-                        {% endif %}
-                        Stripe
-                    </button>
                 </div>
             </form>
         </div>

--- a/app/core/templates/core/integrations.html.j2
+++ b/app/core/templates/core/integrations.html.j2
@@ -182,7 +182,8 @@
                                                     Connect
                                                 </a>
                                             {% elif integration.id == "chargify" %}
-                                                <a href="{% url 'core:integrate_chargify' %}" class="btn-primary gap-1.5">
+                                                <a href="{% url 'core:integrate_chargify' %}"
+                                                   class="btn-primary gap-1.5">
                                                     <i class="ti ti-plug-connected"></i>
                                                     Connect
                                                 </a>

--- a/app/core/templates/core/integrations.html.j2
+++ b/app/core/templates/core/integrations.html.j2
@@ -62,7 +62,7 @@
                     <div class="divide-y divide-gray-100">
                         {% for integration in event_sources %}
                             <div class="px-6 py-5 hover:bg-gray-50/50 transition-colors">
-                                <div class="flex items-start justify-between gap-4">
+                                <div class="flex flex-wrap items-start justify-between gap-4">
                                     <div class="flex items-start gap-4">
                                         <!-- Integration Icon -->
                                         <div class="flex-shrink-0">
@@ -177,20 +177,17 @@
                                             {% endif %}
                                         {% else %}
                                             {% if integration.id == "shopify" %}
-                                                <a href="{% url 'core:integrate_shopify' %}"
-                                                   class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-[#95BF47] hover:bg-[#7ea93d] rounded-lg transition-colors shadow-sm">
+                                                <a href="{% url 'core:integrate_shopify' %}" class="btn-primary gap-1.5">
                                                     <i class="ti ti-plug-connected"></i>
                                                     Connect
                                                 </a>
                                             {% elif integration.id == "chargify" %}
-                                                <a href="{% url 'core:integrate_chargify' %}"
-                                                   class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 rounded-lg transition-colors shadow-sm">
+                                                <a href="{% url 'core:integrate_chargify' %}" class="btn-primary gap-1.5">
                                                     <i class="ti ti-plug-connected"></i>
                                                     Connect
                                                 </a>
                                             {% elif integration.id == "stripe_customer" %}
-                                                <a href="{% url 'core:integrate_stripe' %}"
-                                                   class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-[#635bff] hover:bg-[#5851db] rounded-lg transition-colors shadow-sm">
+                                                <a href="{% url 'core:integrate_stripe' %}" class="btn-primary gap-1.5">
                                                     <i class="ti ti-plug-connected"></i>
                                                     Connect
                                                 </a>
@@ -226,7 +223,7 @@
                     <div class="divide-y divide-gray-100">
                         {% for integration in notification_channels %}
                             <div class="px-6 py-5 hover:bg-gray-50/50 transition-colors">
-                                <div class="flex items-start justify-between gap-4">
+                                <div class="flex flex-wrap items-start justify-between gap-4">
                                     <div class="flex items-start gap-4">
                                         <!-- Integration Icon -->
                                         <div class="flex-shrink-0">
@@ -308,8 +305,7 @@
                                             {% endif %}
                                         {% else %}
                                             {% if integration.id == "slack_notifications" %}
-                                                <a href="{% url 'core:integrate_slack' %}"
-                                                   class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-[#4A154B] hover:bg-[#3e1240] rounded-lg transition-colors shadow-sm">
+                                                <a href="{% url 'core:integrate_slack' %}" class="btn-primary gap-1.5">
                                                     <i class="ti ti-plug-connected"></i>
                                                     Connect
                                                 </a>
@@ -358,7 +354,7 @@
                     <div class="divide-y divide-gray-100">
                         {% for integration in enrichment_services %}
                             <div class="px-6 py-5 hover:bg-gray-50/50 transition-colors">
-                                <div class="flex items-start justify-between gap-4">
+                                <div class="flex flex-wrap items-start justify-between gap-4">
                                     <div class="flex items-start gap-4">
                                         <!-- Integration Icon -->
                                         <div class="flex-shrink-0">
@@ -424,8 +420,7 @@
                                             {% endif %}
                                         {% else %}
                                             {% if integration.id == "hunter" %}
-                                                <a href="{% url 'core:integrate_hunter' %}"
-                                                   class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-[#ff5722] hover:bg-[#e64a19] rounded-lg transition-colors shadow-sm">
+                                                <a href="{% url 'core:integrate_hunter' %}" class="btn-primary gap-1.5">
                                                     <i class="ti ti-plug-connected"></i>
                                                     Connect
                                                 </a>

--- a/app/core/templates/core/members.html.j2
+++ b/app/core/templates/core/members.html.j2
@@ -158,10 +158,12 @@
                                     </div>
                                 </div>
                                 <div class="flex items-center gap-4">
-                                    <!-- Role Badge -->
-                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {% if member.role == 'owner' %}bg-purple-100 text-purple-800 {% elif member.role == 'admin' %}bg-blue-100 text-blue-800 {% else %}bg-gray-100 text-gray-800{% endif %}">
-                                        {{ member.role|title }}
-                                    </span>
+                                    <!-- Role Badge: only when no role dropdown is rendered for this row -->
+                                    {% if member.id == current_member.id or current_member.role == 'user' or current_member.role == 'admin' and member.role == 'owner' %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {% if member.role == 'owner' %}bg-purple-100 text-purple-800 {% elif member.role == 'admin' %}bg-blue-100 text-blue-800 {% else %}bg-gray-100 text-gray-800{% endif %}">
+                                            {{ member.role|title }}
+                                        </span>
+                                    {% endif %}
 
                                     {% if member.id != current_member.id %}
                                         <!-- Role Change Form - Owner can change anyone, Admin can change non-owners -->

--- a/app/core/templates/core/members.html.j2
+++ b/app/core/templates/core/members.html.j2
@@ -159,7 +159,7 @@
                                 </div>
                                 <div class="flex items-center gap-4">
                                     <!-- Role Badge: only when no role dropdown is rendered for this row -->
-                                    {% if member.id == current_member.id or current_member.role == 'user' or current_member.role == 'admin' and member.role == 'owner' %}
+                                    {% if not member.can_manage %}
                                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {% if member.role == 'owner' %}bg-purple-100 text-purple-800 {% elif member.role == 'admin' %}bg-blue-100 text-blue-800 {% else %}bg-gray-100 text-gray-800{% endif %}">
                                             {{ member.role|title }}
                                         </span>

--- a/app/core/templates/core/payment_methods.html.j2
+++ b/app/core/templates/core/payment_methods.html.j2
@@ -7,21 +7,20 @@
 {% block content %}
     <div class="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
         <!-- Header -->
-        <div class="bg-white shadow-sm">
-            <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                <div class="md:flex md:items-center md:justify-between">
-                    <div class="flex-1 min-w-0">
-                        <h2 class="text-3xl font-bold leading-7 text-gray-900 sm:text-4xl flex items-center gap-3">
-                            <i class="ti ti-credit-card text-primary-600"></i> Payment Methods
-                        </h2>
-                        <p class="mt-1 text-lg text-gray-600">Manage your payment methods and billing information</p>
-                    </div>
-                    <div class="mt-4 flex md:mt-0 md:ml-4">
-                        <a href="{% url 'core:billing_dashboard' %}"
-                           class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-all duration-200">
-                            ← Back to Billing
-                        </a>
-                    </div>
+        <div class="max-w-4xl mx-auto pt-8 px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center">
+                <a href="{% url 'core:billing_dashboard' %}"
+                   class="mr-4 p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-all duration-200">
+                    <i class="ti ti-arrow-left text-xl"></i>
+                </a>
+                <div>
+                    <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 flex items-center gap-3">
+                        <span class="p-2 bg-primary-100 rounded-xl">
+                            <i class="ti ti-credit-card text-primary-600 text-xl"></i>
+                        </span>
+                        Payment Methods
+                    </h1>
+                    <p class="mt-1 text-gray-500">Manage your payment methods and billing information</p>
                 </div>
             </div>
         </div>

--- a/app/core/templates/core/select_plan.html.j2
+++ b/app/core/templates/core/select_plan.html.j2
@@ -16,10 +16,10 @@
             <!-- Plan Cards -->
             <div class="mt-12 space-y-4 sm:mt-16 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-6 lg:max-w-4xl lg:mx-auto xl:max-w-none xl:mx-0 xl:grid-cols-4">
                 {% for plan in plans %}
-                    <div class="border border-gray-200 rounded-lg shadow-sm divide-y divide-gray-200 {% if plan.name == 'pro' %}ring-2 ring-primary-500{% endif %}">
+                    <div class="relative border border-gray-200 rounded-lg shadow-sm divide-y divide-gray-200 {% if plan.name == 'pro' %}ring-2 ring-primary-500{% endif %}">
                         {% if plan.name == 'pro' %}
                             <div class="absolute -top-4 left-1/2 transform -translate-x-1/2">
-                                <span class="inline-flex px-4 py-1 rounded-full text-sm font-semibold tracking-wide uppercase bg-primary-500 text-white">
+                                <span class="inline-flex whitespace-nowrap px-4 py-1 rounded-full text-sm font-semibold tracking-wide uppercase bg-primary-500 text-white shadow">
                                     Most Popular
                                 </span>
                             </div>

--- a/app/core/templates/core/upgrade_plan.html.j2
+++ b/app/core/templates/core/upgrade_plan.html.j2
@@ -7,21 +7,20 @@
 {% block content %}
     <div class="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
         <!-- Header -->
-        <div class="bg-white shadow-sm">
-            <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                <div class="md:flex md:items-center md:justify-between">
-                    <div class="flex-1 min-w-0">
-                        <h2 class="text-3xl font-bold leading-7 text-gray-900 sm:text-4xl flex items-center gap-3">
-                            <i class="ti ti-rocket text-primary-600"></i> Upgrade Your Plan
-                        </h2>
-                        <p class="mt-1 text-lg text-gray-600">Choose the perfect plan for your growing business</p>
-                    </div>
-                    <div class="mt-4 flex md:mt-0 md:ml-4">
-                        <a href="{% url 'core:billing_dashboard' %}"
-                           class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-all duration-200">
-                            ← Back to Billing
-                        </a>
-                    </div>
+        <div class="max-w-7xl mx-auto pt-8 px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center">
+                <a href="{% url 'core:billing_dashboard' %}"
+                   class="mr-4 p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-all duration-200">
+                    <i class="ti ti-arrow-left text-xl"></i>
+                </a>
+                <div>
+                    <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 flex items-center gap-3">
+                        <span class="p-2 bg-primary-100 rounded-xl">
+                            <i class="ti ti-rocket text-primary-600 text-xl"></i>
+                        </span>
+                        Change Your Plan
+                    </h1>
+                    <p class="mt-1 text-gray-500">Choose the plan that fits your business</p>
                 </div>
             </div>
         </div>
@@ -29,14 +28,14 @@
         <!-- Main content -->
         <div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
             <!-- Current Plan Banner -->
-            <div class="bg-gradient-to-r from-blue-500 to-blue-600 rounded-xl p-4 sm:p-6 mb-8 text-white">
+            <div class="bg-gradient-to-r from-primary-600 to-primary-700 rounded-xl p-4 sm:p-6 mb-8 text-white">
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
                     <div class="flex-1 min-w-0">
                         <h3 class="text-lg font-semibold truncate">Current Plan: {{ current_plan|title }}</h3>
-                        <p class="text-blue-100 mt-1 text-sm sm:text-base">Ready to unlock more features and higher limits?</p>
+                        <p class="text-primary-100 mt-1 text-sm sm:text-base">Ready to unlock more features and higher limits?</p>
                     </div>
                     <div class="flex items-center mt-4 sm:mt-0 sm:ml-4">
-                        <svg class="h-6 w-6 sm:h-8 sm:w-8 text-blue-200"
+                        <svg class="h-6 w-6 sm:h-8 sm:w-8 text-primary-200"
                              fill="none"
                              stroke="currentColor"
                              viewBox="0 0 24 24">
@@ -48,7 +47,7 @@
             </div>
 
             <!-- Plan Comparison Cards -->
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 mb-8">
+            <div class="grid grid-cols-1 {% if plans|length == 2 %}md:grid-cols-2 max-w-4xl mx-auto{% else %}md:grid-cols-2 lg:grid-cols-3{% endif %} gap-6 lg:gap-8 mb-8">
                 {% for plan in plans %}
                     <div class="group relative bg-white rounded-2xl shadow-lg border {% if plan.recommended %}border-primary-500 ring-2 ring-primary-500 ring-opacity-50 shadow-primary-500/25{% else %}border-gray-200 hover:border-gray-300 hover:shadow-xl{% endif %} transition-all duration-300 transform hover:scale-105">
                         {% if plan.recommended %}
@@ -61,7 +60,7 @@
                             <div class="absolute inset-0 bg-gradient-to-br from-primary-50/50 to-transparent pointer-events-none"></div>
                         {% endif %}
 
-                        <div class="relative p-6 lg:p-8">
+                        <div class="relative p-6 lg:p-8 h-full flex flex-col">
                             <!-- Plan Header -->
                             <div class="text-center mb-8">
                                 {% if plan.recommended %}
@@ -74,7 +73,7 @@
                                         </svg>
                                     </div>
                                 {% elif plan.id == "basic" %}
-                                    <div class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-blue-500 to-blue-600 rounded-full mb-4 shadow-lg">
+                                    <div class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-primary-400 to-primary-500 rounded-full mb-4 shadow-lg">
                                         <svg class="w-8 h-8 text-white"
                                              fill="none"
                                              stroke="currentColor"
@@ -84,7 +83,7 @@
                                         </svg>
                                     </div>
                                 {% else %}
-                                    <div class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-purple-500 to-purple-600 rounded-full mb-4 shadow-lg">
+                                    <div class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-gray-700 to-gray-900 rounded-full mb-4 shadow-lg">
                                         <svg class="w-8 h-8 text-white"
                                              fill="none"
                                              stroke="currentColor"
@@ -106,12 +105,16 @@
                                     <p class="text-sm text-primary-600 font-semibold bg-primary-50 px-3 py-1 rounded-full inline-block">
                                         Perfect for growing teams
                                     </p>
+                                {% elif plan.is_downgrade %}
+                                    <p class="text-sm text-gray-600 font-semibold bg-gray-100 px-3 py-1 rounded-full inline-block">
+                                        Lower tier than your current plan
+                                    </p>
                                 {% elif plan.id == "basic" %}
-                                    <p class="text-sm text-blue-600 font-semibold bg-blue-50 px-3 py-1 rounded-full inline-block">
+                                    <p class="text-sm text-primary-600 font-semibold bg-primary-50 px-3 py-1 rounded-full inline-block">
                                         Great for getting started
                                     </p>
                                 {% else %}
-                                    <p class="text-sm text-purple-600 font-semibold bg-purple-50 px-3 py-1 rounded-full inline-block">
+                                    <p class="text-sm text-gray-700 font-semibold bg-gray-100 px-3 py-1 rounded-full inline-block">
                                         For large organizations
                                     </p>
                                 {% endif %}
@@ -137,7 +140,7 @@
                             </div>
 
                             <!-- CTA Button -->
-                            <div>
+                            <div class="mt-auto">
                                 {% if plan.id == current_plan %}
                                     <div class="w-full py-4 px-6 border-2 border-gray-200 rounded-xl text-center bg-gray-50">
                                         <div class="flex items-center justify-center">
@@ -161,6 +164,8 @@
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"></path>
                                             </svg>
                                             <span>Upgrade to {{ plan.name }}</span>
+                                        {% elif plan.is_downgrade %}
+                                            <span>Downgrade to {{ plan.name }}</span>
                                         {% else %}
                                             <span>Choose {{ plan.name }}</span>
                                             <svg class="ml-2 h-5 w-5 group-hover/btn:translate-x-1 transition-transform"
@@ -184,8 +189,8 @@
 
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <div class="text-center">
-                        <div class="h-16 w-16 bg-gradient-to-r from-blue-500 to-blue-600 rounded-full flex items-center justify-center mx-auto mb-4">
-                            <svg class="h-8 w-8 text-white"
+                        <div class="h-16 w-16 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                            <svg class="h-8 w-8 text-primary-600"
                                  fill="none"
                                  stroke="currentColor"
                                  viewBox="0 0 24 24">
@@ -197,8 +202,8 @@
                     </div>
 
                     <div class="text-center">
-                        <div class="h-16 w-16 bg-gradient-to-r from-green-500 to-green-600 rounded-full flex items-center justify-center mx-auto mb-4">
-                            <svg class="h-8 w-8 text-white"
+                        <div class="h-16 w-16 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                            <svg class="h-8 w-8 text-primary-600"
                                  fill="none"
                                  stroke="currentColor"
                                  viewBox="0 0 24 24">
@@ -211,8 +216,8 @@
                     </div>
 
                     <div class="text-center">
-                        <div class="h-16 w-16 bg-gradient-to-r from-purple-500 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
-                            <svg class="h-8 w-8 text-white"
+                        <div class="h-16 w-16 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                            <svg class="h-8 w-8 text-primary-600"
                                  fill="none"
                                  stroke="currentColor"
                                  viewBox="0 0 24 24">

--- a/app/core/templates/core/workspace_settings.html.j2
+++ b/app/core/templates/core/workspace_settings.html.j2
@@ -82,7 +82,7 @@
                             <input type="text"
                                    name="shop_domain"
                                    id="shop_domain"
-                                   value="{{ workspace.shop_domain }}"
+                                   value="{{ workspace.shop_domain|default_if_none:'' }}"
                                    placeholder="yourbusiness.com"
                                    class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm">
                         </div>

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -47,8 +47,9 @@ def select_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
     plans: list[dict[str, Any]] = []
 
     for plan in plans_queryset:
+        # Bare amount only — the template appends "/month" to dollar prices
         price_display = (
-            "Free" if plan.price_monthly == 0 else f"${plan.price_monthly:.0f}/month"
+            "Free" if plan.price_monthly == 0 else f"${plan.price_monthly:.0f}"
         )
         plans.append(
             {
@@ -108,6 +109,9 @@ def billing_dashboard(request: HttpRequest) -> HttpResponse | HttpResponseRedire
         **billing_data["trial_info"],  # trial_days_remaining, is_trial, etc.
         "available_plans": billing_data["available_plans"],
         "current_plan": billing_data["current_plan"],
+        "current_plan_obj": Plan.objects.filter(
+            name=billing_data["current_plan"], is_active=True
+        ).first(),
     }
 
     return render(request, "core/billing_dashboard.html.j2", context)
@@ -134,6 +138,20 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
 
     billing_service = BillingService()
     available_plans = billing_service.get_available_plans(workspace.subscription_plan)
+
+    # Mark plans cheaper than the current one so the template can present
+    # them honestly as downgrades instead of "upgrades".
+    current_plan_obj = Plan.objects.filter(
+        name=workspace.subscription_plan, is_active=True
+    ).first()
+    if current_plan_obj:
+        for plan in available_plans:
+            try:
+                plan["is_downgrade"] = float(plan.get("price", 0)) < float(
+                    current_plan_obj.price_monthly
+                )
+            except (TypeError, ValueError):
+                plan["is_downgrade"] = False
 
     context: dict[str, Any] = {
         "workspace": workspace,

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -5,6 +5,7 @@ and checkout flows.
 """
 
 import logging
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from django.contrib import messages
@@ -147,10 +148,10 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
     if current_plan_obj:
         for plan in available_plans:
             try:
-                plan["is_downgrade"] = float(plan.get("price", 0)) < float(
-                    current_plan_obj.price_monthly
+                plan["is_downgrade"] = (
+                    Decimal(str(plan.get("price", 0))) < current_plan_obj.price_monthly
                 )
-            except (TypeError, ValueError):
+            except (InvalidOperation, TypeError, ValueError):
                 plan["is_downgrade"] = False
 
     context: dict[str, Any] = {

--- a/app/core/views/members.py
+++ b/app/core/views/members.py
@@ -109,9 +109,20 @@ def members_list(request: HttpRequest) -> HttpResponse:
     current_member = request.workspace_member  # type: ignore[attr-defined]
 
     # Get all members
-    members = WorkspaceMember.objects.filter(
-        workspace=workspace, is_active=True
-    ).select_related("user")
+    members = list(
+        WorkspaceMember.objects.filter(
+            workspace=workspace, is_active=True
+        ).select_related("user")
+    )
+
+    # Whether the viewer gets role/remove controls for each row; the
+    # template shows a static role badge when it doesn't render controls.
+    # (Computed here because Django templates can't parenthesize booleans.)
+    for member in members:
+        member.can_manage = member.id != current_member.id and (
+            current_member.role == "owner"
+            or (current_member.role == "admin" and member.role != "owner")
+        )
 
     # Get pending invitations
     pending_invitations = WorkspaceInvitation.objects.filter(

--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -309,6 +309,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "core.context_processors.workspace_role",
             ],
             # Security: Only enable template debug in development
             "debug": DEBUG,

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@shopify/cli": "^4.5.2",
       },
       "devDependencies": {
-        "@fortawesome/fontawesome-free": "^7.3.1",
         "@tabler/icons-webfont": "^3.45.0",
         "@tailwindcss/cli": "^4.3.3",
         "autoprefixer": "^10.5.4",
@@ -106,8 +105,6 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.19.8", "", { "os": "win32", "cpu": "ia32" }, "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.8", "", { "os": "win32", "cpu": "x64" }, "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA=="],
-
-    "@fortawesome/fontawesome-free": ["@fortawesome/fontawesome-free@7.3.1", "", {}, "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:css": "bunx tailwindcss -i ./src/css/main.css -o ./app/static/dist/main.css --minify",
     "build:fonts": "mkdir -p app/static/dist/fonts && cp -r node_modules/@tabler/icons-webfont/dist/fonts/* app/static/dist/fonts/",
     "build": "bun run build:fonts && bun run build:css",
-    "dev": "bunx tailwindcss -i ./src/css/main.css -o ./app/static/dist/main.css --watch"
+    "dev": "bun run build:fonts && bunx tailwindcss -i ./src/css/main.css -o ./app/static/dist/main.css --watch"
   },
   "devDependencies": {
     "@tabler/icons-webfont": "^3.45.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "dev": "bunx tailwindcss -i ./src/css/main.css -o ./app/static/dist/main.css --watch"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "^7.3.1",
     "@tabler/icons-webfont": "^3.45.0",
     "@tailwindcss/cli": "^4.3.3",
     "autoprefixer": "^10.5.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build:css": "bunx tailwindcss -i ./src/css/main.css -o ./app/static/dist/main.css --minify",
-    "build:fonts": "cp -r node_modules/@fortawesome/fontawesome-free/webfonts app/static/ && mkdir -p app/static/tabler-fonts && cp -r node_modules/@tabler/icons-webfont/dist/fonts/* app/static/tabler-fonts/",
+    "build:fonts": "mkdir -p app/static/dist/fonts && cp -r node_modules/@tabler/icons-webfont/dist/fonts/* app/static/dist/fonts/",
     "build": "bun run build:fonts && bun run build:css",
     "dev": "bunx tailwindcss -i ./src/css/main.css -o ./app/static/dist/main.css --watch"
   },

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -6,13 +6,7 @@
 @source "../app/**/*.html.j2";
 @source "../app/**/*.py";
 
-/* Import FontAwesome */
-@import "@fortawesome/fontawesome-free/css/fontawesome.css";
-@import "@fortawesome/fontawesome-free/css/solid.css";
-@import "@fortawesome/fontawesome-free/css/regular.css";
-@import "@fortawesome/fontawesome-free/css/brands.css";
-
-/* Import Tabler Icons */
+/* Import Tabler Icons (single icon library — keep FontAwesome out) */
 @import "@tabler/icons-webfont/dist/tabler-icons.css";
 
 /* Custom theme configuration for Tailwind v4 */
@@ -93,7 +87,8 @@
   }
 
   .btn-primary {
-    @apply border border-transparent text-white bg-gradient-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 focus-visible:ring-primary-500 shadow-sm;
+    /* primary-700 base keeps white text at >= 4.5:1 contrast (WCAG AA) */
+    @apply border border-transparent text-white bg-gradient-to-r from-primary-700 to-primary-800 hover:from-primary-800 hover:to-primary-900 focus-visible:ring-primary-500 shadow-sm;
   }
 
   .btn-secondary {


### PR DESCRIPTION
## Summary

A screenshot-driven UI/UX review of every page (desktop 1440px + mobile 390px, seeded demo workspace) surfaced one production rendering bug and a set of UX/consistency issues. This PR fixes all of them.

### Bugs
- **Tabler icon fonts 404 on every page** — the compiled CSS resolves fonts at `/static/dist/fonts/`, but the build copied them to `/static/tabler-fonts/`, so every `ti-*` icon rendered as a blank box or CJK fallback glyph. `build:fonts` now targets `app/static/dist/fonts/`.
- "Most Popular" ribbon on Select Plan floated behind the navbar (absolutely positioned without a `relative` parent).
- Select Plan prices rendered as "$29/month /month" (view and template both appended the suffix).
- Workspace Settings pre-filled the domain input with the literal string "None".
- Integration card actions clipped off-screen on mobile ("Disconnect" cut to "Dis…"); rows now wrap.

### Navigation & consistency
- Persistent desktop nav (Dashboard / Integrations / Billing / Members / Settings) — previously these links existed only in the mobile hamburger menu, and Members was only reachable via Settings → Quick Actions. Members added to the mobile menu too.
- The four white-band page headers (Billing History, Payment Methods, plan change, Stripe connect) converted to the chevron-back header pattern the rest of the app uses.
- "Organization" renamed to "Workspace" in the create flow to match the rest of the product.
- Font Awesome removed entirely (5 usages swapped to Tabler) — one icon library, a few hundred KB of fonts off every page load.
- Provider-colored Connect buttons and the blue/purple upgrade page unified onto the brand palette; `btn-primary` darkened one step so white text meets WCAG AA.

### Dashboard & billing semantics
- Activity feed shows company logos via the existing logo endpoint (neutral fallback), red icons for failures, gray for cancellations — previously cancelled/failed events got the same green `$` as successes.
- Insight chips colored by severity (green / amber / red) instead of uniform orange for good and bad news alike.
- Plan-change page labels cheaper plans honestly: "Lower tier than your current plan" + "Downgrade to X".
- Billing History trial tile reads "Trial Ends — N days — until your first invoice" instead of a bare number under "Next Payment"; duplicated trial banner removed from the billing dashboard.
- Billing price tile driven by the `Plan` table instead of hardcoded $29/$99/$299.

## Test plan
- `uv run pytest` — 1669 passed on the rebased branch
- `uv run ruff check` / `ruff format --check` / `uv run mypy` clean on the changed view
- Before/after verified with Playwright screenshots of 14 pages against a seeded dev server: icon fonts load with zero console 404s, nav renders, mobile cards no longer clip, prices render once

🤖 Generated with [Claude Code](https://claude.com/claude-code)