### PR TITLE
feat: encrypt customer PII cached in Redis (Slack encryption-at-rest)

### DIFF
--- a/app/core/encrypted_cache.py
+++ b/app/core/encrypted_cache.py
@@ -49,19 +49,23 @@ def encrypt_cache_value(value: Any) -> str:
     return token
 
 
-def decrypt_cache_value(stored: Any) -> Any:
+def decrypt_cache_value(stored: Any, *, log_failures: bool = True) -> Any:
     """Decode a cache read that may hold an encrypted or legacy value.
 
     Args:
         stored: The raw value returned by ``cache.get``: None (miss), a
             ciphertext token written via :func:`encrypt_cache_value`, or
             a legacy plaintext value written before encryption.
+        log_failures: Warn when a token cannot be decrypted. Callers
+            that detect the failure themselves (raw value present but
+            result None) and emit their own key-specific log pass False
+            to avoid duplicate lines per poisoned entry.
 
     Returns:
         The decrypted, JSON-decoded value; the legacy value unchanged;
         or None for a miss. A token that no configured key can decrypt
-        (key rotated away too early) is logged and treated as a miss
-        rather than surfacing garbage.
+        (key rotated away too early) is treated as a miss rather than
+        surfacing garbage.
     """
     if stored is None:
         return None
@@ -69,9 +73,10 @@ def decrypt_cache_value(stored: Any) -> Any:
         try:
             return json.loads(decrypt(stored))
         except InvalidToken:
-            logger.warning(
-                "Cache value could not be decrypted with any configured key; "
-                "treating as a cache miss"
-            )
+            if log_failures:
+                logger.warning(
+                    "Cache value could not be decrypted with any configured "
+                    "key; treating as a cache miss"
+                )
             return None
     return stored

--- a/app/core/encrypted_cache.py
+++ b/app/core/encrypted_cache.py
@@ -1,0 +1,77 @@
+"""Encrypt/decrypt helpers for PII values stored in the cache (Redis).
+
+Slack Marketplace compliance requires customer data to be encrypted at
+rest in every store, including Redis. These helpers reuse the
+field-encryption cipher (ChaCha20-Poly1305, ``FIELD_ENCRYPTION_KEYS``,
+see :mod:`core.encryption`) so PII-bearing cache values reach Redis as
+ciphertext.
+
+They operate on VALUES, not keys: call sites keep using their own
+``cache.get``/``cache.set`` (preserving key prefixing, TTLs, and test
+patch points) and wrap just the value::
+
+    cache.set(key, encrypt_cache_value(record), timeout=ttl)
+    record = decrypt_cache_value(cache.get(key))
+
+Only PII-bearing values go through these helpers (pending webhook
+payloads, cached customer emails, dashboard activity records).
+Coordination keys stay plaintext on purpose: locks and attempt counters
+rely on SET NX / numeric semantics that ciphertext cannot support, and
+they carry no customer data.
+
+Values are serialized as JSON (``default=str``) before encryption, so
+they must be JSON-representable; non-JSON types (Decimal, datetime) are
+stringified. Legacy plaintext values written before encryption was
+enabled are passed through by :func:`decrypt_cache_value` unchanged, so
+a deploy does not invalidate in-flight cache entries.
+"""
+
+import json
+import logging
+from typing import Any
+
+from core.encryption import InvalidToken, decrypt, encrypt, looks_like_token
+
+logger = logging.getLogger(__name__)
+
+
+def encrypt_cache_value(value: Any) -> str:
+    """Serialize a value to JSON and encrypt it for cache storage.
+
+    Args:
+        value: Any JSON-representable value (non-JSON types are
+            stringified via ``default=str``).
+
+    Returns:
+        A ``pqc1:``-prefixed ciphertext token string.
+    """
+    token: str = encrypt(json.dumps(value, default=str))
+    return token
+
+
+def decrypt_cache_value(stored: Any) -> Any:
+    """Decode a cache read that may hold an encrypted or legacy value.
+
+    Args:
+        stored: The raw value returned by ``cache.get``: None (miss), a
+            ciphertext token written via :func:`encrypt_cache_value`, or
+            a legacy plaintext value written before encryption.
+
+    Returns:
+        The decrypted, JSON-decoded value; the legacy value unchanged;
+        or None for a miss. A token that no configured key can decrypt
+        (key rotated away too early) is logged and treated as a miss
+        rather than surfacing garbage.
+    """
+    if stored is None:
+        return None
+    if isinstance(stored, str) and looks_like_token(stored):
+        try:
+            return json.loads(decrypt(stored))
+        except InvalidToken:
+            logger.warning(
+                "Cache value could not be decrypted with any configured key; "
+                "treating as a cache miss"
+            )
+            return None
+    return stored

--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from typing import Any, ClassVar, cast
 
 import stripe
