### PR TITLE
Fix LTV-milestone timing: conservative post-payment reading of lifetime spend

### DIFF
--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -25,8 +25,8 @@ Signal                  Stripe                  Chargify            Shopify
 first payment           metadata.billing_reason (none - silent)     orders_count
                         == "subscription_create"
 lifetime spend (LTV,    (none - silent)         total_spent from    total_spent
-VIP, at-risk)                                   total_revenue_
-                                                in_cents
+VIP, at-risk)                                   total_revenue_      (see note)
+                                                in_cents (see note)
 customer created_at     (none - anniversary     customer.           customer.
 (anniversary, tenure)   silent)                 created_at          created_at
 trial metadata          parser-derived          (none)              n/a
@@ -36,6 +36,17 @@ customer email          invoices only; cached   customer.email      customer.
                         (encrypted) for                             email
                         subscription events
 ======================  ======================  ==================  ==========
+
+Note on lifetime-spend semantics (issue #110): neither Shopify nor
+Chargify documents whether the lifetime-spend snapshot embedded in a
+payment webhook already includes the payment being reported, and
+Shopify's customer aggregates are known to update asynchronously (the
+snapshot can lag the triggering order; the fields were removed from
+webhook payloads entirely in API 2025-01). The LTV-milestone detector
+therefore uses the conservative post-payment reading - the reported
+total is treated as the NEW lifetime value, a proven floor under every
+scenario - so a milestone can fire late but never early or falsely.
+See _detect_ltv_milestone for the full reasoning.
 
 Note on aggregation: the pending event queue keeps only the winning event's
 metadata. If a detector needs a field from a lower-priority event in the
@@ -436,6 +447,32 @@ class InsightDetector:
         treated as $0 - a single large payment would falsely "cross"
         every milestone below its amount.
 
