### PR TITLE
review: address Copilot comments on PR #125

### DIFF
--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -1374,9 +1374,13 @@ class StripeSourcePlugin(BaseSourcePlugin):
                     try:
                         email = decrypt(email)
                     except InvalidToken:
+                        # Evict the entry: it can never decrypt again, and
+                        # leaving it would repeat this warning (and a doomed
+                        # decrypt attempt) on every lookup until TTL expiry.
+                        cache.delete(cache_key)
                         logger.warning(
                             f"Cached email for {customer_id} could not be "
-                            "decrypted; treating as cache miss"
+                            "decrypted; evicted and treated as cache miss"
                         )
                         return ""
                 logger.debug(f"Found cached email for {customer_id}")

--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -224,7 +224,11 @@ class InsightDetector:
     def _detect_first_payment(
         self, event_data: dict[str, Any], customer_data: dict[str, Any]
     ) -> InsightInfo | None:
-        """Detect if this is the customer's first payment.
+        """Detect a first payment, at the scope the payload can prove.
+
+        Stripe proves a subscription's first payment (the insight says
+        "for this subscription"); Shopify's order count proves a
+        customer's first order (the insight says "from this customer").
 
         Two truthful signals, one per provider family:
 

--- a/tests/test_stripe_realistic_scenarios.py
+++ b/tests/test_stripe_realistic_scenarios.py
@@ -1057,6 +1057,26 @@ class TestWebhookCustomerDataExtraction:
             assert result == "cached@example.com"
             mock_cache.get.assert_called_once_with("stripe_customer_email:cus_test123")
 
+    def test_get_cached_customer_email_evicts_undecryptable_token(
+        self, stripe_plugin: StripeSourcePlugin
+    ) -> None:
+        """Test an undecryptable cached token is evicted, not retried forever.
+
+        A token no configured key can decrypt (e.g. after a bad key
+        rotation) can never succeed again; it must be deleted so every
+        subsequent lookup doesn't repeat the warning and decrypt attempt
+        until TTL expiry.
+        """
+        with patch("plugins.sources.stripe.cache") as mock_cache:
+            mock_cache.get.return_value = "pqc1:not-a-valid-token"
+
+            result = stripe_plugin._get_cached_customer_email("cus_test123")
+
+            assert result == ""
+            mock_cache.delete.assert_called_once_with(
+                "stripe_customer_email:cus_test123"
+            )
+
     def test_get_cached_customer_email_legacy_plaintext(
         self, stripe_plugin: StripeSourcePlugin
     ) -> None:


### PR DESCRIPTION
Copilot's review of #125 landed just as it merged; this addresses both findings:

1. **Stale docstring** — `_detect_first_payment` still said "the customer's first payment" while the Stripe path is deliberately subscription-scoped. The docstring now states the scoping rule explicitly (Stripe proves the subscription's first payment; Shopify's order count proves the customer's first order).
2. **Undecryptable cache entries lingered** — a cached email token no configured key can decrypt (e.g. after a bad key rotation) was left in Redis, repeating the warning and a doomed decrypt attempt on every lookup until TTL expiry (now 45 days). It is now evicted on first failure, with a regression test.

Full suite: 1706 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)