### PR TITLE
feat: add programmatic marketing screenshot suite

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,67 @@
+name: Marketing Screenshots
+
+# Manual-only: these captures exist for the marketing site and docs,
+# not for CI verification.
+on:
+  workflow_dispatch:
+    inputs:
+      screenshot:
+        description: 'Screenshot to capture (e.g. dashboard.py, or "all")'
+        required: false
+        default: 'all'
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    name: Capture Screenshots
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Install Playwright browser dependencies
+        run: uv run playwright install --with-deps chromium
+
+      - name: Capture screenshots
+        run: bin/record_screenshots.sh "${{ github.event.inputs.screenshot }}"
+
+      - name: Upload to Cloudflare R2
+        if: ${{ always() && env.R2_BUCKET != '' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        run: |
+          aws s3 sync screenshots/output/ "s3://${R2_BUCKET}/screenshots/" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --content-type image/png \
+            --cache-control "public, max-age=300" \
+            --exclude "*" --include "*.png" \
+            --no-progress
+
+      - name: Upload screenshots artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: screenshots/output/*.png
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -172,5 +172,8 @@ app/static/tabler-fonts/
 
 # Django collectstatic output
 app/staticfiles/
+
+# Marketing screenshot captures
+screenshots/output/
 shopify.app.toml
 .DS_Store

--- a/bin/record_screenshots.sh
+++ b/bin/record_screenshots.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+SCREENSHOTS_DIR="screenshots"
+OUTPUT_DIR="$SCREENSHOTS_DIR/output"
+
+build_frontend() {
+    echo "Building frontend assets..."
+    bun install --frozen-lockfile
+    bun run build
+}
+
+ensure_browser() {
+    echo "Ensuring Playwright Chromium is installed..."
+    uv run playwright install chromium
+}
+
+run_screenshot() {
+    local file="$1"
+    local basename
+    basename=$(basename "$file" .py)
+    echo "--- Capturing: $file ---"
+    # addopts is cleared to drop --disable-socket: the live server and
+    # the browser both need real sockets.
+    uv run pytest "$file" \
+        --override-ini="python_files=*.py" \
+        --override-ini="python_functions=$basename" \
+        --override-ini="addopts=" \
+        -s
+}
+
+INPUT="${1:-all}"
+
+# Validate input: must be "all" or a safe Python filename (not conftest.py)
+if [[ "$INPUT" != "all" ]]; then
+    if [[ ! "$INPUT" =~ ^[a-zA-Z0-9_-]+\.py$ ]]; then
+        echo "Error: Invalid screenshot name '$INPUT'. Must be 'all' or a filename like 'dashboard.py'"
+        exit 1
+    fi
+    if [[ "$INPUT" == "conftest.py" ]]; then
+        echo "Error: 'conftest.py' is not a valid screenshot target"
+        exit 1
+    fi
+fi
+
+build_frontend
+ensure_browser
+mkdir -p "$OUTPUT_DIR"
+
+if [ "$INPUT" = "all" ]; then
+    echo "Capturing all screenshots..."
+    for file in "$SCREENSHOTS_DIR"/*.py; do
+        [ -f "$file" ] || continue
+        [[ "$(basename "$file")" == "conftest.py" ]] && continue
+        run_screenshot "$file"
+    done
+else
+    FILE="$SCREENSHOTS_DIR/$INPUT"
+    if [ ! -f "$FILE" ]; then
+        echo "Error: $FILE not found"
+        exit 1
+    fi
+    run_screenshot "$FILE"
+fi
+
+echo "Done. Screenshots are in $OUTPUT_DIR/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dev = [
     "pytest-env>=1.6.0",
     "pytest-socket>=0.8.0",
 ]
+# Marketing screenshot capture (bin/record_screenshots.sh)
+screenshots = [
+    "playwright>=1.49,<2.0",
+]
 
 [tool.ruff]
 line-length = 88

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -1,0 +1,53 @@
+# Marketing Screenshots
+
+Programmatic, reproducible screenshots of the app for the marketing
+site, docs, and app-store listings. Every capture boots the real app
+against a seeded demo workspace, so screenshots stay current with the
+UI instead of rotting in a design folder.
+
+The demo data is Office Space themed: the **Initech** workspace is
+owned by Peter Gibbons, with Samir Nagheenanajar as a member and a
+pending invite for Michael Bolton. The activity feed shows Initech's
+customers — Initrode, Chotchkie's, Flingers, Penetrode, and Milton's
+Swingline trial.
+
+## Running locally
+
+```bash
+bin/record_screenshots.sh            # capture everything
+bin/record_screenshots.sh dashboard.py   # capture one scenario
+```
+
+Output lands in `screenshots/output/` (gitignored). The script builds
+the frontend, installs the Playwright Chromium if needed, and runs
+each scenario through pytest with a live server and SQLite — no
+external services required.
+
+## Running in CI
+
+The **Marketing Screenshots** workflow is manual-only: trigger it from
+the Actions tab (workflow_dispatch), optionally naming a single
+scenario file. Captures are uploaded as a build artifact, and synced to
+Cloudflare R2 when the `R2_*` secrets are configured.
+
+## Adding a scenario
+
+Create `screenshots/<name>.py` with a single function named `<name>`
+(the runner maps filename → pytest function). Use the `page` /
+`mobile_page` fixtures for an authenticated session and `shoot()` to
+navigate and capture:
+
+```python
+import pytest
+from playwright.sync_api import Page
+
+from conftest import shoot
+
+
+@pytest.mark.django_db(transaction=True)
+def my_page(page: Page) -> None:
+    shoot(page, "my-page", "/my-page/")
+```
+
+Keep captures at the fixture defaults (1440x900 desktop / 390x844
+mobile, 2x scale) so the set stays visually consistent.

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -49,5 +49,6 @@ def my_page(page: Page) -> None:
     shoot(page, "my-page", "/my-page/")
 ```
 
-Keep captures at the fixture defaults (1440x900 desktop / 390x844
-mobile, 2x scale) so the set stays visually consistent.
+Keep captures at the fixture defaults (1920x1080 desktop frame and
+390x844 mobile frame, both at 2x — output is 3840px / 780px wide, so
+Full HD is the floor) so the set stays visually consistent.

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -14,6 +14,7 @@ Swingline trial.
 ## Running locally
 
 ```bash
+uv sync --all-groups                 # one-time: installs the playwright dependency
 bin/record_screenshots.sh            # capture everything
 bin/record_screenshots.sh dashboard.py   # capture one scenario
 ```

--- a/screenshots/billing.py
+++ b/screenshots/billing.py
@@ -1,0 +1,10 @@
+"""Capture the billing dashboard during an active Pro trial."""
+
+import pytest
+from conftest import shoot
+from playwright.sync_api import Page
+
+
+@pytest.mark.django_db(transaction=True)
+def billing(page: Page) -> None:
+    shoot(page, "billing", "/billing/")

--- a/screenshots/conftest.py
+++ b/screenshots/conftest.py
@@ -1,0 +1,291 @@
+"""Fixtures for capturing marketing screenshots.
+
+Boots the app against the test database via pytest-django's
+``live_server``, seeds a fully Office Space-themed demo workspace
+(Initech), logs in as Peter Gibbons through a forged session cookie
+(the app itself only offers passkey/Slack OAuth), and hands scenarios
+authenticated Playwright pages at marketing-friendly viewports.
+
+Run via ``bin/record_screenshots.sh`` — the suite is intentionally
+outside pytest's ``testpaths`` so normal test runs never collect it.
+"""
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Generator
+from urllib.parse import urlparse
+
+import pytest
+from core.models import (
+    Integration,
+    UserProfile,
+    Workspace,
+    WorkspaceInvitation,
+    WorkspaceMember,
+)
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import Client
+from django.utils import timezone
+from playwright.sync_api import (
+    Browser,
+    BrowserContext,
+    Page,
+    Playwright,
+    sync_playwright,
+)
+
+# Playwright's sync API keeps an asyncio loop alive in the main thread,
+# which trips Django's async-context guard on ORM calls. This is capture
+# tooling, not the app, so the guard adds nothing here.
+os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
+
+DESKTOP_VIEWPORT = {"width": 1440, "height": 900}
+MOBILE_VIEWPORT = {"width": 390, "height": 844}
+OUTPUT_DIR = Path(__file__).parent / "output"
+
+# Initech's customers, straight from the movie
+OFFICE_SPACE_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "payment",
+        "event_type": "payment_success",
+        "provider": "stripe",
+        "status": "success",
+        "amount": 4999.00,
+        "currency": "USD",
+        "headline": "Payment received from Initrode",
+        "company_name": "Initrode",
+        "company_domain": "initrode.com",
+        "customer_email": "billing@initrode.com",
+        "customer_name": "Dom Portwood",
+        "plan_name": "TPS Premium",
+        "card_last4": "4242",
+        "payment_method": "card",
+        "insight_text": "3rd successful payment in a row",
+        "insight_icon": "chart",
+    },
+    {
+        "type": "payment",
+        "event_type": "payment_failure",
+        "provider": "stripe",
+        "status": "failed",
+        "amount": 150.00,
+        "currency": "USD",
+        "headline": "Payment failed for Chotchkie's",
+        "company_name": "Chotchkie's",
+        "company_domain": "chotchkies.com",
+        "customer_email": "joanna@chotchkies.com",
+        "customer_name": "Joanna",
+        "plan_name": "Flair Basic",
+        "card_last4": "0341",
+        "payment_method": "card",
+        "severity": "warning",
+        "insight_text": "2nd failure this week — sounds like a case of the Mondays",
+        "insight_icon": "warning",
+    },
+    {
+        "type": "order",
+        "event_type": "order_created",
+        "provider": "shopify",
+        "status": "success",
+        "amount": 1280.50,
+        "currency": "USD",
+        "headline": "New order from Flingers",
+        "company_name": "Flingers",
+        "company_domain": "flingers.com",
+        "customer_email": "orders@flingers.com",
+        "customer_name": "Brian",
+        "order_number": "#1042",
+    },
+    {
+        "type": "payment",
+        "event_type": "subscription_cancelled",
+        "provider": "chargify",
+        "status": "cancelled",
+        "amount": 89.00,
+        "currency": "USD",
+        "headline": "Subscription cancelled by Penetrode",
+        "company_name": "Penetrode",
+        "company_domain": "penetrode.com",
+        "customer_email": "accounts@penetrode.com",
+        "customer_name": "Bob Slydell",
+        "plan_name": "Two Bobs",
+        "severity": "critical",
+        "insight_text": (
+            "Customer for 14 months, LTV $686 — what would you say they did here?"
+        ),
+        "insight_icon": "warning",
+    },
+    {
+        "type": "payment",
+        "event_type": "trial_started",
+        "provider": "stripe",
+        "status": "pending",
+        "amount": 0,
+        "currency": "USD",
+        "headline": "Trial started for Swingline",
+        "company_name": "Swingline",
+        "company_domain": "swingline.com",
+        "customer_email": "milton@swingline.com",
+        "customer_name": "Milton Waddams",
+        "plan_name": "Stapler Tier",
+    },
+]
+
+
+@pytest.fixture(autouse=True)
+def screenshot_settings(settings) -> None:
+    """Cache the seeded activity feed where the live server can read it.
+
+    ``test_settings`` uses DummyCache, which would leave the dashboard's
+    Recent Activity empty. LocMemCache is shared across threads, so the
+    live-server thread sees what the fixture seeds.
+    """
+    settings.CACHES = {
+        "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
+    }
+
+
+def _seed_activity(workspace: Workspace) -> None:
+    """Store three days of themed webhook activity in the cache."""
+    now = time.time()
+    ws_id = str(workspace.uuid)
+    for day_offset in range(3):
+        date = timezone.now() - timezone.timedelta(days=day_offset)
+        activity_key = f"webhook_activity:{ws_id}:{date.strftime('%Y-%m-%d')}"
+        keys = []
+        for i, event in enumerate(OFFICE_SPACE_EVENTS):
+            # Thin out older days so the feed looks organic
+            if (i + day_offset) % 2 == 0 and day_offset > 0:
+                continue
+            record = dict(event)
+            record["timestamp"] = now - day_offset * 86400 - i * 3600
+            record["external_id"] = f"evt_os_{day_offset}_{i}"
+            record["customer_id"] = f"cus_os_{i:04d}"
+            key = f"webhook_record:os:{ws_id}:{day_offset}:{i}"
+            cache.set(key, record, 7 * 86400)
+            keys.append(key)
+        cache.set(activity_key, keys, 7 * 86400)
+
+
+@pytest.fixture
+def office_space_data(db) -> dict[str, Any]:
+    """Seed the Initech workspace with members, integrations, and activity."""
+    peter = User.objects.create_user(
+        username="peter",
+        email="peter.gibbons@initech.com",
+        first_name="Peter",
+        last_name="Gibbons",
+    )
+    samir = User.objects.create_user(
+        username="samir",
+        email="samir@initech.com",
+        first_name="Samir",
+        last_name="Nagheenanajar",
+    )
+
+    workspace = Workspace.objects.create(
+        name="Initech",
+        subscription_plan="pro",
+        subscription_status="trial",
+    )
+    WorkspaceMember.objects.create(user=peter, workspace=workspace, role="owner")
+    WorkspaceMember.objects.create(user=samir, workspace=workspace, role="user")
+    UserProfile.objects.create(user=peter, workspace=workspace)
+
+    for integration_type in ("slack_notifications", "stripe_customer"):
+        Integration.objects.create(
+            workspace=workspace,
+            integration_type=integration_type,
+            is_active=True,
+            oauth_credentials={"team_name": "initech"},
+        )
+
+    WorkspaceInvitation.objects.create(
+        workspace=workspace,
+        email="michael.bolton@initech.com",
+        role="admin",
+        invited_by=peter,
+    )
+
+    _seed_activity(workspace)
+
+    return {"owner": peter, "member": samir, "workspace": workspace}
+
+
+@pytest.fixture(scope="session")
+def playwright() -> Generator[Playwright, Any, None]:
+    with sync_playwright() as pw:
+        yield pw
+
+
+@pytest.fixture(scope="session")
+def browser(playwright: Playwright) -> Generator[Browser, Any, None]:
+    browser_instance = playwright.chromium.launch(args=["--no-sandbox"])
+    yield browser_instance
+    browser_instance.close()
+
+
+@pytest.fixture
+def session_cookie(office_space_data: dict[str, Any], live_server) -> dict[str, str]:
+    """Authenticated session cookie for the workspace owner."""
+    client = Client()
+    client.force_login(office_space_data["owner"])
+    return {
+        "name": "sessionid",
+        "value": client.cookies["sessionid"].value,
+        "domain": urlparse(live_server.url).hostname,
+        "path": "/",
+    }
+
+
+def _new_context(
+    browser: Browser, live_server, session_cookie: dict[str, str], **kwargs: Any
+) -> BrowserContext:
+    context = browser.new_context(
+        base_url=live_server.url,
+        device_scale_factor=2,  # crisp images for marketing use
+        **kwargs,
+    )
+    context.add_cookies([session_cookie])
+    return context
+
+
+@pytest.fixture
+def page(
+    browser: Browser, live_server, session_cookie: dict[str, str]
+) -> Generator[Page, Any, None]:
+    """Authenticated desktop page."""
+    context = _new_context(
+        browser, live_server, session_cookie, viewport=DESKTOP_VIEWPORT
+    )
+    yield context.new_page()
+    context.close()
+
+
+@pytest.fixture
+def mobile_page(
+    browser: Browser, live_server, session_cookie: dict[str, str]
+) -> Generator[Page, Any, None]:
+    """Authenticated mobile page."""
+    context = _new_context(
+        browser,
+        live_server,
+        session_cookie,
+        viewport=MOBILE_VIEWPORT,
+        is_mobile=True,
+        has_touch=True,
+    )
+    yield context.new_page()
+    context.close()
+
+
+def shoot(target: Page, name: str, path: str, full_page: bool = True) -> None:
+    """Navigate to ``path`` and save ``output/<name>.png``."""
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    target.goto(path, wait_until="networkidle")
+    # Let entrance animations (fade/slide) settle before the capture
+    target.wait_for_timeout(400)
+    target.screenshot(path=str(OUTPUT_DIR / f"{name}.png"), full_page=full_page)
+    print(f"captured {name}.png")

--- a/screenshots/conftest.py
+++ b/screenshots/conftest.py
@@ -41,7 +41,10 @@ from playwright.sync_api import (
 # tooling, not the app, so the guard adds nothing here.
 os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
 
-DESKTOP_VIEWPORT = {"width": 1440, "height": 900}
+# Full HD desktop frame captured at 2x, so output files are 3840px
+# wide (Full HD is the floor, never the ceiling). Full-page captures
+# grow taller as the page requires.
+DESKTOP_VIEWPORT = {"width": 1920, "height": 1080}
 MOBILE_VIEWPORT = {"width": 390, "height": 844}
 OUTPUT_DIR = Path(__file__).parent / "output"
 
@@ -243,11 +246,7 @@ def session_cookie(office_space_data: dict[str, Any], live_server) -> dict[str, 
 def _new_context(
     browser: Browser, live_server, session_cookie: dict[str, str], **kwargs: Any
 ) -> BrowserContext:
-    context = browser.new_context(
-        base_url=live_server.url,
-        device_scale_factor=2,  # crisp images for marketing use
-        **kwargs,
-    )
+    context = browser.new_context(base_url=live_server.url, **kwargs)
     context.add_cookies([session_cookie])
     return context
 
@@ -256,9 +255,13 @@ def _new_context(
 def page(
     browser: Browser, live_server, session_cookie: dict[str, str]
 ) -> Generator[Page, Any, None]:
-    """Authenticated desktop page."""
+    """Authenticated desktop page (Full HD frame at 2x pixels)."""
     context = _new_context(
-        browser, live_server, session_cookie, viewport=DESKTOP_VIEWPORT
+        browser,
+        live_server,
+        session_cookie,
+        viewport=DESKTOP_VIEWPORT,
+        device_scale_factor=2,
     )
     yield context.new_page()
     context.close()
@@ -274,6 +277,7 @@ def mobile_page(
         live_server,
         session_cookie,
         viewport=MOBILE_VIEWPORT,
+        device_scale_factor=2,  # retina-density, matches real phones
         is_mobile=True,
         has_touch=True,
     )

--- a/screenshots/dashboard.py
+++ b/screenshots/dashboard.py
@@ -1,0 +1,17 @@
+"""Capture the dashboard hero shot (desktop and mobile).
+
+Shows the Initech workspace with usage stats and the enriched
+Recent Activity feed: Initrode payments, Chotchkie's churn risk,
+a Flingers order, Penetrode's cancellation, and Milton's Swingline
+trial.
+"""
+
+import pytest
+from conftest import shoot
+from playwright.sync_api import Page
+
+
+@pytest.mark.django_db(transaction=True)
+def dashboard(page: Page, mobile_page: Page) -> None:
+    shoot(page, "dashboard", "/dashboard/")
+    shoot(mobile_page, "dashboard-mobile", "/dashboard/")

--- a/screenshots/integrations.py
+++ b/screenshots/integrations.py
@@ -1,0 +1,15 @@
+"""Capture the integrations page (desktop and mobile).
+
+Shows connected Slack and Stripe integrations alongside the
+available Shopify, Chargify, and Hunter.io connectors.
+"""
+
+import pytest
+from conftest import shoot
+from playwright.sync_api import Page
+
+
+@pytest.mark.django_db(transaction=True)
+def integrations(page: Page, mobile_page: Page) -> None:
+    shoot(page, "integrations", "/integrations/")
+    shoot(mobile_page, "integrations-mobile", "/integrations/")

--- a/screenshots/members.py
+++ b/screenshots/members.py
@@ -1,0 +1,14 @@
+"""Capture the team members page.
+
+Shows Peter Gibbons (owner), Samir Nagheenanajar, and a pending
+admin invitation for Michael Bolton.
+"""
+
+import pytest
+from conftest import shoot
+from playwright.sync_api import Page
+
+
+@pytest.mark.django_db(transaction=True)
+def members(page: Page) -> None:
+    shoot(page, "members", "/workspace/members/")

--- a/screenshots/pricing.py
+++ b/screenshots/pricing.py
@@ -1,0 +1,10 @@
+"""Capture the plan selection (pricing) page."""
+
+import pytest
+from conftest import shoot
+from playwright.sync_api import Page
+
+
+@pytest.mark.django_db(transaction=True)
+def pricing(page: Page) -> None:
+    shoot(page, "pricing", "/select-plan/")

--- a/uv.lock
+++ b/uv.lock
@@ -558,6 +558,73 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/220a7f5824a64a60443fc03b39dfac4ea63a7fb6d481efa27eafa928e7f4/greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4", size = 238141, upload-time = "2026-06-26T18:22:48.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -811,6 +878,9 @@ dev = [
     { name = "pytest-socket" },
     { name = "ruff" },
 ]
+screenshots = [
+    { name = "playwright" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -844,6 +914,7 @@ dev = [
     { name = "pytest-socket", specifier = ">=0.8.0" },
     { name = "ruff", specifier = ">=0.15.22,<0.16.0" },
 ]
+screenshots = [{ name = "playwright", specifier = ">=1.49,<2.0" }]
 
 [[package]]
 name = "packaging"
@@ -870,6 +941,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
 ]
 
 [[package]]
@@ -945,6 +1035,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a programmatic screenshot suite — mirroring sbomify's screencasts setup — that produces reproducible, marketing-ready captures of the app instead of hand-taken screenshots that rot as the UI evolves.

- **`screenshots/`**: pytest + Playwright scenarios that boot the real app via pytest-django's `live_server` against SQLite (no external services), seed a fully Office Space-themed demo workspace, and capture 2x-scale PNGs. The **Initech** workspace is owned by Peter Gibbons, with Samir Nagheenanajar as a member and a pending admin invite for Michael Bolton; the activity feed shows Initrode payments ("TPS Premium"), Chotchkie's churn risk ("Flair Basic"), a Flingers order, Penetrode's cancellation ("Two Bobs"), and Milton's Swingline trial.
- **Scenarios**: dashboard (desktop + mobile), integrations (desktop + mobile), billing, members, pricing — 7 captures total, from a Full HD 1920x1080 desktop frame (390x844 mobile) at `device_scale_factor=2`, so desktop output is 3840px wide.
- **`bin/record_screenshots.sh`**: local runner with the same interface as sbomify's recorder — `all` or a single scenario file, filename→pytest-function mapping via `--override-ini`.
- **`.github/workflows/screenshots.yml`**: **manual-only** (`workflow_dispatch`, no push/PR triggers). Uploads captures as a build artifact and syncs to Cloudflare R2 when the `R2_*` secrets are configured, same as sbomify.
- Playwright ships in its own `screenshots` dependency group; the suite lives outside pytest's `testpaths` so `uv run pytest` never collects it. `screenshots/output/` is gitignored.

Notable plumbing: `DJANGO_ALLOW_ASYNC_UNSAFE` is set inside the suite's conftest only (Playwright's sync API keeps an asyncio loop alive, tripping Django's async guard), and the conftest overrides the test settings' DummyCache with LocMemCache so the seeded activity feed is visible to the live-server thread.

## Test plan

- `bin/record_screenshots.sh` — all 5 scenarios pass locally, 7 PNGs produced; dashboard hero verified visually (fonts, icons, themed data all render)
- `uv run pytest` — 1669 passed, suite not collected
- `uv run ruff check` / `format --check` clean on the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
