### PR TITLE
fix: make first-payment insight fire for Stripe; keep trial-ending notifications attributable

### DIFF
--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from typing import Any, ClassVar, cast
 
 import stripe
+from core.encryption import InvalidToken, decrypt, encrypt, looks_like_token
 from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpRequest
@@ -23,9 +24,17 @@ from webhooks.utils.currency import from_minor_units
 
 logger = logging.getLogger(__name__)
 
-# Cache key prefix and TTL for customer email lookup
+# Cache key prefix and TTL for customer email lookup.
+#
+# The TTL must span the longest gap between an email-carrying event (an
+# invoice) and an email-less subscription event that needs the lookup.
+# customer.subscription.trial_will_end fires ~3 days before a trial ends -
+# up to a month after the $0 trial-creation invoice cached the email. The
+# old 1-hour TTL guaranteed those notifications rendered with no customer
+# identity at all ("Trial ending soon / Stripe"). 45 days covers 30-day
+# trials with headroom; every later invoice refreshes the entry.
 CUSTOMER_EMAIL_CACHE_PREFIX = "stripe_customer_email:"
-CUSTOMER_EMAIL_CACHE_TTL = 3600  # 1 hour
+CUSTOMER_EMAIL_CACHE_TTL = 45 * 24 * 60 * 60  # 45 days
 
 # Maximum allowed gap between a subscription's trial_end and the invoice's
 # period_start for the invoice to count as the first post-trial invoice.
@@ -1323,6 +1332,10 @@ class StripeSourcePlugin(BaseSourcePlugin):
         We cache the email from invoice events so subscription events can
         look it up by customer ID.
 
+        The value is encrypted at rest: customer emails are PII and the
+        long TTL keeps them in Redis for weeks (Slack compliance requires
+        customer PII encrypted at rest in both Postgres and Redis).
+
         Args:
             customer_id: Stripe customer ID (e.g., cus_xxx).
             email: Customer email address.
@@ -1331,7 +1344,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
             return
         try:
             cache_key = f"{CUSTOMER_EMAIL_CACHE_PREFIX}{customer_id}"
-            cache.set(cache_key, email, timeout=CUSTOMER_EMAIL_CACHE_TTL)
+            cache.set(cache_key, encrypt(email), timeout=CUSTOMER_EMAIL_CACHE_TTL)
             logger.debug(f"Cached customer email for {customer_id}")
         except Exception as e:
             # Don't fail webhook processing if caching fails