+        Semantics of the reported total (issue #110): neither Shopify
+        nor Chargify documents whether the lifetime-spend snapshot in a
+        payment webhook already includes the payment being reported.
+        For Shopify it is known to be updated ASYNCHRONOUSLY - the
+        customer aggregates can lag the order that triggered the
+        webhook (Shopify's own Flow troubleshooting doc says
+        orders_count/total_spent/last_order_id "will be invalid" for a
+        customer who just ordered until the record refreshes, and the
+        fields were removed from webhook payloads entirely in API
+        2025-01). So the snapshot may be pre-payment, post-payment, or
+        stale, and we must never guess.
+
+        The only reading that can never celebrate EARLY is to treat the
+        reported total as the post-payment ceiling: fire a milestone
+        only when the reported total itself proves it was reached
+        (milestone <= reported) and this payment's window plausibly
+        crossed it (milestone > reported - amount). The reported total
+        is a floor on true lifetime spend under every scenario
+        (post-payment: exact; pre-payment or stale: undercount), so a
+        fired milestone is always genuinely reached. If the snapshot
+        turns out to be pre-payment, the celebration arrives one
+        payment late - per product rule, a delayed celebration beats a
+        false one. Note the strict "crossed under both interpretations"
+        test is the empty set (pre window (r, r+a] and post window
+        (r-a, r] never overlap), so this is the conservative rule.
+
         Args:
             event_data: Event data dictionary.
             customer_data: Customer data dictionary.
@@ -447,12 +484,16 @@ class InsightDetector:
         if event_type != "payment_success":
             return None
 
-        previous_ltv = _get_ltv(customer_data)
-        if previous_ltv is None:
+        reported_total = _get_ltv(customer_data)
+        if reported_total is None:
             return None
 
         current_amount = _to_float(event_data.get("amount"))
-        new_ltv = previous_ltv + current_amount
+        # Post-payment (conservative) reading: the reported total is the
+        # new LTV; the pre-payment LTV is at least reported - amount,
+        # clamped at 0 (a stale snapshot can be smaller than the payment).
+        new_ltv = reported_total
+        previous_ltv = max(reported_total - current_amount, 0.0)
 
         # Celebrate the LARGEST milestone crossed by this payment (a big
         # payment can cross several at once - one Slack message per event).

--- a/tests/test_insight_detector.py
+++ b/tests/test_insight_detector.py
@@ -201,7 +201,8 @@ class TestLTVMilestoneDetection:
         event = {"type": "payment_success", "amount": 200.00}
         customer = {
             "orders_count": 5,
-            "total_spent": 900.00,  # Will cross $1000 with this payment
+            # Reported total is read as post-payment: $900 -> $1,100
+            "total_spent": 1100.00,
             "payment_history": [{"status": "success", "amount": 300}] * 3,
         }
 
@@ -216,7 +217,8 @@ class TestLTVMilestoneDetection:
         event = {"type": "payment_success", "amount": 500.00}
         customer = {
             "orders_count": 20,
-            "total_spent": 4800.00,  # Will cross $5000 with this payment
+            # Reported total is read as post-payment: $4,700 -> $5,200
+            "total_spent": 5200.00,
             "payment_history": [{"status": "success", "amount": 300}] * 5,
         }
 
@@ -246,7 +248,8 @@ class TestLTVMilestoneDetection:
         event = {"type": "payment_success", "amount": 100.00}
         customer = {
             "orders_count": 3,
-            "total_spent": 450.00,  # Will cross $500 with this payment
+            # Reported total is read as post-payment: $420 -> $520
+            "total_spent": 520.00,
             "payment_history": [{"status": "success", "amount": 150}] * 3,
         }
 
@@ -272,7 +275,7 @@ class TestLTVMilestoneDetection:
     def test_milestone_uses_event_currency(self, detector: InsightDetector) -> None:
         """Test that milestone text uses the payment's currency, not $."""
         event = {"type": "payment_success", "amount": 200.00, "currency": "EUR"}
-        customer = {"orders_count": 5, "total_spent": 900.00}
+        customer = {"orders_count": 5, "total_spent": 1100.00}
 
         result = detector._detect_ltv_milestone(event, customer)
 
@@ -288,7 +291,8 @@ class TestLargestLTVMilestone:
         event = {"type": "payment_success", "amount": 60000.00}
         customer = {
             "orders_count": 10,
-            "total_spent": 500.00,
+            # Reported total is read as post-payment: $500 -> $60,500
+            "total_spent": 60500.00,
             "payment_history": [{"status": "success", "amount": 250}] * 2,
         }
 
@@ -305,7 +309,8 @@ class TestLargestLTVMilestone:
         event = {"type": "payment_success", "amount": 200.00}
         customer = {
             "orders_count": 10,
-            "total_spent": 4900.00,  # Crosses only $5,000
+            # Reported total is read as post-payment: crosses only $5,000
+            "total_spent": 5100.00,
             "payment_history": [{"status": "success", "amount": 200}] * 2,
         }
 
@@ -313,6 +318,137 @@ class TestLargestLTVMilestone:
 
         assert result is not None
         assert "5,000" in result.text
+
+
+class TestLTVMilestoneConservativeSemantics:
+    """Regression tests for the conservative total_spent reading (issue #110).
+
+    Neither Shopify nor Chargify documents whether the lifetime-spend
+    snapshot in a payment webhook includes the payment being reported,
+    and Shopify's aggregates update asynchronously. The detector must
+    therefore treat the reported total as the post-payment ceiling: a
+    milestone fires only when reported - amount < milestone <= reported.
+    A celebration may arrive late but can never be early or false.
+    """
+
+    def test_milestone_fires_when_reported_total_proves_it(
+        self, detector: InsightDetector
+    ) -> None:
+        """A reported total at/above the milestone within the payment window fires.
+
+        Reported $1,000 with a $200 payment: window ($800, $1,000] contains
+        the $1,000 milestone, and the customer provably reached $1,000.
+        """
+        event = {"type": "payment_success", "amount": 200.00}
+        customer = {"orders_count": 5, "total_spent": 1000.00}
+
+        result = detector._detect_ltv_milestone(event, customer)
+
+        assert result is not None
+        assert "1,000" in result.text
+
+    def test_no_early_celebration_when_total_below_milestone(
+        self, detector: InsightDetector
+    ) -> None:
+        """A reported total below the milestone must never fire it.
+
+        Under the old pre-payment math, reported $900 + $200 payment
+        claimed "Crossed $1,000 lifetime!". If $900 was already the
+        post-payment total, that celebration was one payment early. The
+        conservative reading stays silent until the provider's own
+        number proves the milestone.
+        """
+        event = {"type": "payment_success", "amount": 200.00}
+        customer = {"orders_count": 5, "total_spent": 900.00}
+
+        result = detector._detect_ltv_milestone(event, customer)
+
+        assert result is None
+
+    def test_stale_zero_snapshot_stays_silent(self, detector: InsightDetector) -> None:
+        """A stale $0 snapshot with a large payment must not fire milestones.
+
+        Shopify's customer aggregates can lag the triggering order, so
+        total_spent "0.00" plus a $1,500 payment proves nothing about
+        lifetime spend having crossed $1,000 - the old math would have
+        celebrated it.
+        """
+        event = {"type": "payment_success", "amount": 1500.00}
+        customer = {"orders_count": 3, "total_spent": "0.00"}
+
+        result = detector._detect_ltv_milestone(event, customer)
+
+        assert result is None
+
+    def test_negative_previous_ltv_clamped_to_zero(
+        self, detector: InsightDetector
+    ) -> None:
+        """A payment larger than the reported total clamps previous LTV to 0.
+
+        Reported $1,200 with a $1,500 payment: reported - amount is
+        negative, so the window becomes ($0, $1,200] and the $1,000
+        milestone (proven by the reported total) still fires.
+        """
+        event = {"type": "payment_success", "amount": 1500.00}
+        customer = {"orders_count": 4, "total_spent": 1200.00}
+
+        result = detector._detect_ltv_milestone(event, customer)
+
+        assert result is not None
+        assert "1,000" in result.text
+
+    def test_zero_amount_payment_never_fires(self, detector: InsightDetector) -> None:
+        """A zero-amount event yields an empty window and stays silent.
+
+        With amount 0 the window (reported, reported] is empty even when
+        the reported total sits exactly on a milestone - nothing was
+        crossed BY this payment.
+        """
+        event = {"type": "payment_success", "amount": 0}
+        customer = {"orders_count": 9, "total_spent": 5000.00}
+
+        result = detector._detect_ltv_milestone(event, customer)
+
+        assert result is None
+
+    def test_chargify_lifetime_value_same_conservative_reading(
+        self, detector: InsightDetector
+    ) -> None:
+        """Chargify-style totals get the same conservative semantics.
+
+        Chargify's total_revenue_in_cents ("total payments since
+        signup") is equally undocumented on whether it includes the
+        payment that triggered the webhook, so the post-payment reading
+        applies: $950 reported + $100 payment does not fire $1,000, but
+        a reported $1,000 does.
+        """
+        event = {"type": "payment_success", "amount": 100.00}
+
+        below = detector._detect_ltv_milestone(
+            event, {"total_spent": 950.00, "customer_id": "chargify_1"}
+        )
+        assert below is None
+
+        proven = detector._detect_ltv_milestone(
+            event, {"total_spent": 1000.00, "customer_id": "chargify_1"}
+        )
+        assert proven is not None
+        assert "1,000" in proven.text
+
+    def test_stripe_without_ltv_field_still_silent(
+        self, detector: InsightDetector
+    ) -> None:
+        """Stripe payloads carry no lifetime-spend field and stay silent.
+
+        The conservative change must not alter Stripe's behavior:
+        unknown LTV is not $0, so no milestone can ever fire.
+        """
+        event = {"type": "payment_success", "amount": 10000.00}
+        customer = {"email": "big@example.com", "customer_id": "cus_123"}
+
+        result = detector._detect_ltv_milestone(event, customer)
+
+        assert result is None
 
 
 class TestAnniversaryDetection:
@@ -874,7 +1010,8 @@ class TestStringLTVHandling:
         event = {"type": "payment_success", "amount": 200.00}
         customer = {
             "orders_count": 5,
-            "total_spent": "900.00",  # String that will cross $1000
+            # String reported total, read as post-payment: crossed $1,000
+            "total_spent": "1100.00",
             "payment_history": [{"status": "success", "amount": 300}] * 3,
         }
 
@@ -888,7 +1025,8 @@ class TestStringLTVHandling:
         event = {"type": "payment_success", "amount": "200.00"}  # String amount
         customer = {
             "orders_count": 5,
-            "total_spent": 900.00,
+            # Reported total is read as post-payment: crossed $1,000
+            "total_spent": 1100.00,
             "payment_history": [{"status": "success", "amount": 300}] * 3,
         }
 
@@ -919,7 +1057,8 @@ class TestInsightPriority:
         event = {"type": "payment_success", "amount": 1500.00}
         customer = {
             "orders_count": 5,
-            "total_spent": 900.00,  # Will cross $1000
+            # Reported total proves $1,000 was crossed by this payment
+            "total_spent": 2000.00,
         }
 
         result = detector.detect(event, customer)


### PR DESCRIPTION
## Summary

Resolves the question in #110: does Shopify's `customer.total_spent` embedded in an `orders/paid` webhook already include the just-paid order?

**Research verdict: inconclusive by design — the snapshot is updated asynchronously and Shopify never documents its inclusion semantics.** The third decision criterion from the issue applies (never show guessed data; a delayed celebration beats a false one), so `_detect_ltv_milestone` now uses the conservative post-payment reading: a milestone fires only when `reported_total - amount < milestone <= reported_total`, with the pre-payment floor clamped at 0.

## Research findings

1. **Shopify does not define the field's timing anywhere.** The REST Customer resource lists `total_spent` in examples without a property definition, and the GraphQL `Customer.amountSpent` / `numberOfOrders` docs say only "in their lifetime" with no statement about whether an in-flight order is included ([GraphQL Customer object](https://shopify.dev/docs/api/admin-graphql/latest/objects/Customer), [REST Customer resource](https://shopify.dev/docs/api/admin-rest/latest/resources/customer)).
2. **The customer aggregates are updated asynchronously and can lag the triggering order.** Shopify's own Flow troubleshooting documentation states that for "customers who have placed an order, but where the customer record itself has not actually been updated," the values `orders_count` (`numberOfOrders`), `total_spent` (`amountSpent`), and `last_order_id` "will be invalid" — the documented workaround is to add a Wait step and re-fetch ([Shopify Flow troubleshooting](https://help.shopify.com/en/manual/shopify-flow/create/troubleshoot)). Community reports confirm the embedded snapshot showing `orders_count: 0` / `total_spent: 0` after a first order, sometimes persisting until the customer record is touched ([community thread: customer order fields out of date](https://community.shopify.com/t/customer-order-related-fields-such-as-orders-count-total-spent-and-last-order-id-are-out-of-date/236314)).
3. **Shopify has been removing these fields from webhooks outright.** They were deprecated from the customer object in order/checkout webhooks (intermittently absent as far back as API 2022-07, [community thread](https://community.shopify.com/t/orders-webhook-in-some-cases-doesnt-have-orders-count-and-total-spent/166704)) and removed from customer webhook payloads in API 2025-01 in favor of the new `customers/purchasing_summary` webhook ([Shopify changelog](https://shopify.dev/changelog/new-customer-s-webhook-and-changes-to-existing-customer-s-webhooks-payload)). Shopify staff guidance is to fetch the customer resource directly instead of relying on the embedded snapshot ([community thread with staff reply](https://community.shopify.com/t/determining-first-time-order/231632)).
4. **Chargify/Maxio is equally undocumented.** `total_revenue_in_cents` is described only as total payments toward the subscription since signup — Maxio relabeled the admin UI "Total Revenue" to "Total Payments" ([Maxio changelog](https://maxio-chargify.zendesk.com/hc/en-us/articles/5405582561037-Total-revenue-on-subscriptions-now-labeled-as-total-payments)) — with no statement on whether the snapshot in a `payment_success` webhook includes the triggering payment.

## Which criterion applied

**Criterion 3 (inconclusive / can go either way).** The snapshot may be pre-payment, post-payment, or stale. One nuance: the literal rule "fire only when crossed under BOTH interpretations" is mathematically the empty set — the pre-payment window `(r, r+a]` and post-payment window `(r-a, r]` never overlap — which would disable the insight entirely. The faithful embodiment of the intent (no early/false celebration ever, delayed is acceptable) is the post-payment reading: firing requires `milestone <= reported_total`, and the reported total is a proven floor on true lifetime spend under every scenario (post-payment: exact; pre-payment or stale: undercount). So no fired milestone can ever be early or false; if the snapshot turns out to be pre-payment, the celebration arrives one payment late. This is also exactly the math the issue prescribed for the post-payment case, including the negative-previous guard (clamped to 0).

## Provider scoping

- **Shopify**: conservative post-payment reading (rationale above).
- **Chargify**: same reading — same documented ambiguity, and the reported total remains a proven floor, so the rule never overstates. If its snapshot is post-payment (likely, since it is serialized after the payment succeeds), the math is exactly right.
- **Stripe**: unaffected — it sends no lifetime-spend field, `_get_ltv` returns None, and the detector stays silent (locked in by a regression test).
- `detect_risk_status` / VIP / at-risk are unchanged: they make current-state claims against the reported floor, which never overstates.

The module docstring's per-provider signal matrix was updated with a lifetime-spend semantics note.

## Tests

- New `TestLTVMilestoneConservativeSemantics` class: milestone fires when the reported total proves it; no early celebration when the total is below the milestone (the exact double-count scenario from the audit); stale `"0.00"` snapshot with a large payment stays silent; negative previous-LTV clamp; zero-amount window is empty; Chargify-style totals get the same reading; Stripe stays silent.
- Existing milestone tests updated to post-payment fixtures.
- Full suite: **1713 passed**; `ruff check`, `ruff format`, and `mypy app/` all clean.

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)