+from core.encrypted_cache import decrypt_cache_value, encrypt_cache_value
 from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpRequest
@@ -1331,7 +1332,12 @@ class StripeSourcePlugin(BaseSourcePlugin):
             return
         try:
             cache_key = f"{CUSTOMER_EMAIL_CACHE_PREFIX}{customer_id}"
-            cache.set(cache_key, email, timeout=CUSTOMER_EMAIL_CACHE_TTL)
+            # Customer emails are PII and must be encrypted at rest in Redis.
+            cache.set(
+                cache_key,
+                encrypt_cache_value(email),
+                timeout=CUSTOMER_EMAIL_CACHE_TTL,
+            )
             logger.debug(f"Cached customer email for {customer_id}")
         except Exception as e:
             # Don't fail webhook processing if caching fails
@@ -1350,7 +1356,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
             return ""
         try:
             cache_key = f"{CUSTOMER_EMAIL_CACHE_PREFIX}{customer_id}"
-            email = cache.get(cache_key)
+            email = decrypt_cache_value(cache.get(cache_key))
             if email:
                 logger.debug(f"Found cached email for {customer_id}")
                 return str(email)

--- a/app/webhooks/services/database_lookup.py
+++ b/app/webhooks/services/database_lookup.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from core.encrypted_cache import decrypt_cache_value, encrypt_cache_value
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -191,9 +192,11 @@ class DatabaseLookupService:
                 display_type, timestamp_key, workspace_id
             )
 
+            # Records carry customer PII (ids, emails, order data) and
+            # must be encrypted at rest in Redis.
             cache.set(
                 webhook_key,
-                json.dumps(webhook_record, default=str),
+                encrypt_cache_value(webhook_record),
                 timeout=self.ttl_seconds,
             )
 
@@ -337,7 +340,7 @@ class DatabaseLookupService:
 
             cache.set(
                 webhook_key,
-                json.dumps(webhook_record, default=str),
+                encrypt_cache_value(webhook_record),
                 timeout=self.ttl_seconds,
             )
 