@@ -1339,6 +1352,10 @@ class StripeSourcePlugin(BaseSourcePlugin):
 
     def _get_cached_customer_email(self, customer_id: str) -> str:
         """Retrieve cached customer email by customer ID.
+
+        Tolerates legacy plaintext entries written before encryption was
+        introduced; an encrypted entry that no configured key can decrypt
+        is treated as a cache miss rather than surfacing ciphertext.
 
         Args:
             customer_id: Stripe customer ID (e.g., cus_xxx).
@@ -1350,10 +1367,20 @@ class StripeSourcePlugin(BaseSourcePlugin):
             return ""
         try:
             cache_key = f"{CUSTOMER_EMAIL_CACHE_PREFIX}{customer_id}"
-            email = cache.get(cache_key)
-            if email:
+            cached = cache.get(cache_key)
+            if cached:
+                email = str(cached)
+                if looks_like_token(email):
+                    try:
+                        email = decrypt(email)
+                    except InvalidToken:
+                        logger.warning(
+                            f"Cached email for {customer_id} could not be "
+                            "decrypted; treating as cache miss"
+                        )
+                        return ""
                 logger.debug(f"Found cached email for {customer_id}")
-                return str(email)
+                return email
         except Exception as e:
             logger.warning(f"Failed to get cached customer email: {e}")
         return ""

--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -2,6 +2,46 @@
 
 This module analyzes payment events and customer data to detect significant
 milestones and generate contextual insights for notifications.
+
+SIGNAL AVAILABILITY CONTRACT
+============================
+
+We only ever see webhook payloads - there is no provider API access. Every
+detector must therefore be built on a signal the provider ACTUALLY sends,
+and must stay silent (return None) when that signal is absent. The two
+failure modes this prevents are both silent in production:
+
+* False positive: defaulting a missing field (e.g. treating unknown order
+  history as 0 labeled every Stripe renewal a "first payment").
+* Dead feature: requiring a field the provider never sends (e.g. keying
+  first-payment solely off Shopify's orders_count made the insight
+  unreachable for Stripe, which never sends order history).
+
+Per-provider signal sources (update this table when adding a detector):
+
+======================  ======================  ==================  ==========
+Signal                  Stripe                  Chargify            Shopify
+======================  ======================  ==================  ==========
+first payment           metadata.billing_reason (none - silent)     orders_count
+                        == "subscription_create"
+lifetime spend (LTV,    (none - silent)         total_spent from    total_spent
+VIP, at-risk)                                   total_revenue_
+                                                in_cents
+customer created_at     (none - anniversary     customer.           customer.
+(anniversary, tenure)   silent)                 created_at          created_at
+trial metadata          parser-derived          (none)              n/a
+failure attempt count   attempt_count/          failure_reason      n/a
+                        next_payment_attempt    only
+customer email          invoices only; cached   customer.email      customer.
+                        (encrypted) for                             email
+                        subscription events
+======================  ======================  ==================  ==========
+
+Note on aggregation: the pending event queue keeps only the winning event's
+metadata. If a detector needs a field from a lower-priority event in the
+same idempotency bucket (e.g. the invoice's billing_reason when
+subscription_created wins), that field must be explicitly merged in
+PendingEventQueue._aggregate_events or it is silently discarded.
 """
 
 import calendar
@@ -186,10 +226,16 @@ class InsightDetector:
     ) -> InsightInfo | None:
         """Detect if this is the customer's first payment.
 
-        Requires the provider to have sent an order count (Shopify embeds
-        it in order webhooks). Absence of history data is NOT evidence of
-        a first payment - Stripe/Chargify payloads carry no history, and
-        defaulting to 0 would label every renewal a "first payment".
+        Two truthful signals, one per provider family:
+
+        - Stripe: the invoice's ``billing_reason`` is "subscription_create"
+          only on a subscription's first invoice (renewals are
+          "subscription_cycle", plan changes "subscription_update").
+        - Shopify: the customer object's order count.
+
+        Absence of BOTH signals is NOT evidence of a first payment -
+        Chargify payloads carry neither, and defaulting to 0 would label
+        every renewal a "first payment".
 
         Args:
             event_data: Event data dictionary.
@@ -200,13 +246,33 @@ class InsightDetector:
         """
         event_type = event_data.get("type", "")
         # Note: trial_started is excluded - no payment has occurred yet
-        if event_type not in ("payment_success", "subscription_created"):
+        if event_type not in (
+            "payment_success",
+            "invoice_paid",
+            "subscription_created",
+        ):
             return None
 
         # Don't show "first payment" for trials - they haven't paid yet
-        metadata = event_data.get("metadata", {})
+        metadata = event_data.get("metadata") or {}
         if metadata.get("is_trial"):
             return None
+
+        # Stripe: first invoice of a new subscription. Require a positive
+        # amount so the $0 invoice Stripe issues when a trial starts (also
+        # billing_reason "subscription_create") never counts as a payment.
+        # Wording is subscription-scoped, not customer-scoped: the webhook
+        # proves this subscription's first payment, but an existing customer
+        # adding a second subscription looks identical - we never claim
+        # more than the payload can prove.
+        if (
+            metadata.get("billing_reason") == "subscription_create"
+            and _to_float(event_data.get("amount")) > 0
+        ):
+            return InsightInfo(
+                icon=self.ICONS["first_payment"],
+                text="First payment for this subscription",
+            )
 
         orders_count = customer_data.get("orders_count")
         if orders_count is None:

