### PR TITLE
fix: working stripe sync lock, race-safe pending-queue finalize, no connection leaks

### DIFF
--- a/app/webhooks/services/billing.py
+++ b/app/webhooks/services/billing.py
@@ -23,8 +23,9 @@ from typing import Any, cast
 import stripe
 from core.models import Workspace
 from core.services.stripe import StripeAPI
-from django.core.cache import cache
 from django.db.models import Q
+
+from .redis_client import get_raw_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -101,9 +102,8 @@ def _get_lock_client() -> Any | None:
         backend is not Redis (e.g. DummyCache in tests) so callers can
         fail open.
     """
-    try:
-        client = cache.client.get_client()  # type: ignore[attr-defined]
-    except Exception:
+    client = get_raw_redis_client()
+    if client is None:
         return None
     # Don't treat MagicMocks from broadly-patched test caches as clients.
     if "Mock" in client.__class__.__name__:

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -273,14 +273,15 @@ class PendingEventQueue:
     def _release_append_lock(self, key: str, token: str) -> None:
         """Release the distributed append lock if still owned.
 
-        Compare-then-delete through the cache API is not atomic (Redis
-        Lua cannot see the backend's prefixed, pickled keys), so a
-        successor acquiring between the get and the delete can still
-        lose its lock - but only within that microsecond window, versus
-        the unconditional delete which clobbered the successor whenever
-        THIS holder ran past the lock TTL. The append lock guards a
-        ~millisecond read-modify-write, so shrinking the exposure to the
-        compare window is the practical fix.
+        Compare-then-delete through the cache API is not atomic (a truly
+        atomic Lua compare-and-delete would mean reimplementing the
+        backend's key prefixing and value serialization against raw
+        Redis), so a successor acquiring between the get and the delete
+        can still lose its lock - but only within that microsecond
+        window, versus the unconditional delete which clobbered the
+        successor whenever THIS holder ran past the lock TTL. The append
+        lock guards a ~millisecond read-modify-write, so shrinking the
+        exposure to the compare window is the practical fix.
 
         Args:
             key: Cache key of the pending list the lock protects.

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -31,6 +31,9 @@ from typing import Any, ClassVar, cast
 from core.models import Integration, Workspace
 from django.conf import settings
 from django.core.cache import cache
+from django.db import connections
+
+from .redis_client import get_raw_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -221,18 +224,38 @@ class PendingEventQueue:
         Raises:
             RuntimeError: If the append lock could not be acquired.
         """
+        if not self._acquire_append_lock(key):
+            raise RuntimeError(f"Could not acquire append lock for {key}")
+        try:
+            existing = cache.get(key) or []
+            existing.append(item)
+            cache.set(key, existing, timeout=self.TTL_SECONDS)
+        finally:
+            self._release_append_lock(key)
+
+    def _acquire_append_lock(self, key: str) -> bool:
+        """Try to acquire the distributed append lock for a pending list.
+
+        Args:
+            key: Cache key of the pending list the lock protects.
+
+        Returns:
+            True when acquired, False when all attempts timed out.
+        """
         lock_key = f"append_lock:{key}"
         for _ in range(APPEND_LOCK_MAX_ATTEMPTS):
             if cache.add(lock_key, "1", timeout=APPEND_LOCK_TTL_SECONDS):
-                try:
-                    existing = cache.get(key) or []
-                    existing.append(item)
-                    cache.set(key, existing, timeout=self.TTL_SECONDS)
-                finally:
-                    cache.delete(lock_key)
-                return
+                return True
             time.sleep(APPEND_LOCK_RETRY_DELAY_SECONDS)
-        raise RuntimeError(f"Could not acquire append lock for {key}")
+        return False
+
+    def _release_append_lock(self, key: str) -> None:
+        """Release the distributed append lock for a pending list.
+
+        Args:
+            key: Cache key of the pending list the lock protects.
+        """
+        cache.delete(f"append_lock:{key}")
 
     def _schedule_processing(
         self,
@@ -260,7 +283,7 @@ class PendingEventQueue:
 
             timer = threading.Timer(
                 self.DELAY_SECONDS,
-                self._process_events,
+                self._process_events_in_thread,
                 args=[idempotency_key, workspace_id, provider_name, workspace],
             )
             timer.daemon = True  # Don't block shutdown
@@ -272,6 +295,32 @@ class PendingEventQueue:
                 f"Scheduled processing in {self.DELAY_SECONDS}s for "
                 f"idempotency_key {idempotency_key}"
             )
+
+    def _process_events_in_thread(
+        self,
+        idempotency_key: str,
+        workspace_id: str,
+        provider_name: str,
+        workspace: Workspace | None,
+    ) -> None:
+        """Run ``_process_events`` in a timer thread, then close DB connections.
+
+        Timer threads die right after this call; without an explicit
+        close, the ORM connection each one opened is never returned to
+        PostgreSQL, leaking one server connection per processed group.
+
+        Args:
+            idempotency_key: Stripe idempotency key.
+            workspace_id: Workspace UUID string.
+            provider_name: Name of the provider.
+            workspace: Workspace model instance.
+        """
+        try:
+            self._process_events(
+                idempotency_key, workspace_id, provider_name, workspace
+            )
+        finally:
+            connections.close_all()
 
     def _process_events(
         self,
@@ -335,9 +384,14 @@ class PendingEventQueue:
 
             attempts_key = f"pending_webhook_attempts:{workspace_id}:{idempotency_key}"
             if success:
-                # Delete pending events only after successful send
-                cache.delete(key)
+                # Remove exactly the items that were sent; events appended
+                # by another worker mid-send stay queued for their own cycle.
+                remainder = self._remove_processed_items(key, stored_items)
                 cache.delete(attempts_key)
+                if remainder:
+                    self._schedule_processing(
+                        idempotency_key, workspace_id, provider_name, workspace
+                    )
             else:
                 # Leave events for the periodic recovery sweep, but give
                 # up loudly on groups that will never deliver (e.g. a
@@ -348,8 +402,14 @@ class PendingEventQueue:
                         f"Giving up on notification for {idempotency_key} after "
                         f"{attempts} failed delivery attempts; dropping events"
                     )
-                    cache.delete(key)
+                    # Drop only what we tried to send; a mid-send append is
+                    # a new group and gets a fresh attempt budget.
+                    remainder = self._remove_processed_items(key, stored_items)
                     cache.delete(attempts_key)
+                    if remainder:
+                        self._schedule_processing(
+                            idempotency_key, workspace_id, provider_name, workspace
+                        )
                 else:
                     logger.warning(
                         f"Notification failed for {idempotency_key}, events left "
@@ -358,6 +418,50 @@ class PendingEventQueue:
         finally:
             # Always release the lock
             self._release_lock(lock_key)
+
+    def _remove_processed_items(
+        self, key: str, processed_items: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Atomically remove the processed items from the pending list.
+
+        The read-aggregate-send sequence runs without the append lock (a
+        Slack HTTP call is far too slow to hold it), so another worker
+        can append an event to the list mid-send. Deleting the key
+        outright would drop that event unprocessed. Under the append
+        lock, remove exactly the items that were aggregated and keep
+        anything that arrived after the snapshot. Items are compared by
+        value; ``_queued_at`` timestamps make equal-looking events from
+        distinct webhooks distinguishable.
+
+        Args:
+            key: Cache key of the pending list.
+            processed_items: Snapshot of the items that were aggregated
+                and sent (or given up on).
+
+        Returns:
+            Items still queued (appended during the send), empty when the
+            list is fully drained.
+        """
+        if not self._acquire_append_lock(key):
+            # Lock stuck (crashed holder past TTL churn): fall back to the
+            # pre-lock behavior of deleting the whole key rather than
+            # leaving the group to be resent forever by the recovery sweep.
+            logger.warning(
+                f"Could not acquire append lock to finalize {key}; "
+                f"deleting the pending list outright"
+            )
+            cache.delete(key)
+            return []
+        try:
+            current = cache.get(key) or []
+            remainder = [item for item in current if item not in processed_items]
+            if remainder:
+                cache.set(key, remainder, timeout=self.TTL_SECONDS)
+            else:
+                cache.delete(key)
+            return remainder
+        finally:
+            self._release_append_lock(key)
 
     def _record_failed_attempt(self, attempts_key: str) -> int:
         """Increment and return the failed-delivery counter for a group.
@@ -808,34 +912,25 @@ class PendingEventQueue:
 
         except Exception as e:
             logger.error(f"Error during orphan recovery scan: {e}", exc_info=True)
+        finally:
+            # Sweeps run in the long-lived recovery thread (or the startup
+            # thread); return their ORM connections instead of holding one
+            # PostgreSQL connection open per thread between sweeps.
+            connections.close_all()
 
         return processed_count
 
-    def _get_redis_client(self):
+    def _get_redis_client(self) -> Any | None:
         """Get a raw Redis client for key scanning.
 
-        Supports django-redis (``cache.client.get_client()``) and Django's
-        built-in RedisCache backend (``cache._cache.get_client()``). The
-        raw client is used ONLY for SCAN; reads and writes always go
+        The raw client is used ONLY for SCAN; reads and writes always go
         through the cache API so key prefixing and serialization stay
         consistent.
 
         Returns:
             Redis client or None if unavailable.
         """
-        try:
-            return cache.client.get_client()  # type: ignore[attr-defined]
-        except AttributeError:
-            pass  # Not django-redis; try Django's built-in backend
-        except Exception as e:
-            logger.warning(f"Cannot access Redis client for orphan recovery: {e}")
-            return None
-
-        try:
-            return cache._cache.get_client(None, write=True)  # type: ignore[attr-defined]
-        except Exception as e:
-            logger.warning(f"Cannot access Redis client for orphan recovery: {e}")
-            return None
+        return get_raw_redis_client()
 
     def _scan_pending_keys(self, redis_client):
         """Scan Redis for pending webhook keys.

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -55,6 +55,12 @@ APPEND_LOCK_TTL_SECONDS = 5
 APPEND_LOCK_MAX_ATTEMPTS = 20
 APPEND_LOCK_RETRY_DELAY_SECONDS = 0.05
 
+# Finalization (removing sent items) runs in worker threads with no
+# request waiting, so it can afford a budget longer than the lock TTL:
+# even a crashed lock holder expires within the wait, keeping the
+# delete-outright fallback for truly pathological cases only.
+APPEND_LOCK_FINALIZE_MAX_ATTEMPTS = 120  # 120 * 0.05s = 6s > 5s TTL
+
 # How often the background sweep retries undelivered events. Combined
 # with TTL_SECONDS this defines the delivery-retry schedule.
 RECOVERY_SWEEP_INTERVAL_SECONDS = 300
@@ -233,17 +239,23 @@ class PendingEventQueue:
         finally:
             self._release_append_lock(key)
 
-    def _acquire_append_lock(self, key: str) -> bool:
+    def _acquire_append_lock(
+        self, key: str, max_attempts: int = APPEND_LOCK_MAX_ATTEMPTS
+    ) -> bool:
         """Try to acquire the distributed append lock for a pending list.
 
         Args:
             key: Cache key of the pending list the lock protects.
+            max_attempts: Acquisition attempts before giving up. Callers
+                on the request path keep the short default; callers that
+                can wait (finalization) pass a budget exceeding the lock
+                TTL so a crashed holder's lock expires within it.
 
         Returns:
             True when acquired, False when all attempts timed out.
         """
         lock_key = f"append_lock:{key}"
-        for _ in range(APPEND_LOCK_MAX_ATTEMPTS):
+        for _ in range(max_attempts):
             if cache.add(lock_key, "1", timeout=APPEND_LOCK_TTL_SECONDS):
                 return True
             time.sleep(APPEND_LOCK_RETRY_DELAY_SECONDS)
@@ -430,8 +442,10 @@ class PendingEventQueue:
         outright would drop that event unprocessed. Under the append
         lock, remove exactly the items that were aggregated and keep
         anything that arrived after the snapshot. Items are compared by
-        value; ``_queued_at`` timestamps make equal-looking events from
-        distinct webhooks distinguishable.
+        value, removing ONE occurrence per processed item so duplicates
+        with identical content keep their multiplicity (``_queued_at``
+        timestamps make equal-looking events from distinct webhooks
+        distinguishable in practice, but this does not rely on it).
 
         Args:
             key: Cache key of the pending list.
@@ -442,9 +456,12 @@ class PendingEventQueue:
             Items still queued (appended during the send), empty when the
             list is fully drained.
         """
-        if not self._acquire_append_lock(key):
-            # Lock stuck (crashed holder past TTL churn): fall back to the
-            # pre-lock behavior of deleting the whole key rather than
+        if not self._acquire_append_lock(
+            key, max_attempts=APPEND_LOCK_FINALIZE_MAX_ATTEMPTS
+        ):
+            # The finalize budget outlasts the lock TTL, so this means
+            # sustained contention, not one crashed holder. Fall back to
+            # the pre-lock behavior of deleting the whole key rather than
             # leaving the group to be resent forever by the recovery sweep.
             logger.warning(
                 f"Could not acquire append lock to finalize {key}; "
@@ -454,7 +471,14 @@ class PendingEventQueue:
             return []
         try:
             current = cache.get(key) or []
-            remainder = [item for item in current if item not in processed_items]
+            remainder = list(current)
+            for item in processed_items:
+                try:
+                    remainder.remove(item)
+                except ValueError:
+                    # Already gone (e.g. the list was rewritten after a
+                    # TTL expiry); nothing to remove for this item.
+                    pass
             if remainder:
                 cache.set(key, remainder, timeout=self.TTL_SECONDS)
             else:

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -26,6 +26,7 @@ import copy
 import logging
 import threading
 import time
+import uuid
 from typing import Any, ClassVar, cast
 
 from core.models import Integration, Workspace
@@ -230,19 +231,25 @@ class PendingEventQueue:
         Raises:
             RuntimeError: If the append lock could not be acquired.
         """
-        if not self._acquire_append_lock(key):
+        token = self._acquire_append_lock(key)
+        if token is None:
             raise RuntimeError(f"Could not acquire append lock for {key}")
         try:
             existing = cache.get(key) or []
             existing.append(item)
             cache.set(key, existing, timeout=self.TTL_SECONDS)
         finally:
-            self._release_append_lock(key)
+            self._release_append_lock(key, token)
 
     def _acquire_append_lock(
         self, key: str, max_attempts: int = APPEND_LOCK_MAX_ATTEMPTS
-    ) -> bool:
+    ) -> str | None:
         """Try to acquire the distributed append lock for a pending list.
+
+        The lock value is a per-acquisition token so release can verify
+        ownership: without it, a holder delayed past the lock TTL (GC
+        pause, slow cache) would unconditionally delete the lock a
+        successor has since acquired, reintroducing concurrent writers.
 
         Args:
             key: Cache key of the pending list the lock protects.
@@ -252,22 +259,36 @@ class PendingEventQueue:
                 TTL so a crashed holder's lock expires within it.
 
         Returns:
-            True when acquired, False when all attempts timed out.
+            The ownership token when acquired, None when all attempts
+            timed out.
         """
         lock_key = f"append_lock:{key}"