@@ -358,6 +361,9 @@ class DatabaseLookupService:
         self, webhook_key: str, workspace_id: str = "global"
     ) -> None:
         """Add webhook key to daily activity list with cleanup.
+
+        The index itself stays plaintext on purpose: it holds only cache
+        key names (no PII); the records those keys point at are encrypted.
 
         Args:
             webhook_key: Redis key for the webhook record.
@@ -492,7 +498,7 @@ class DatabaseLookupService:
 
             cache.set(
                 webhook_key,
-                json.dumps(webhook_record, default=str),
+                encrypt_cache_value(webhook_record),
                 timeout=self.ttl_seconds,
             )
 
@@ -538,9 +544,11 @@ class DatabaseLookupService:
                 if isinstance(webhook_keys, str):
                     webhook_keys = json.loads(webhook_keys)
 
-                # Fetch webhook records
+                # Fetch webhook records (decrypting; legacy plaintext
+                # entries written before encryption come back as JSON
+                # strings and take the json.loads branch)
                 for webhook_key in webhook_keys:
-                    webhook_data = cache.get(webhook_key)
+                    webhook_data = decrypt_cache_value(cache.get(webhook_key))
                     if webhook_data:
                         if isinstance(webhook_data, str):
                             webhook_data = json.loads(webhook_data)

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -498,7 +498,12 @@ class PendingEventQueue:
             cache.delete(key)
             return []
         try:
-            current = decrypt_cache_value(cache.get(key)) or []
+            current = self._read_pending_items(key)
+            if current is None:
+                # The list turned undecryptable mid-send (key rotation in
+                # exactly that window); _read_pending_items already purged
+                # it and logged at error level.
+                return []
             remainder = list(current)
             for item in processed_items:
                 try:

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -28,6 +28,7 @@ import threading
 import time
 from typing import Any, ClassVar, cast
 
+from core.encrypted_cache import decrypt_cache_value, encrypt_cache_value
 from core.models import Integration, Workspace
 from django.conf import settings
 from django.core.cache import cache
@@ -227,9 +228,11 @@ class PendingEventQueue:
         if not self._acquire_append_lock(key):
             raise RuntimeError(f"Could not acquire append lock for {key}")
         try:
-            existing = cache.get(key) or []
+            existing = decrypt_cache_value(cache.get(key)) or []
             existing.append(item)
-            cache.set(key, existing, timeout=self.TTL_SECONDS)
+            # Pending payloads carry customer PII (emails, names, order
+            # data) and must be encrypted at rest in Redis.
+            cache.set(key, encrypt_cache_value(existing), timeout=self.TTL_SECONDS)
         finally:
             self._release_append_lock(key)
 
@@ -360,7 +363,7 @@ class PendingEventQueue:
         try:
             # Get all stored events
             key = f"pending_webhook:{workspace_id}:{idempotency_key}"
-            stored_items = cache.get(key) or []
+            stored_items = decrypt_cache_value(cache.get(key)) or []
 
             if not stored_items:
                 logger.warning(
@@ -453,10 +456,10 @@ class PendingEventQueue:
             cache.delete(key)
             return []
         try:
-            current = cache.get(key) or []
+            current = decrypt_cache_value(cache.get(key)) or []
             remainder = [item for item in current if item not in processed_items]
             if remainder:
-                cache.set(key, remainder, timeout=self.TTL_SECONDS)
+                cache.set(key, encrypt_cache_value(remainder), timeout=self.TTL_SECONDS)
             else:
                 cache.delete(key)
             return remainder
@@ -982,7 +985,7 @@ class PendingEventQueue:
             _, workspace_id, idempotency_key = parts
 
             # Get stored events
-            stored_items = cache.get(key)
+            stored_items = decrypt_cache_value(cache.get(key))
             if not stored_items:
                 return False
 

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -375,7 +375,9 @@ class PendingEventQueue:
         try:
             # Get all stored events
             key = f"pending_webhook:{workspace_id}:{idempotency_key}"
-            stored_items = decrypt_cache_value(cache.get(key)) or []
+            stored_items = self._read_pending_items(key)
+            if stored_items is None:
+                return  # Poisoned entry purged; already logged loudly
 
             if not stored_items:
                 logger.warning(
@@ -489,6 +491,41 @@ class PendingEventQueue:
             return remainder
         finally:
             self._release_append_lock(key)
+
+    def _read_pending_items(self, key: str) -> list[dict[str, Any]] | None:
+        """Read and decrypt the pending list, purging poisoned entries.
+
+        ``decrypt_cache_value`` returns None both for a true miss and for
+        a ciphertext token no configured key can decrypt (e.g. the key
+        was rotated out of ``FIELD_ENCRYPTION_KEYS`` before the entry
+        drained). The two must not be conflated: a poisoned entry would
+        otherwise sit in Redis until TTL expiry, logging "no events
+        found" on every timer/sweep pass while its notifications are
+        silently lost. Purge it (and its attempt counter) loudly instead
+        - it can never be processed.
+
+        Args:
+            key: Cache key of the pending list
+                ("pending_webhook:{workspace}:{idempotency_key}").
+
+        Returns:
+            The decrypted item list ([] when the key is absent), or None
+            when a poisoned entry was found and purged.
+        """
+        raw = cache.get(key)
+        items = decrypt_cache_value(raw)
+        if raw is not None and items is None:
+            logger.error(
+                f"Pending events under {key} could not be decrypted with any "
+                f"configured key (FIELD_ENCRYPTION_KEYS rotated too early?). "
+                f"Dropping the undecryptable entry; its notifications are lost."
+            )
+            cache.delete(key)
+            cache.delete(
+                key.replace("pending_webhook:", "pending_webhook_attempts:", 1)
+            )
+            return None
+        return items or []
 
     def _record_failed_attempt(self, attempts_key: str) -> int:
         """Increment and return the failed-delivery counter for a group.
@@ -1008,8 +1045,8 @@ class PendingEventQueue:
 
             _, workspace_id, idempotency_key = parts
 
-            # Get stored events
-            stored_items = decrypt_cache_value(cache.get(key))
+            # Get stored events (a poisoned entry is purged and skipped)
+            stored_items = self._read_pending_items(key)
             if not stored_items:
                 return False
 

--- a/app/webhooks/services/pending_event_queue.py
+++ b/app/webhooks/services/pending_event_queue.py
@@ -535,7 +535,9 @@ class PendingEventQueue:
             when a poisoned entry was found and purged.
         """
         raw = cache.get(key)
-        items = decrypt_cache_value(raw)
+        # log_failures=False: the key-specific error below covers the
+        # poisoned case; the generic warning would just duplicate it.
+        items = decrypt_cache_value(raw, log_failures=False)
         if raw is not None and items is None:
             logger.error(
                 f"Pending events under {key} could not be decrypted with any "

--- a/app/webhooks/services/webhook_storage.py
+++ b/app/webhooks/services/webhook_storage.py
@@ -2,6 +2,11 @@
 
 This module provides services for storing and retrieving raw webhook
 payloads in Redis with 7-day TTL-based expiration for debugging and analysis.
+
+Raw payloads are the most PII-dense data in the system (full customer
+emails, names, addresses, order contents), so records are encrypted at
+rest via core.encrypted_cache. The daily index stays plaintext: it holds
+only cache key names.
 """
 
 import json
@@ -9,6 +14,7 @@ import logging
 from datetime import timedelta
 from typing import Any
 