--- a/app/webhooks/services/notification_builder.py
+++ b/app/webhooks/services/notification_builder.py
@@ -524,7 +524,11 @@ class NotificationBuilder:
             return "Payment failed"
 
         elif event_type == "subscription_created":
-            return "New customer!"
+            # "New subscription", not "New customer": the webhook proves a
+            # subscription was created, but an existing customer adding a
+            # second subscription fires the same event - never claim more
+            # than the payload can prove.
+            return "New subscription!"
 
         elif event_type == "subscription_updated":
             # Check for upgrade/downgrade

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -492,6 +492,7 @@ class PendingEventQueue:
                     result_customer[field] = customer_data[field]
 
         self._merge_payment_failure(result_event, stored_items)
+        self._merge_paid_invoice_metadata(result_event, stored_items)
 
         logger.info(
             f"Aggregated {len(stored_items)} events: type={result_event.get('type')}, "
@@ -553,6 +554,43 @@ class PendingEventQueue:
             f"Merged payment_failure into {result_event.get('type')} notification "
             f"(reason: {failure_metadata.get('failure_reason', 'unknown')})"
         )
+
+    def _merge_paid_invoice_metadata(
+        self,
+        result_event: dict[str, Any],
+        stored_items: list[dict[str, Any]],
+    ) -> None:
+        """Fold a losing paid invoice's billing_reason into the winner.
+
+        When subscription.created and invoice.paid share an idempotency
+        bucket, the subscription event wins the type contest and its
+        metadata carries no billing_reason. That field is the only
+        truthful first-payment signal Stripe gives us ("subscription_create"
+        appears solely on a subscription's first invoice), so preserve it
+        for InsightDetector instead of discarding it with the loser.
+
+        Args:
+            result_event: Aggregated event data (mutated).
+            stored_items: Original list of stored items.
+        """
+        metadata = result_event.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+            result_event["metadata"] = metadata
+        if metadata.get("billing_reason"):
+            return  # The winner was itself an invoice event
+
+        for item in stored_items:
+            event_data = item["event_data"]
+            if event_data.get("type") not in ("payment_success", "invoice_paid"):
+                continue
+            item_metadata = event_data.get("metadata")
+            if not isinstance(item_metadata, dict):
+                continue
+            billing_reason = item_metadata.get("billing_reason")
+            if billing_reason:
+                metadata["billing_reason"] = billing_reason
+                return
 
     def _warn_if_missing_email(
         self,

--- a/tests/test_event_processing.py
+++ b/tests/test_event_processing.py
@@ -271,8 +271,9 @@ def test_subscription_created_event() -> None:
     notification = processor.build_rich_notification(event_data, customer_data)
     assert isinstance(notification, RichNotification)
     assert notification.type == NotificationType.SUBSCRIPTION_CREATED
-    # Headlines are now event-focused
-    assert "New customer" in notification.headline
+    # Headlines claim only what the webhook proves: a new subscription,
+    # not necessarily a new customer.
+    assert "New subscription" in notification.headline
 
 
 def test_subscription_canceled_event() -> None:

--- a/tests/test_insight_detector_fixes.py
+++ b/tests/test_insight_detector_fixes.py
@@ -130,6 +130,116 @@ class TestFirstPaymentRequiresHistoryFields:
         assert "First payment" in result.text
 
 
+class TestFirstPaymentFromStripeBillingReason:
+    """Stripe first payments are detected via invoice billing_reason.
+
+    Stripe never sends order history, but the first invoice of a
+    subscription is unambiguously marked with billing_reason
+    "subscription_create" (renewals: "subscription_cycle", plan changes:
+    "subscription_update").
+    """
+
+    def test_subscription_create_invoice_is_first_payment(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test a paid invoice with billing_reason=subscription_create fires."""
+        event = {
+            "type": "payment_success",
+            "provider": "stripe",
+            "amount": 49.00,
+            "currency": "USD",
+            "metadata": {"billing_reason": "subscription_create"},
+        }
+        customer_data = {"email": "billing@acme.com", "customer_id": "cus_123"}
+
+        result = detector._detect_first_payment(event, customer_data)
+
+        assert result is not None
+        assert result.icon == "new"
+        assert "First payment" in result.text
+
+    def test_aggregated_subscription_created_event_is_first_payment(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test the aggregated subscription_created winner fires.
+
+        The pending event queue folds the losing invoice's billing_reason
+        into the subscription_created winner's metadata; the detector must
+        honor it on that event type too.
+        """
+        event = {
+            "type": "subscription_created",
+            "provider": "stripe",
+            "amount": 99.00,
+            "currency": "USD",
+            "metadata": {"billing_reason": "subscription_create"},
+        }
+        customer_data = {"email": "billing@acme.com", "customer_id": "cus_123"}
+
+        result = detector._detect_first_payment(event, customer_data)
+
+        assert result is not None
+        assert "First payment" in result.text
+
+    def test_subscription_cycle_renewal_is_not_first_payment(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test a renewal invoice (billing_reason=subscription_cycle) stays silent."""
+        event = {
+            "type": "payment_success",
+            "provider": "stripe",
+            "amount": 49.00,
+            "currency": "USD",
+            "metadata": {"billing_reason": "subscription_cycle"},
+        }
+        customer_data = {"email": "billing@acme.com", "customer_id": "cus_123"}
+
+        result = detector._detect_first_payment(event, customer_data)
+
+        assert result is None
+
+    def test_zero_amount_subscription_create_is_not_first_payment(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test the $0 trial-creation invoice is not labeled a payment.
+
+        When a trial starts, Stripe issues a $0 invoice whose
+        billing_reason is also "subscription_create" - no money moved.
+        """
+        event = {
+            "type": "payment_success",
+            "provider": "stripe",
+            "amount": 0.0,
+            "currency": "USD",
+            "metadata": {"billing_reason": "subscription_create"},
+        }
+        customer_data = {"email": "billing@acme.com", "customer_id": "cus_123"}
+
+        result = detector._detect_first_payment(event, customer_data)
+
+        assert result is None
+
+    def test_trial_metadata_blocks_first_payment(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test is_trial metadata still suppresses the insight."""
+        event = {
+            "type": "subscription_created",
+            "provider": "stripe",
+            "amount": 49.00,
+            "currency": "USD",
+            "metadata": {
+                "billing_reason": "subscription_create",
+                "is_trial": True,
+            },
+        }
+        customer_data = {"email": "billing@acme.com", "customer_id": "cus_123"}
+
+        result = detector._detect_first_payment(event, customer_data)
+
+        assert result is None
+
+
 class TestTrialInsightCurrencyAndInterval:
     """The trial insight honors the event currency and billing interval."""
 

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -250,6 +250,73 @@ class TestPendingEventQueueAggregation:
         assert event["currency"] == "USD"
         assert event["external_id"] == "in_second"
 
+    def test_aggregate_preserves_billing_reason_from_losing_invoice(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test the losing invoice's billing_reason survives aggregation.
+
+        subscription.created wins the type contest over invoice.paid, but
+        the invoice's billing_reason ("subscription_create") is Stripe's
+        only truthful first-payment signal - it must be folded into the
+        winner's metadata for InsightDetector.
+        """
+        stored_items = [
+            {
+                "event_data": {
+                    "type": "subscription_created",
+                    "customer_id": "cus_123",
+                    "amount": 99.00,
+                    "metadata": {"plan_name": "Pro"},
+                },
+                "customer_data": {"email": ""},
+            },
+            {
+                "event_data": {
+                    "type": "payment_success",
+                    "customer_id": "cus_123",
+                    "amount": 99.00,
+                    "metadata": {"billing_reason": "subscription_create"},
+                },
+                "customer_data": {"email": "test@example.com"},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        assert event["type"] == "subscription_created"
+        assert event["metadata"]["billing_reason"] == "subscription_create"
+        assert event["metadata"]["plan_name"] == "Pro"
+
+    def test_aggregate_keeps_winning_invoice_billing_reason(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Test a winning invoice's own billing_reason is not overwritten."""
+        stored_items = [
+            {
+                "event_data": {
+                    "type": "payment_success",
+                    "customer_id": "cus_123",
+                    "amount": 49.00,
+                    "metadata": {"billing_reason": "subscription_cycle"},
+                },
+                "customer_data": {"email": "test@example.com"},
+            },
+            {
+                "event_data": {
+                    "type": "invoice_paid",
+                    "customer_id": "cus_123",
+                    "amount": 49.00,
+                    "metadata": {"billing_reason": "subscription_create"},
+                },
+                "customer_data": {"email": "test@example.com"},
+            },
+        ]
+
+        event, customer = queue._aggregate_events(stored_items)
+
+        assert event["type"] == "payment_success"
+        assert event["metadata"]["billing_reason"] == "subscription_cycle"
+
     def test_aggregate_surfaces_payment_failure_with_subscription_created(
         self, queue: PendingEventQueue
     ) -> None:

--- a/tests/test_stripe_realistic_scenarios.py
+++ b/tests/test_stripe_realistic_scenarios.py
@@ -190,13 +190,18 @@ class TestTrialSignupIntegration:
         header_block = attachment["blocks"][0]
         assert header_block["type"] == "header"
 
-    def test_non_trial_subscription_generates_new_customer_notification(
+    def test_non_trial_subscription_generates_new_subscription_notification(
         self,
         stripe_plugin: StripeSourcePlugin,
         event_processor: EventProcessor,
         customer_data: dict[str, Any],
     ) -> None:
-        """Test that subscription.created with status=active shows 'New customer!'."""
+        """Test that subscription.created with status=active shows 'New subscription!'.
+
+        The headline is subscription-scoped, not customer-scoped: the
+        webhook cannot prove the customer is new (an existing customer
+        adding a second subscription fires the same event).
+        """
         # Create a non-trial subscription payload (status=active, no trial fields)
         active_subscription_data = {
             "id": "sub_active123",
@@ -249,8 +254,8 @@ class TestTrialSignupIntegration:
             event_data, customer_data
         )
 
-        # Verify notification shows "New customer!"
-        assert "New customer" in notification.headline
+        # Verify notification shows "New subscription!"
+        assert "New subscription" in notification.headline
 
     def test_trial_does_not_show_first_payment_insight(
         self,
@@ -1010,24 +1015,58 @@ class TestWebhookCustomerDataExtraction:
     def test_cache_customer_email_from_invoice(
         self, stripe_plugin: StripeSourcePlugin
     ) -> None:
-        """Test that customer email is cached from invoice events."""
+        """Test that customer email is cached encrypted, not as plaintext.
+
+        Emails are PII and the cache TTL keeps them in Redis for weeks,
+        so the stored value must be a ciphertext token.
+        """
+        from core.encryption import decrypt, looks_like_token
+
         with patch("plugins.sources.stripe.cache") as mock_cache:
             stripe_plugin._cache_customer_email("cus_test123", "test@example.com")
 
             mock_cache.set.assert_called_once()
             call_args = mock_cache.set.call_args
             assert call_args[0][0] == "stripe_customer_email:cus_test123"
-            assert call_args[0][1] == "test@example.com"
+            stored_value = call_args[0][1]
+            assert stored_value != "test@example.com"
+            assert looks_like_token(stored_value)
+            assert decrypt(stored_value) == "test@example.com"
+
+    def test_email_cache_ttl_covers_trial_length(self) -> None:
+        """Test the cache TTL outlives a 30-day trial.
+
+        trial_will_end fires ~3 days before the trial ends - up to a month
+        after the invoice event that cached the email. A short TTL makes
+        every trial-ending notification anonymous.
+        """
+        from plugins.sources.stripe import CUSTOMER_EMAIL_CACHE_TTL
+
+        thirty_days = 30 * 24 * 60 * 60
+        assert CUSTOMER_EMAIL_CACHE_TTL > thirty_days
 
     def test_get_cached_customer_email(self, stripe_plugin: StripeSourcePlugin) -> None:
-        """Test that cached customer email is retrieved."""
+        """Test that an encrypted cached email is decrypted on retrieval."""
+        from core.encryption import encrypt
+
+        with patch("plugins.sources.stripe.cache") as mock_cache:
+            mock_cache.get.return_value = encrypt("cached@example.com")
+
+            result = stripe_plugin._get_cached_customer_email("cus_test123")
+
+            assert result == "cached@example.com"
+            mock_cache.get.assert_called_once_with("stripe_customer_email:cus_test123")
+
+    def test_get_cached_customer_email_legacy_plaintext(
+        self, stripe_plugin: StripeSourcePlugin
+    ) -> None:
+        """Test legacy plaintext cache entries are still returned as-is."""
         with patch("plugins.sources.stripe.cache") as mock_cache:
             mock_cache.get.return_value = "cached@example.com"
 
             result = stripe_plugin._get_cached_customer_email("cus_test123")
 
             assert result == "cached@example.com"
-            mock_cache.get.assert_called_once_with("stripe_customer_email:cus_test123")
 
     def test_get_customer_data_uses_cached_email_for_subscription(
         self, stripe_plugin: StripeSourcePlugin


### PR DESCRIPTION
## Problem

Two silent failures in the same category — features consuming data signals the provider never sends for that event:

1. **"First payment" insight never fired for Stripe.** The detector keyed solely off `customer_data["orders_count"]`, a field only Shopify supplies. The earlier fix (9fcd5ff) correctly stopped missing history from defaulting to 0 (which had labeled every renewal a first payment) but over-corrected: Stripe went from "always wrong" to "never fires".
2. **Trial-ending notifications rendered anonymous** ("Trial ending soon / Stripe", no customer). `trial_will_end` payloads carry no email, and the fallback email cache (populated from invoice events) had a 1-hour TTL — but trial_will_end fires ~3 days before trial end, weeks after the last invoice.

## Fix

**First payment (Stripe):**
- Detect via the invoice's `billing_reason == "subscription_create"` — Stripe sets it only on a subscription's first invoice (renewals: `subscription_cycle`, plan changes: `subscription_update`). Require a positive amount so the $0 trial-creation invoice never counts.
- Preserve `billing_reason` through aggregation: when `subscription.created` + `invoice.paid` share an idempotency bucket, the subscription event wins and previously discarded the invoice's metadata — the only truthful first-payment signal with it.

**Claim only what the payload proves** (we never show guessed data):
- Stripe-path insight text is "First payment for this subscription" — the webhook can't prove the *customer* is new (a second subscription from an existing customer looks identical). The Shopify `orders_count` path keeps customer-scoped wording since that signal is customer-level.
- `subscription_created` headline: "New customer!" → "New subscription!" for the same reason.

**Trial-ending identity:**
- Email cache TTL 1h → 45 days (covers 30-day trials with headroom; every later invoice refreshes it).
- Cached emails are now encrypted at rest via `core.encryption` (customer PII in Redis, per #100), with graceful handling of legacy plaintext entries and undecryptable tokens (treated as cache miss).

**Category guard:** `insight_detector.py` module docstring now documents the per-provider signal availability contract (which signal backs each detector, per provider) plus the aggregation-discards-loser-metadata pitfall, so future detectors are only built on signals their provider actually sends.

## Known gaps left silent by design (no truthful webhook signal)

- LTV/VIP/at-risk and anniversaries for Stripe (no lifetime spend / customer created_at in payloads)
- First payment for Chargify (only heuristic signals available, e.g. total_revenue == current amount)

## Testing

- 11 new regression tests (detector billing_reason paths, aggregation preservation, encrypted cache round-trip, TTL floor, legacy plaintext tolerance)
- Full suite: 1705 passed; ruff and mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)