+        token = uuid.uuid4().hex
         for _ in range(max_attempts):
-            if cache.add(lock_key, "1", timeout=APPEND_LOCK_TTL_SECONDS):
-                return True
+            if cache.add(lock_key, token, timeout=APPEND_LOCK_TTL_SECONDS):
+                return token
             time.sleep(APPEND_LOCK_RETRY_DELAY_SECONDS)
-        return False
+        return None
 
-    def _release_append_lock(self, key: str) -> None:
-        """Release the distributed append lock for a pending list.
+    def _release_append_lock(self, key: str, token: str) -> None:
+        """Release the distributed append lock if still owned.
+
+        Compare-then-delete through the cache API is not atomic (Redis
+        Lua cannot see the backend's prefixed, pickled keys), so a
+        successor acquiring between the get and the delete can still
+        lose its lock - but only within that microsecond window, versus
+        the unconditional delete which clobbered the successor whenever
+        THIS holder ran past the lock TTL. The append lock guards a
+        ~millisecond read-modify-write, so shrinking the exposure to the
+        compare window is the practical fix.
 
         Args:
             key: Cache key of the pending list the lock protects.
+            token: Ownership token returned by ``_acquire_append_lock``.
         """
-        cache.delete(f"append_lock:{key}")
+        lock_key = f"append_lock:{key}"
+        if cache.get(lock_key) == token:
+            cache.delete(lock_key)
 
     def _schedule_processing(
         self,
@@ -456,9 +477,10 @@ class PendingEventQueue:
             Items still queued (appended during the send), empty when the
             list is fully drained.
         """
-        if not self._acquire_append_lock(
+        token = self._acquire_append_lock(
             key, max_attempts=APPEND_LOCK_FINALIZE_MAX_ATTEMPTS
-        ):
+        )
+        if token is None:
             # The finalize budget outlasts the lock TTL, so this means
             # sustained contention, not one crashed holder. Fall back to
             # the pre-lock behavior of deleting the whole key rather than
@@ -485,7 +507,7 @@ class PendingEventQueue:
                 cache.delete(key)
             return remainder
         finally:
-            self._release_append_lock(key)
+            self._release_append_lock(key, token)
 
     def _record_failed_attempt(self, attempts_key: str) -> int:
         """Increment and return the failed-delivery counter for a group.

--- a/app/webhooks/services/redis_client.py
+++ b/app/webhooks/services/redis_client.py
@@ -1,0 +1,42 @@
+"""Raw Redis client access for the default Django cache.
+
+Coordination primitives that the public cache API cannot express (SCAN
+for key discovery, redis-py distributed locks) need the raw client
+behind the default cache. This helper probes the two supported backend
+shapes: django-redis (``cache.client.get_client()``) and Django's
+built-in ``RedisCache`` (``cache._cache.get_client(None, write=True)``).
+
+Reads and writes must still go through the cache API so key prefixing
+and serialization stay consistent; use the raw client only for
+operations the cache API does not expose (SCAN, locks).
+"""
+
+import logging
+from typing import Any
+
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+
+def get_raw_redis_client() -> Any | None:
+    """Return the raw Redis client backing the default cache, if any.
+
+    Returns:
+        A redis-py client, or None when the default cache is not backed
+        by Redis (e.g. LocMemCache/DummyCache in tests) so callers can
+        degrade gracefully.
+    """
+    try:
+        return cache.client.get_client()  # type: ignore[attr-defined]
+    except AttributeError:
+        pass  # Not django-redis; try Django's built-in backend
+    except Exception as e:
+        logger.warning(f"Cannot access raw Redis client: {e}")
+        return None
+
+    try:
+        return cache._cache.get_client(None, write=True)  # type: ignore[attr-defined]
+    except Exception as e:
+        logger.warning(f"Cannot access raw Redis client: {e}")
+        return None

--- a/app/webhooks/services/redis_client.py
+++ b/app/webhooks/services/redis_client.py
@@ -31,12 +31,16 @@ def get_raw_redis_client() -> Any | None:
         return cache.client.get_client()  # type: ignore[attr-defined]
     except AttributeError:
         pass  # Not django-redis; try Django's built-in backend
-    except Exception as e:
-        logger.warning(f"Cannot access raw Redis client: {e}")
+    except Exception:
+        logger.warning("Cannot access raw Redis client", exc_info=True)
         return None
 
     try:
         return cache._cache.get_client(None, write=True)  # type: ignore[attr-defined]
-    except Exception as e:
-        logger.warning(f"Cannot access raw Redis client: {e}")
+    except AttributeError:
+        # Not a Redis-backed cache at all (LocMemCache/DummyCache in
+        # dev/tests): an expected configuration, not a failure to log.
+        return None
+    except Exception:
+        logger.warning("Cannot access raw Redis client", exc_info=True)
         return None

--- a/tests/test_billing_state_consistency.py
+++ b/tests/test_billing_state_consistency.py
@@ -150,6 +150,42 @@ class FakeCache:
         self.client = _FakeCacheClientWrapper(client)
 
 
+class _FakeBuiltinBackend:
+    """Mimics the inner backend of Django's built-in RedisCache."""
+
+    def __init__(self, client: FakeRedisClient) -> None:
+        """Store the fake client.
+
+        Args:
+            client: Fake Redis client to expose.
+        """
+        self._client = client
+
+    def get_client(self, key: Any = None, *, write: bool = False) -> FakeRedisClient:
+        """Return the underlying fake Redis client.
+
+        Args:
+            key: Ignored cache key (built-in backend signature).
+            write: Ignored write flag (built-in backend signature).
+
+        Returns:
+            The FakeRedisClient.
+        """
+        return self._client
+
+
+class FakeBuiltinCache:
+    """Mimics Django's built-in RedisCache shape: no .client, has ._cache."""
+
+    def __init__(self, client: FakeRedisClient) -> None:
+        """Wrap the fake Redis client.
+
+        Args:
+            client: Fake Redis client backing this cache.
+        """
+        self._cache = _FakeBuiltinBackend(client)
+
+
 @pytest.fixture
 def fake_redis() -> Any:
     """Install a fake Redis-backed cache for the billing lock.
@@ -160,7 +196,7 @@ def fake_redis() -> Any:
     events: list[str] = []
     lock = FakeLock(events)
     client = FakeRedisClient(lock)
-    with patch("webhooks.services.billing.cache", FakeCache(client)):
+    with patch("webhooks.services.redis_client.cache", FakeCache(client)):
         yield lock, client
 
 
@@ -526,6 +562,25 @@ class TestStripeSyncLock:
         no-ops instead of blocking webhook processing."""
         with stripe_sync_lock(CUSTOMER_ID):
             pass  # DummyCache in test settings: must not raise
+
+    def test_lock_works_with_django_builtin_redis_backend(self) -> None:
+        """The lock must engage under Django's built-in RedisCache.
+
+        Production configures django.core.cache.backends.redis.RedisCache,
+        which exposes the raw client via ``cache._cache.get_client`` — NOT
+        the django-redis ``cache.client`` API. Probing only the latter made
+        the lock silently fail open (run unlocked) in production.
+        """
+        events: list[str] = []
+        lock = FakeLock(events)
+        client = FakeRedisClient(lock)
+
+        with patch("webhooks.services.redis_client.cache", FakeBuiltinCache(client)):
+            with stripe_sync_lock(CUSTOMER_ID):
+                pass
+
+        assert events == ["acquire", "release"]
+        assert client.lock_names == [f"stripe_sync_lock:{CUSTOMER_ID}"]
 
 
 class TestSubscriptionDeletedScoping:

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -5,11 +5,16 @@ of webhook events to allow related events to be aggregated before sending
 a single notification.
 """
 
+import copy
 import threading
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from webhooks.services.pending_event_queue import PendingEventQueue
+from webhooks.services.pending_event_queue import (
+    MAX_SEND_ATTEMPTS,
+    PendingEventQueue,
+)
 
 
 class TestPendingEventQueueStorage:
@@ -920,7 +925,7 @@ class TestOrphanRecovery:
         self, queue: PendingEventQueue
     ) -> None:
         """Test that _get_redis_client handles errors gracefully."""
-        with patch("webhooks.services.pending_event_queue.cache") as mock_cache:
+        with patch("webhooks.services.redis_client.cache") as mock_cache:
             mock_cache.client.get_client.side_effect = AttributeError("No client")
             mock_cache._cache.get_client.side_effect = AttributeError("No client")
 
@@ -944,7 +949,7 @@ class TestOrphanRecovery:
         mock_cache = MagicMock(spec=["_cache"])
         mock_cache._cache.get_client.return_value = raw_client
 
-        with patch("webhooks.services.pending_event_queue.cache", mock_cache):
+        with patch("webhooks.services.redis_client.cache", mock_cache):
             result = queue._get_redis_client()
 
         assert result is raw_client
@@ -1533,3 +1538,194 @@ class TestPeriodicRecovery:
                         queue._periodic_recovery_loop(300)
 
         mock_recover.assert_not_called()
+
+
+class InMemoryCache:
+    """Minimal stateful stand-in for the Django cache API.
+
+    Deep-copies values on get/set to mimic the serialization round-trip
+    of a real Redis-backed cache, so identity-based shortcuts in the
+    code under test would be caught.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the empty store."""
+        self.store: dict[str, Any] = {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return a deep copy of the stored value, or the default."""
+        if key not in self.store:
+            return default
+        return copy.deepcopy(self.store[key])
+
+    def set(self, key: str, value: Any, timeout: Any = None) -> None:
+        """Store a deep copy of the value."""
+        self.store[key] = copy.deepcopy(value)
+
+    def add(self, key: str, value: Any, timeout: Any = None) -> bool:
+        """Store the value only if the key is absent (SET NX)."""
+        if key in self.store:
+            return False
+        self.store[key] = copy.deepcopy(value)
+        return True
+
+    def delete(self, key: str) -> None:
+        """Remove the key if present."""
+        self.store.pop(key, None)
+
+
+class TestProcessDeleteRace:
+    """A mid-send append must survive processing (issue #101 finding H4)."""
+
+    KEY = "pending_webhook:ws_456:idem_123"
+
+    @pytest.fixture
+    def queue(self) -> PendingEventQueue:
+        """Create a fresh queue instance with no active timers."""
+        queue = PendingEventQueue()
+        with queue._lock:
+            queue._active_timers.clear()
+        return queue
+
+    @staticmethod
+    def _item(event_type: str, queued_at: float) -> dict[str, Any]:
+        """Build a stored queue item.
+
+        Args:
+            event_type: Normalized event type for the item.
+            queued_at: _queued_at timestamp distinguishing the item.
+
+        Returns:
+            A stored item dict as _store_event would create it.
+        """
+        return {
+            "event_data": {"type": event_type, "_queued_at": queued_at},
+            "customer_data": {"email": "test@example.com"},
+        }
+
+    def test_mid_send_append_survives_successful_send(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """An event appended during the Slack send is kept and rescheduled.
+
+        Before the fix, _process_events deleted the whole key after a
+        successful send, silently dropping any event another worker
+        appended between the read and the delete.
+        """
+        fake_cache = InMemoryCache()
+        item_a = self._item("subscription_created", 1.0)
+        item_b = self._item("invoice_paid", 2.0)
+        fake_cache.store[self.KEY] = [item_a]
+
+        def append_mid_send(*_args: Any, **_kwargs: Any) -> bool:
+            queue._locked_append(self.KEY, item_b)
+            return True
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
+            with patch.object(queue, "_send_notification", side_effect=append_mid_send):
+                with patch.object(queue, "_schedule_processing") as mock_schedule:
+                    queue._process_events("idem_123", "ws_456", "stripe", None)
+
+        assert fake_cache.store[self.KEY] == [item_b]
+        mock_schedule.assert_called_once_with("idem_123", "ws_456", "stripe", None)
+
+    def test_fully_drained_list_is_deleted(self, queue: PendingEventQueue) -> None:
+        """With no mid-send append, a successful send removes the key."""
+        fake_cache = InMemoryCache()
+        fake_cache.store[self.KEY] = [self._item("subscription_created", 1.0)]
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
+            with patch.object(queue, "_send_notification", return_value=True):
+                with patch.object(queue, "_schedule_processing") as mock_schedule:
+                    queue._process_events("idem_123", "ws_456", "stripe", None)
+
+        assert self.KEY not in fake_cache.store
+        mock_schedule.assert_not_called()
+
+    def test_give_up_drops_only_processed_items(self, queue: PendingEventQueue) -> None:
+        """Exhausting MAX_SEND_ATTEMPTS drops the sent group, not newcomers.
+
+        A mid-send append is a new group: it stays queued, gets a fresh
+        attempt budget (the counter is reset), and is rescheduled.
+        """
+        fake_cache = InMemoryCache()
+        attempts_key = "pending_webhook_attempts:ws_456:idem_123"
+        item_a = self._item("subscription_created", 1.0)
+        item_b = self._item("invoice_paid", 2.0)
+        fake_cache.store[self.KEY] = [item_a]
+        fake_cache.store[attempts_key] = MAX_SEND_ATTEMPTS - 1
+
+        def append_mid_send(*_args: Any, **_kwargs: Any) -> bool:
+            queue._locked_append(self.KEY, item_b)
+            return False
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
+            with patch.object(queue, "_send_notification", side_effect=append_mid_send):
+                with patch.object(queue, "_schedule_processing") as mock_schedule:
+                    queue._process_events("idem_123", "ws_456", "stripe", None)
+
+        assert fake_cache.store[self.KEY] == [item_b]
+        assert attempts_key not in fake_cache.store
+        mock_schedule.assert_called_once_with("idem_123", "ws_456", "stripe", None)
+
+
+class TestThreadConnectionCleanup:
+    """Worker threads must return their ORM connections (issue #101 M3)."""
+
+    @pytest.fixture
+    def queue(self) -> PendingEventQueue:
+        """Create a fresh queue instance with no active timers."""
+        queue = PendingEventQueue()
+        with queue._lock:
+            queue._active_timers.clear()
+        return queue
+
+    def test_timer_thread_wrapper_closes_connections(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """The timer entry point closes DB connections after processing."""
+        with patch.object(queue, "_process_events") as mock_process:
+            with patch(
+                "webhooks.services.pending_event_queue.connections"
+            ) as mock_connections:
+                queue._process_events_in_thread("idem_123", "ws_456", "stripe", None)
+
+        mock_process.assert_called_once_with("idem_123", "ws_456", "stripe", None)
+        mock_connections.close_all.assert_called_once()
+
+    def test_timer_thread_wrapper_closes_connections_on_error(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Connections are closed even when processing raises."""
+        with patch.object(queue, "_process_events", side_effect=RuntimeError("boom")):
+            with patch(
+                "webhooks.services.pending_event_queue.connections"
+            ) as mock_connections:
+                with pytest.raises(RuntimeError):
+                    queue._process_events_in_thread(
+                        "idem_123", "ws_456", "stripe", None
+                    )
+
+        mock_connections.close_all.assert_called_once()
+
+    def test_scheduled_timer_targets_thread_wrapper(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Timers run the connection-closing wrapper, not _process_events."""
+        queue._schedule_processing("idem_x", "ws_x", "stripe", None)
+        timer = queue._active_timers["ws_x:idem_x"]
+        try:
+            assert timer.function == queue._process_events_in_thread
+        finally:
+            timer.cancel()
+
+    def test_recovery_sweep_closes_connections(self, queue: PendingEventQueue) -> None:
+        """Each recovery sweep closes the thread's DB connections."""
+        with patch.object(queue, "_get_redis_client", return_value=MagicMock()):
+            with patch.object(queue, "_scan_pending_keys", return_value=iter([])):
+                with patch(
+                    "webhooks.services.pending_event_queue.connections"
+                ) as mock_connections:
+                    queue.recover_orphaned_events()
+
+        mock_connections.close_all.assert_called_once()

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -1668,6 +1668,51 @@ class TestProcessDeleteRace:
         assert attempts_key not in fake_cache.store
         mock_schedule.assert_called_once_with("idem_123", "ws_456", "stripe", None)
 
+    def test_identical_duplicate_appended_mid_send_is_kept(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Removal preserves multiplicity for identical items.
+
+        If an item with byte-identical content is appended mid-send,
+        removing "all equal items" would drop both the processed one and
+        the newcomer; exactly one occurrence per processed item must go.
+        """
+        fake_cache = InMemoryCache()
+        item_a = self._item("subscription_created", 1.0)
+        fake_cache.store[self.KEY] = [item_a]
+
+        def append_identical_mid_send(*_args: Any, **_kwargs: Any) -> bool:
+            queue._locked_append(self.KEY, copy.deepcopy(item_a))
+            return True
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
+            with patch.object(
+                queue, "_send_notification", side_effect=append_identical_mid_send
+            ):
+                with patch.object(queue, "_schedule_processing") as mock_schedule:
+                    queue._process_events("idem_123", "ws_456", "stripe", None)
+
+        assert fake_cache.store[self.KEY] == [item_a]
+        mock_schedule.assert_called_once()
+
+    def test_finalize_lock_budget_outlasts_lock_ttl(self) -> None:
+        """The finalize acquisition budget must exceed the lock TTL.
+
+        A crashed append-lock holder blocks finalization until the lock
+        expires; a budget shorter than the TTL would make finalization
+        reliably fall into the delete-outright fallback in that window.
+        """
+        from webhooks.services.pending_event_queue import (
+            APPEND_LOCK_FINALIZE_MAX_ATTEMPTS,
+            APPEND_LOCK_RETRY_DELAY_SECONDS,
+            APPEND_LOCK_TTL_SECONDS,
+        )
+
+        finalize_budget = (
+            APPEND_LOCK_FINALIZE_MAX_ATTEMPTS * APPEND_LOCK_RETRY_DELAY_SECONDS
+        )
+        assert finalize_budget > APPEND_LOCK_TTL_SECONDS
+
 
 class TestThreadConnectionCleanup:
     """Worker threads must return their ORM connections (issue #101 M3)."""

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -1428,18 +1428,25 @@ class TestLockedAppend:
                     queue._locked_append("pending_webhook:ws:idem", {"x": 1})
 
     def test_append_releases_lock_even_on_error(self, queue: PendingEventQueue) -> None:
-        """Test that the append lock is released when cache.set fails."""
-        with patch("webhooks.services.pending_event_queue.cache") as mock_cache:
-            mock_cache.add.return_value = True
-            mock_cache.get.return_value = []
-            mock_cache.set.side_effect = RuntimeError("redis down")
+        """Test that the append lock is released when cache.set fails.
 
+        Uses the stateful fake because release now verifies ownership
+        (get-compare-delete) before removing the lock.
+        """
+        fake_cache = InMemoryCache()
+        key = "pending_webhook:ws:idem"
+        lock_key = f"append_lock:{key}"
+
+        def failing_set(k: str, value: Any, timeout: Any = None) -> None:
+            raise RuntimeError("redis down")
+
+        fake_cache.set = failing_set  # type: ignore[method-assign]
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
             with pytest.raises(RuntimeError, match="redis down"):
-                queue._locked_append("pending_webhook:ws:idem", {"x": 1})
+                queue._locked_append(key, {"x": 1})
 
-            mock_cache.delete.assert_called_once_with(
-                "append_lock:pending_webhook:ws:idem"
-            )
+        assert lock_key not in fake_cache.store
 
 
 class TestPeriodicRecovery:
@@ -1712,6 +1719,36 @@ class TestProcessDeleteRace:
             APPEND_LOCK_FINALIZE_MAX_ATTEMPTS * APPEND_LOCK_RETRY_DELAY_SECONDS
         )
         assert finalize_budget > APPEND_LOCK_TTL_SECONDS
+
+    def test_stale_release_does_not_clobber_successors_lock(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Release verifies ownership before deleting the lock.
+
+        A holder delayed past the lock TTL (GC pause, slow cache) must
+        not delete the lock a successor has since acquired; only the
+        current owner's token releases it.
+        """
+        fake_cache = InMemoryCache()
+        lock_key = f"append_lock:{self.KEY}"
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
+            stale_token = queue._acquire_append_lock(self.KEY)
+            assert stale_token is not None
+
+            # Simulate TTL expiry followed by a successor's acquisition
+            fake_cache.delete(lock_key)
+            new_token = queue._acquire_append_lock(self.KEY)
+            assert new_token is not None
+            assert new_token != stale_token
+
+            # The stale holder's release is a no-op...
+            queue._release_append_lock(self.KEY, stale_token)
+            assert fake_cache.store[lock_key] == new_token
+
+            # ...while the rightful owner's release works
+            queue._release_append_lock(self.KEY, new_token)
+            assert lock_key not in fake_cache.store
 
 
 class TestThreadConnectionCleanup:


### PR DESCRIPTION
## Summary

Closes out the three remaining defects from the reliability audit in #101 (the queue-API mismatch, recovery guard, and key-prefix bugs were already fixed by #119):

1. **`stripe_sync_lock` was dead in production.** `billing._get_lock_client` probed only the django-redis API (`cache.client.get_client()`), but production configures Django's built-in `RedisCache` — so the per-customer billing lock silently failed open and every write-then-sync sequence ran unlocked. The dual-backend probe that #119 added for orphan recovery is now extracted into a shared helper (`webhooks/services/redis_client.py`) and used by both call sites (DRY per CLAUDE.md).

2. **Process-then-delete race.** `_process_events` did `cache.get` → aggregate → send → `cache.delete`; an event appended by another worker mid-send was deleted unprocessed. Finalization now happens under the existing distributed append lock and removes exactly the items that were sent — anything appended after the snapshot stays queued and is rescheduled for its own cycle. The `MAX_SEND_ATTEMPTS` give-up path likewise drops only the group it tried to send, resetting the attempt budget for newcomers.

3. **Timer threads leaked DB connections.** Timer threads now run `_process_events` through a wrapper that calls `connections.close_all()` in a `finally`, and recovery sweeps close connections after each pass, so worker threads no longer strand one PostgreSQL connection each.

Deliberately NOT in scope: the architectural question from #101 (adopting django-redis vs. moving delayed processing to a real task runner). With these fixes every mechanism works through the public cache API against the built-in backend, so that migration is now an optimization, not a correctness fix.

## Tests

- New: lock engages under the built-in `RedisCache` shape; mid-send append survives a successful send and a give-up; fully-drained list is deleted; timer wrapper and recovery sweep close connections (including on error); scheduled timers target the wrapper.
- Updated: client-probe tests now patch the shared `redis_client` module.
- `uv run pytest`: 1704 passed. `uv run mypy app/`: clean. Ruff: clean.

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)