+from core.encrypted_cache import decrypt_cache_value, encrypt_cache_value
 from django.core.cache import cache
 from django.http import HttpRequest
 from django.utils import timezone
@@ -136,11 +142,16 @@ class WebhookStorageService:
                 "body_size": len(raw_body),
             }
 
-            # Store in Redis with TTL
+            # Store in Redis with TTL, encrypted (raw payloads carry the
+            # full customer PII of the original webhook)
             webhook_key = self._get_webhook_key(
                 provider_name, workspace_id, timestamp_ms
             )
-            cache.set(webhook_key, json.dumps(webhook_record), timeout=self.ttl_seconds)
+            cache.set(
+                webhook_key,
+                encrypt_cache_value(webhook_record),
+                timeout=self.ttl_seconds,
+            )
 
             # Add to daily index
             date_str = now.strftime("%Y-%m-%d")
@@ -210,7 +221,10 @@ class WebhookStorageService:
 
             results: list[dict[str, Any]] = []
             for key in webhook_keys:
-                webhook_data = cache.get(key)
+                # Decrypting; legacy plaintext entries written before
+                # encryption come back as JSON strings and take the
+                # json.loads branch
+                webhook_data = decrypt_cache_value(cache.get(key))
                 if webhook_data:
                     if isinstance(webhook_data, str):
                         webhook_data = json.loads(webhook_data)

--- a/tests/test_encrypted_cache.py
+++ b/tests/test_encrypted_cache.py
@@ -75,3 +75,21 @@ class TestDecryptCacheValue:
         """
         bogus = TOKEN_PREFIX + "A" * 64
         assert decrypt_cache_value(bogus) is None
+
+    def test_log_failures_false_suppresses_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Callers with their own failure logging can silence the warning.
+
+        The pending queue logs a key-specific error for poisoned
+        entries; a second generic warning per entry would be noise.
+        """
+        bogus = TOKEN_PREFIX + "A" * 64
+
+        with caplog.at_level("WARNING", logger="core.encrypted_cache"):
+            assert decrypt_cache_value(bogus, log_failures=False) is None
+        assert caplog.records == []
+
+        with caplog.at_level("WARNING", logger="core.encrypted_cache"):
+            assert decrypt_cache_value(bogus) is None
+        assert len(caplog.records) == 1

--- a/tests/test_encrypted_cache.py
+++ b/tests/test_encrypted_cache.py
@@ -1,0 +1,77 @@
+"""Tests for the encrypted cache value helpers (issue #100).
+
+Customer PII cached in Redis (pending webhook payloads, customer emails,
+dashboard activity records) must be encrypted at rest. These tests cover
+the value-level helpers plus their rollout compatibility guarantees.
+"""
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from core.encrypted_cache import decrypt_cache_value, encrypt_cache_value
+from core.encryption import TOKEN_PREFIX
+
+
+class TestEncryptCacheValue:
+    """Values are serialized and leave for the cache as ciphertext."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "billing@acme.com",
+            {"email": "a@b.co", "amount": 29.99, "nested": {"names": ["Jo"]}},
+            [{"event_data": {"type": "invoice_paid", "_queued_at": 1721.5}}],
+        ],
+    )
+    def test_roundtrip(self, value: Any) -> None:
+        """Encrypt then decrypt returns an equal value."""
+        token = encrypt_cache_value(value)
+        assert isinstance(token, str)
+        assert token.startswith(TOKEN_PREFIX)
+        assert decrypt_cache_value(token) == value
+
+    def test_plaintext_never_visible_in_token(self) -> None:
+        """The serialized plaintext must not appear in the token."""
+        token = encrypt_cache_value({"email": "secret@example.com"})
+        assert "secret@example.com" not in token
+
+    def test_non_json_types_are_stringified(self) -> None:
+        """Decimal and similar types survive via default=str."""
+        token = encrypt_cache_value({"amount": Decimal("12.30")})
+        assert decrypt_cache_value(token) == {"amount": "12.30"}
+
+
+class TestDecryptCacheValue:
+    """Reads tolerate misses, legacy plaintext, and stale tokens."""
+
+    def test_none_is_a_miss(self) -> None:
+        """A cache miss (None) stays None."""
+        assert decrypt_cache_value(None) is None
+
+    @pytest.mark.parametrize(
+        "legacy",
+        [
+            "plain@example.com",
+            '{"json": "string record"}',
+            [{"event_data": {"type": "invoice_paid"}}],
+            42,
+        ],
+    )
+    def test_legacy_plaintext_passes_through(self, legacy: Any) -> None:
+        """Values written before encryption are returned unchanged.
+
+        A deploy that enables encryption must not invalidate in-flight
+        pending events or cached records.
+        """
+        assert decrypt_cache_value(legacy) == legacy
+
+    def test_undecryptable_token_is_a_miss(self) -> None:
+        """A token no configured key can decrypt degrades to a miss.
+
+        This is the key-rotated-away-too-early case: surfacing the raw
+        token (or raising) would break webhook processing; a cache miss
+        just costs a re-fetch.
+        """
+        bogus = TOKEN_PREFIX + "A" * 64
+        assert decrypt_cache_value(bogus) is None

--- a/tests/test_enriched_storage.py
+++ b/tests/test_enriched_storage.py
@@ -8,6 +8,7 @@ import json
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from core.encrypted_cache import decrypt_cache_value
 from webhooks.models.rich_notification import (
     CompanyInfo,
     CustomerInfo,
@@ -141,7 +142,7 @@ class TestStoreEnrichedRecord:
         # Verify the stored data structure
         first_call_args = mock_cache.set.call_args_list[0]
         stored_key = first_call_args[0][0]
-        webhook_data = json.loads(first_call_args[0][1])
+        webhook_data = decrypt_cache_value(first_call_args[0][1])
 
         # Verify key contains workspace_id
         assert workspace_id in stored_key
@@ -241,7 +242,7 @@ class TestStoreEnrichedRecord:
         assert result is True
 
         first_call_args = mock_cache.set.call_args_list[0]
-        webhook_data = json.loads(first_call_args[0][1])
+        webhook_data = decrypt_cache_value(first_call_args[0][1])
 
         assert "company_name" not in webhook_data
         assert "company_logo_url" not in webhook_data
@@ -282,7 +283,7 @@ class TestStoreEnrichedRecord:
         assert result is True
 
         first_call_args = mock_cache.set.call_args_list[0]
-        webhook_data = json.loads(first_call_args[0][1])
+        webhook_data = decrypt_cache_value(first_call_args[0][1])
 
         assert "insight_text" not in webhook_data
         assert "insight_icon" not in webhook_data
@@ -380,7 +381,7 @@ class TestWorkspaceIsolation:
         assert ":global:" in stored_key
 
         # Verify stored record contains workspace_id field
-        webhook_data = json.loads(first_call_args[0][1])
+        webhook_data = decrypt_cache_value(first_call_args[0][1])
         assert webhook_data["workspace_id"] == "global"
 
     @patch("webhooks.services.database_lookup.cache")
@@ -406,7 +407,7 @@ class TestWorkspaceIsolation:
         )
 
         first_call_args = mock_cache.set.call_args_list[0]
-        webhook_data = json.loads(first_call_args[0][1])
+        webhook_data = decrypt_cache_value(first_call_args[0][1])
         assert webhook_data["workspace_id"] == ws_id
 
     @patch("webhooks.services.database_lookup.cache")

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -1701,7 +1701,7 @@ class TestProcessDeleteRace:
                 with patch.object(queue, "_schedule_processing") as mock_schedule:
                     queue._process_events("idem_123", "ws_456", "stripe", None)
 
-        assert fake_cache.store[self.KEY] == [item_a]
+        assert decrypt_cache_value(fake_cache.store[self.KEY]) == [item_a]
         mock_schedule.assert_called_once()
 
     def test_finalize_lock_budget_outlasts_lock_ttl(self) -> None:
@@ -1721,6 +1721,72 @@ class TestProcessDeleteRace:
             APPEND_LOCK_FINALIZE_MAX_ATTEMPTS * APPEND_LOCK_RETRY_DELAY_SECONDS
         )
         assert finalize_budget > APPEND_LOCK_TTL_SECONDS
+
+
+class TestPoisonedEntryPurge:
+    """Undecryptable pending entries are purged, not skipped forever.
+
+    decrypt_cache_value returns None for both a miss and a token no
+    configured key can decrypt (key rotated away too early). Without
+    distinguishing them, a poisoned entry sits in Redis until TTL
+    expiry, logging "no events found" on every pass while its
+    notifications are silently lost.
+    """
+
+    KEY = "pending_webhook:ws_456:idem_123"
+    ATTEMPTS_KEY = "pending_webhook_attempts:ws_456:idem_123"
+    POISONED = "pqc1:" + "A" * 64  # decrypts with no configured key
+
+    @pytest.fixture
+    def queue(self) -> PendingEventQueue:
+        """Create a fresh queue instance with no active timers."""
+        queue = PendingEventQueue()
+        with queue._lock:
+            queue._active_timers.clear()
+        return queue
+
+    def test_process_events_purges_poisoned_entry(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """Processing deletes an undecryptable entry and sends nothing."""
+        fake_cache = InMemoryCache()
+        fake_cache.store[self.KEY] = self.POISONED
+        fake_cache.store[self.ATTEMPTS_KEY] = 3
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
+            with patch.object(queue, "_send_notification") as mock_send:
+                queue._process_events("idem_123", "ws_456", "stripe", None)
+
+        mock_send.assert_not_called()
+        assert self.KEY not in fake_cache.store
+        assert self.ATTEMPTS_KEY not in fake_cache.store
+
+    def test_recovery_sweep_purges_poisoned_entry(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """The orphan sweep deletes an undecryptable entry, not loops on it."""
+        fake_cache = InMemoryCache()
+        fake_cache.store[self.KEY] = self.POISONED
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
+            recovered = queue._recover_single_event(self.KEY)
+
+        assert recovered is False
+        assert self.KEY not in fake_cache.store
+
+    def test_true_miss_is_not_treated_as_poisoned(
+        self, queue: PendingEventQueue
+    ) -> None:
+        """An absent key still reads as an empty list, nothing deleted."""
+        fake_cache = InMemoryCache()
+        fake_cache.store[self.ATTEMPTS_KEY] = 3
+
+        with patch("webhooks.services.pending_event_queue.cache", fake_cache):
+            items = queue._read_pending_items(self.KEY)
+
+        assert items == []
+        # The attempts counter is untouched on a plain miss
+        assert fake_cache.store[self.ATTEMPTS_KEY] == 3
 
 
 class TestThreadConnectionCleanup:

--- a/tests/test_pending_event_queue.py
+++ b/tests/test_pending_event_queue.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from core.encrypted_cache import decrypt_cache_value, encrypt_cache_value
 from webhooks.services.pending_event_queue import (
     MAX_SEND_ATTEMPTS,
     PendingEventQueue,
@@ -57,8 +58,12 @@ class TestPendingEventQueueStorage:
         queue._store_event("idem_key", "ws_123", event_data, customer_data)
 
         key = "pending_webhook:ws_123:idem_key"
-        stored = mock_cache.get(key)
-        assert stored is not None
+        raw = mock_cache.get(key)
+        assert raw is not None
+        # Payloads carry PII and reach Redis encrypted (issue #100)
+        assert isinstance(raw, str)
+        assert "test@example.com" not in raw
+        stored = decrypt_cache_value(raw)
         assert len(stored) == 1
         # Check original fields are present (plus _queued_at timestamp)
         assert stored[0]["event_data"]["type"] == event_data["type"]
@@ -80,7 +85,7 @@ class TestPendingEventQueueStorage:
         queue._store_event("idem_key", "ws_123", event2, customer2)
 
         key = "pending_webhook:ws_123:idem_key"
-        stored = mock_cache.get(key)
+        stored = decrypt_cache_value(mock_cache.get(key))
         assert len(stored) == 2
 
 
@@ -593,7 +598,7 @@ class TestPendingEventQueueIntegration:
 
         # Check event was stored
         key = "pending_webhook:ws_456:idem_123"
-        stored = mock_cache.get(key)
+        stored = decrypt_cache_value(mock_cache.get(key))
         assert stored is not None
         assert len(stored) == 1
 
@@ -636,7 +641,7 @@ class TestPendingEventQueueIntegration:
 
         # Check both events were stored
         key = "pending_webhook:ws_456:idem_123"
-        stored = mock_cache.get(key)
+        stored = decrypt_cache_value(mock_cache.get(key))
         assert len(stored) == 2
 
         # Clean up
@@ -1141,7 +1146,7 @@ class TestCustomerBasedAggregation:
 
         # Check that key includes time bucket
         expected_key = f"pending_webhook:ws_456:customer:cus_123:t{expected_bucket}"
-        stored = mock_cache.get(expected_key)
+        stored = decrypt_cache_value(mock_cache.get(expected_key))
         assert stored is not None
         assert len(stored) == 1
 
@@ -1164,7 +1169,7 @@ class TestCustomerBasedAggregation:
 
         # Check that key is unchanged (no time bucket)
         expected_key = "pending_webhook:ws_456:req_abc123"
-        stored = mock_cache.get(expected_key)
+        stored = decrypt_cache_value(mock_cache.get(expected_key))
         assert stored is not None
         assert len(stored) == 1
 
@@ -1207,7 +1212,7 @@ class TestCustomerBasedAggregation:
 
         # Both events should be stored under the same key
         expected_key = f"pending_webhook:ws_456:customer:cus_123:t{time_bucket}"
-        stored = mock_cache.get(expected_key)
+        stored = decrypt_cache_value(mock_cache.get(expected_key))
         assert stored is not None
         assert len(stored) == 2
 
@@ -1259,7 +1264,7 @@ class TestCustomerBasedAggregation:
             )
 
         # Event should have been added to the PREVIOUS bucket (not current)
-        stored = mock_cache.get(prev_key)
+        stored = decrypt_cache_value(mock_cache.get(prev_key))
         assert stored is not None
         assert len(stored) == 2  # Original + new event
 
@@ -1615,7 +1620,7 @@ class TestProcessDeleteRace:
         fake_cache = InMemoryCache()
         item_a = self._item("subscription_created", 1.0)
         item_b = self._item("invoice_paid", 2.0)
-        fake_cache.store[self.KEY] = [item_a]
+        fake_cache.store[self.KEY] = encrypt_cache_value([item_a])
 
         def append_mid_send(*_args: Any, **_kwargs: Any) -> bool:
             queue._locked_append(self.KEY, item_b)
@@ -1626,11 +1631,15 @@ class TestProcessDeleteRace:
                 with patch.object(queue, "_schedule_processing") as mock_schedule:
                     queue._process_events("idem_123", "ws_456", "stripe", None)
 
-        assert fake_cache.store[self.KEY] == [item_b]
+        assert decrypt_cache_value(fake_cache.store[self.KEY]) == [item_b]
         mock_schedule.assert_called_once_with("idem_123", "ws_456", "stripe", None)
 
     def test_fully_drained_list_is_deleted(self, queue: PendingEventQueue) -> None:
-        """With no mid-send append, a successful send removes the key."""
+        """With no mid-send append, a successful send removes the key.
+
+        Seeded as a legacy plaintext list: events queued before the
+        encryption deploy must still process and drain.
+        """
         fake_cache = InMemoryCache()
         fake_cache.store[self.KEY] = [self._item("subscription_created", 1.0)]
 
@@ -1652,7 +1661,7 @@ class TestProcessDeleteRace:
         attempts_key = "pending_webhook_attempts:ws_456:idem_123"
         item_a = self._item("subscription_created", 1.0)
         item_b = self._item("invoice_paid", 2.0)
-        fake_cache.store[self.KEY] = [item_a]
+        fake_cache.store[self.KEY] = encrypt_cache_value([item_a])
         fake_cache.store[attempts_key] = MAX_SEND_ATTEMPTS - 1
 
         def append_mid_send(*_args: Any, **_kwargs: Any) -> bool:
@@ -1664,7 +1673,7 @@ class TestProcessDeleteRace:
                 with patch.object(queue, "_schedule_processing") as mock_schedule:
                     queue._process_events("idem_123", "ws_456", "stripe", None)
 
-        assert fake_cache.store[self.KEY] == [item_b]
+        assert decrypt_cache_value(fake_cache.store[self.KEY]) == [item_b]
         assert attempts_key not in fake_cache.store
         mock_schedule.assert_called_once_with("idem_123", "ws_456", "stripe", None)
 

--- a/tests/test_stripe_realistic_scenarios.py
+++ b/tests/test_stripe_realistic_scenarios.py
@@ -16,6 +16,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from core.encrypted_cache import decrypt_cache_value
 from plugins.sources.stripe import StripeSourcePlugin
 from webhooks.models.rich_notification import RichNotification
 from webhooks.services.event_consolidation import EventConsolidationService
@@ -1010,14 +1011,16 @@ class TestWebhookCustomerDataExtraction:
     def test_cache_customer_email_from_invoice(
         self, stripe_plugin: StripeSourcePlugin
     ) -> None:
-        """Test that customer email is cached from invoice events."""
+        """Test that customer email is cached encrypted (PII at rest)."""
         with patch("plugins.sources.stripe.cache") as mock_cache:
             stripe_plugin._cache_customer_email("cus_test123", "test@example.com")
 
             mock_cache.set.assert_called_once()
             call_args = mock_cache.set.call_args
             assert call_args[0][0] == "stripe_customer_email:cus_test123"
-            assert call_args[0][1] == "test@example.com"
+            stored = call_args[0][1]
+            assert "test@example.com" not in stored
+            assert decrypt_cache_value(stored) == "test@example.com"
 
     def test_get_cached_customer_email(self, stripe_plugin: StripeSourcePlugin) -> None:
         """Test that cached customer email is retrieved."""

--- a/tests/test_webhook_storage.py
+++ b/tests/test_webhook_storage.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from core.encrypted_cache import decrypt_cache_value
 from django.http import HttpRequest
 from django.test.client import RequestFactory
 from django.utils import timezone
@@ -136,10 +137,13 @@ class TestWebhookStorageService:
         # Verify cache.set was called for the webhook record
         assert mock_cache.set.call_count >= 1
 
-        # Check the webhook record structure
+        # Check the webhook record structure (stored encrypted - raw
+        # payloads are the most PII-dense data in the system)
         first_call_args = mock_cache.set.call_args_list[0]
         webhook_key = first_call_args[0][0]
-        webhook_data = json.loads(first_call_args[0][1])
+        stored_value = first_call_args[0][1]
+        assert stored_value.startswith("pqc1:")
+        webhook_data = decrypt_cache_value(stored_value)
 
         assert webhook_key.startswith("webhook_raw:stripe:workspace123:")
         assert webhook_data["provider"] == "stripe"
@@ -167,7 +171,7 @@ class TestWebhookStorageService:
         assert result is True
         first_call_args = mock_cache.set.call_args_list[0]
         webhook_key = first_call_args[0][0]
-        webhook_data = json.loads(first_call_args[0][1])
+        webhook_data = decrypt_cache_value(first_call_args[0][1])
 
         assert "global" in webhook_key
         assert webhook_data["workspace_uuid"] == "global"


### PR DESCRIPTION
> **Stacked on #128** (base branch `fix/redis-reliability-followups`) because both rework the pending-event queue's cache reads/writes. Merge #128 first; GitHub will retarget this PR to master automatically.

## Summary

Completes the application-side scope of #100: customer PII cached in Redis is now encrypted at rest, reusing the ChaCha20-Poly1305 / `FIELD_ENCRYPTION_KEYS` cipher that PR #120 built for DB credential fields.

Covered sites (the three flagged in the issue):
- **Pending webhook payloads** (`pending_event_queue`) — emails, names, amounts, order data
- **Cached Stripe customer emails** (`stripe_customer_email:*`)
- **Dashboard activity records** (`database_lookup` payment/order/enriched records)
- **Raw webhook payloads** (`webhook_raw:*`, `webhook_storage.py`) — found in a repo-wide key-family audit; not in the issue's original list but the most PII-dense store of all (full bodies, 7-day TTL, written on every webhook)

Design: a new `core/encrypted_cache.py` provides `encrypt_cache_value` / `decrypt_cache_value` that operate on **values**, not keys — call sites keep their own `cache.get`/`cache.set` (preserving TTLs, key prefixing, and existing test patch points). Values are JSON-serialized (`default=str`) then encrypted to the same `pqc1:` token format as the DB fields, so key rotation covers both stores with one env var.

Rollout safety:
- Legacy plaintext values written before the deploy pass through `decrypt_cache_value` unchanged — in-flight pending events and cached records keep working (covered by tests).
- A token no configured key can decrypt (rotated away too early) degrades to a cache miss with a warning instead of breaking webhook processing.
- Deliberately plaintext: locks, attempt counters, the sweep marker, and the daily activity **key index** (a list of cache key names, no PII) — these rely on SET NX / numeric semantics ciphertext cannot support.

## What this does NOT cover

Infrastructure-level at-rest encryption on the managed Redis/Postgres volumes (the other half of the issue's recommendation) is an ops action outside this repo — worth doing for the Slack compliance checklist regardless of this PR.

## Tests

New `tests/test_encrypted_cache.py` (roundtrip, plaintext-never-in-token, legacy passthrough, stale-token-as-miss, `default=str` behavior); pending-queue storage/race tests now assert ciphertext reaches the store and decrypts correctly; Stripe email test asserts the email is not visible in the stored value; enriched-storage tests decrypt before asserting. Full suite: 1715 passed. mypy + ruff clean.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rollout & rollback notes

- **Upgrade** is seamless: legacy plaintext values (pickled pending lists, plaintext emails, JSON records) pass through `decrypt_cache_value` unchanged; covered by tests.
- **Rollback** is not clean: entries written after this deploy are ciphertext the old code can't read (the old email cache would even surface the raw token as the "email", 1h TTL). If a rollback is ever needed, flush the Redis cache with it — its contents are re-derivable/TTL-bounded.
- **Key rotation**: unlike DB rows, cache entries can't be batch re-encrypted. Keep the old key in `FIELD_ENCRYPTION_KEYS` until the longest cache TTL has passed (activity records: 7 days by default) or flush Redis; a prematurely-rotated key hits the poisoned-entry path (purged loudly for pending events, cache miss elsewhere).
- **Type fidelity**: only Stripe events enter the pending queue (Shopify/Chargify process immediately), and Stripe floats amounts at the boundary, so the JSON round-trip introduces no type changes to queued data; dashboard records and the email cache were already JSON/strings.


## Verified against real Redis

A 22-assertion smoke test was run against a real Redis 7 with Django's built-in `RedisCache` backend (the production configuration): ciphertext-on-the-wire (no plaintext PII in raw Redis bytes), full queue→process→finalize pass, legacy plaintext drain, mid-send-append survival, orphan-recovery SCAN through the real `KEY_PREFIX`, email cache roundtrip + legacy read, dashboard record roundtrip, poisoned-entry purge, and the #128 billing lock engaging on a real redis-py lock. Also confirmed: with `FIELD_ENCRYPTION_KEYS` unset and `DEBUG=False`, writes fail loud (`ImproperlyConfigured`) rather than silently storing plaintext.
