### PR TITLE
feat: detect Chargify first payments via signup_success revenue

### DIFF
--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -70,6 +70,9 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         "subscription_updated": "subscription_updated",
         "subscription_cancelled": "subscription_canceled",
         "subscription_expired": "subscription_canceled",
+        # A successful signup creates the subscription; trialing signups
+        # are re-typed to trial_started by _parse_signup_success.
+        "signup_success": "subscription_created",
     }
 
     # Subscription states that represent the end of a subscription. A
@@ -92,7 +95,6 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             "invoice_created",
             "invoice_updated",
             "invoice_paid",
-            "signup_success",
             "signup_failure",
             "component_allocation_change",
         }
@@ -354,12 +356,22 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             # Only set when the payload actually carries the field:
             # LTV-based detectors treat a missing key as "unknown" and
             # stay silent, whereas a defaulted 0 would let a single big
-            # payment falsely "cross" milestones.
+            # payment falsely "cross" milestones. A malformed value is
+            # skipped the same way - this optional analytics field must
+            # never fail the whole webhook (a 400 makes Chargify retry
+            # the event forever).
             total_revenue_cents = self._current_webhook_data.get(
                 "payload[subscription][total_revenue_in_cents]"
             )
             if total_revenue_cents is not None:
-                customer_data["total_spent"] = float(total_revenue_cents) / 100
+                try:
+                    customer_data["total_spent"] = float(total_revenue_cents) / 100
+                except (ValueError, TypeError):
+                    logger.warning(
+                        "Ignoring malformed total_revenue_in_cents in "
+                        "Chargify customer data",
+                        extra={"customer_id": customer_id},
+                    )
 
             return customer_data
         except (KeyError, ValueError) as e:
@@ -423,6 +435,8 @@ class ChargifySourcePlugin(BaseSourcePlugin):
         ):
             # Product and billing date changes are handled like state changes
             return self._parse_subscription_state_change(event_type, data)
+        elif event_type == "signup_success":
+            return self._parse_signup_success(data)
         elif event_type in self.EVENT_TYPE_MAPPING:
             # Remaining routable events are subscription lifecycle events
             return self._parse_subscription_lifecycle(event_type, data)
@@ -825,6 +839,58 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             },
             "customer_data": customer_data,
         }
+
+    def _parse_signup_success(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Parse signup_success webhook data.
+
+        A signup CREATES the subscription, so the payload's
+        total_revenue_in_cents can only contain money collected by this
+        signup - prior payments are impossible on a brand-new
+        subscription. Revenue > 0 therefore proves a first payment
+        (surfaced as ``is_signup_payment`` metadata for InsightDetector);
+        a missing or still-zero revenue counter merely loses the insight,
+        never fabricates one.
+
+        Trialing signups are emitted as ``trial_started`` (mirroring the
+        Stripe parser's re-typing) with no payment claim, even when a
+        setup fee collected revenue - conservative over clever.
+
+        Args:
+            data: Form data dictionary.
+
+        Returns:
+            Parsed event data dictionary.
+        """
+        event = self._parse_subscription_lifecycle("signup_success", data)
+
+        if data.get("payload[subscription][state]") == "trialing":
+            event["type"] = "trial_started"
+            event["metadata"]["is_trial"] = True
+            return event
+
+        revenue_cents = data.get("payload[subscription][total_revenue_in_cents]")
+        if revenue_cents in (None, ""):
+            return event
+
+        currency = self._extract_currency(data)
+        try:
+            revenue = self._parse_amount_cents(revenue_cents, currency)
+        except InvalidDataError:
+            # A malformed optional field must not reject the signup event
+            logger.warning(
+                "Ignoring malformed total_revenue_in_cents on signup_success",
+                extra={
+                    "subscription_id": data.get("payload[subscription][id]", ""),
+                },
+            )
+            return event
+
+        if revenue > 0:
+            event["amount"] = float(revenue)
+            event["currency"] = currency
+            event["metadata"]["is_signup_payment"] = True
+
+        return event
 
     def get_event_type(self, event_data: dict[str, Any]) -> str:
         """Get event type from webhook data.

--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -363,7 +363,9 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             total_revenue_cents = self._current_webhook_data.get(
                 "payload[subscription][total_revenue_in_cents]"
             )
-            if total_revenue_cents is not None:
+            # "" is how a form-encoded payload spells "absent" - skip it
+            # silently rather than warn on every such webhook.
+            if total_revenue_cents not in (None, ""):
                 try:
                     customer_data["total_spent"] = float(total_revenue_cents) / 100
                 except (ValueError, TypeError):

--- a/app/plugins/sources/chargify.py
+++ b/app/plugins/sources/chargify.py
@@ -366,9 +366,15 @@ class ChargifySourcePlugin(BaseSourcePlugin):
             # "" is how a form-encoded payload spells "absent" - skip it
             # silently rather than warn on every such webhook.
             if total_revenue_cents not in (None, ""):
+                # Same minor-unit conversion as every payment amount:
+                # a hardcoded /100 would be 100x off for zero-decimal
+                # currencies like JPY.
+                currency = self._extract_currency(self._current_webhook_data)
                 try:
-                    customer_data["total_spent"] = float(total_revenue_cents) / 100
-                except (ValueError, TypeError):
+                    customer_data["total_spent"] = float(
+                        self._parse_amount_cents(total_revenue_cents, currency)
+                    )
+                except InvalidDataError:
                     logger.warning(
                         "Ignoring malformed total_revenue_in_cents in "
                         "Chargify customer data",

--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -17,28 +17,30 @@ failure modes this prevents are both silent in production:
   first-payment solely off Shopify's orders_count made the insight
   unreachable for Stripe, which never sends order history).
 
-Per-provider signal sources (update this table when adding a detector):
+Per-provider signal sources (update this list when adding a detector):
 
-======================  ======================  ==================  ==========
-Signal                  Stripe                  Chargify            Shopify
-======================  ======================  ==================  ==========
-first payment           metadata.billing_reason is_signup_payment   orders_count
-                        == "subscription_create" from signup_success
-                                                revenue
-lifetime spend (LTV,    (none - silent)         total_spent from    total_spent
-VIP, at-risk)                                   total_revenue_      (see note)
-                                                in_cents (see note)
-customer created_at     (none - anniversary     customer.           customer.
-(anniversary, tenure)   silent)                 created_at          created_at
-trial metadata          parser-derived          parser-derived      n/a
-                                                (signup state
-                                                trialing)
-failure attempt count   attempt_count/          failure_reason      n/a
-                        next_payment_attempt    only
-customer email          invoices only; cached   customer.email      customer.
-                        (encrypted) for                             email
-                        subscription events
-======================  ======================  ==================  ==========
+* first payment:
+  Stripe = invoice billing_reason "subscription_create";
+  Chargify = is_signup_payment metadata from signup_success revenue;
+  Shopify = customer orders_count.
+* lifetime spend (LTV, VIP, at-risk):
+  Stripe = none (silent);
+  Chargify = total_spent from total_revenue_in_cents (see note);
+  Shopify = total_spent (see note).
+* customer created_at (anniversary, tenure):
+  Stripe = none (anniversary silent);
+  Chargify and Shopify = customer.created_at.
+* trial metadata:
+  Stripe = parser-derived;
+  Chargify = parser-derived (signup_success with state "trialing");
+  Shopify = n/a.
+* failure attempt count:
+  Stripe = attempt_count / next_payment_attempt;
+  Chargify = failure_reason only;
+  Shopify = n/a.
+* customer email:
+  Stripe = invoices only, cached (encrypted) for subscription events;
+  Chargify and Shopify = customer.email.
 
 Note on lifetime-spend semantics (issue #110): neither Shopify nor
 Chargify documents whether the lifetime-spend snapshot embedded in a

--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -22,14 +22,17 @@ Per-provider signal sources (update this table when adding a detector):
 ======================  ======================  ==================  ==========
 Signal                  Stripe                  Chargify            Shopify
 ======================  ======================  ==================  ==========
-first payment           metadata.billing_reason (none - silent)     orders_count
-                        == "subscription_create"
+first payment           metadata.billing_reason is_signup_payment   orders_count
+                        == "subscription_create" from signup_success
+                                                revenue
 lifetime spend (LTV,    (none - silent)         total_spent from    total_spent
 VIP, at-risk)                                   total_revenue_      (see note)
                                                 in_cents (see note)
 customer created_at     (none - anniversary     customer.           customer.
 (anniversary, tenure)   silent)                 created_at          created_at
-trial metadata          parser-derived          (none)              n/a
+trial metadata          parser-derived          parser-derived      n/a
+                                                (signup state
+                                                trialing)
 failure attempt count   attempt_count/          failure_reason      n/a
                         next_payment_attempt    only
 customer email          invoices only; cached   customer.email      customer.
@@ -241,16 +244,20 @@ class InsightDetector:
         "for this subscription"); Shopify's order count proves a
         customer's first order (the insight says "from this customer").
 
-        Two truthful signals, one per provider family:
+        Three truthful signals, one per provider family:
 
         - Stripe: the invoice's ``billing_reason`` is "subscription_create"
           only on a subscription's first invoice (renewals are
           "subscription_cycle", plan changes "subscription_update").
+        - Chargify: ``is_signup_payment`` metadata, set by the parser when
+          a signup_success payload shows revenue on the subscription the
+          signup just created - prior payments are impossible there.
         - Shopify: the customer object's order count.
 
-        Absence of BOTH signals is NOT evidence of a first payment -
-        Chargify payloads carry neither, and defaulting to 0 would label
-        every renewal a "first payment".
+        Absence of ALL of these is NOT evidence of a first payment -
+        e.g. a Chargify payment_success/renewal_success payload carries
+        no history, and defaulting to 0 would label every renewal a
+        "first payment".
 
         Args:
             event_data: Event data dictionary.
@@ -273,17 +280,18 @@ class InsightDetector:
         if metadata.get("is_trial"):
             return None
 
-        # Stripe: first invoice of a new subscription. Require a positive
-        # amount so the $0 invoice Stripe issues when a trial starts (also
-        # billing_reason "subscription_create") never counts as a payment.
-        # Wording is subscription-scoped, not customer-scoped: the webhook
-        # proves this subscription's first payment, but an existing customer
-        # adding a second subscription looks identical - we never claim
-        # more than the payload can prove.
+        # Stripe: first invoice of a new subscription. Chargify: revenue
+        # collected by the signup that created the subscription. Require a
+        # positive amount so the $0 invoice Stripe issues when a trial
+        # starts (also billing_reason "subscription_create") never counts
+        # as a payment. Wording is subscription-scoped, not customer-scoped:
+        # the webhook proves this subscription's first payment, but an
+        # existing customer adding a second subscription looks identical -
+        # we never claim more than the payload can prove.
         if (
             metadata.get("billing_reason") == "subscription_create"
-            and _to_float(event_data.get("amount")) > 0
-        ):
+            or metadata.get("is_signup_payment")
+        ) and _to_float(event_data.get("amount")) > 0:
             return InsightInfo(
                 icon=self.ICONS["first_payment"],
                 text="First payment for this subscription",

--- a/tests/test_chargify_webhooks_comprehensive.py
+++ b/tests/test_chargify_webhooks_comprehensive.py
@@ -258,6 +258,116 @@ class TestChargifyWebhookParsing:
         assert result["metadata"]["cancel_at_period_end"] is True
         assert result["metadata"]["chargify_event"] == "subscription_state_change"
 
+    def test_signup_success_with_revenue_is_first_payment(
+        self, provider: ChargifySourcePlugin, request_factory: RequestFactory
+    ) -> None:
+        """Test a paid signup parses with the first-payment signal.
+
+        A signup creates the subscription, so revenue in the payload can
+        only have been collected by this signup - is_signup_payment is a
+        proven first payment, not an inference.
+        """
+        form_data = {
+            "event": "signup_success",
+            "payload[subscription][id]": "sub_12345",
+            "payload[subscription][state]": "active",
+            "payload[subscription][total_revenue_in_cents]": "2999",
+            "payload[subscription][customer][id]": "cust_456",
+            "payload[subscription][customer][email]": "test@example.com",
+            "payload[subscription][customer][organization]": "Acme Corp",
+            "payload[subscription][product][name]": "Premium Plan",
+            "created_at": "2024-01-15T10:30:00Z",
+        }
+
+        result = provider.parse_webhook(_mock_chargify_request(form_data))
+
+        assert result is not None
+        assert result["type"] == "subscription_created"
+        assert result["amount"] == 29.99
+        assert result["currency"] == "USD"
+        assert result["metadata"]["is_signup_payment"] is True
+        assert result["metadata"]["subscription_id"] == "sub_12345"
+        assert result["metadata"]["chargify_event"] == "signup_success"
+
+    def test_signup_success_trialing_is_trial_started(
+        self, provider: ChargifySourcePlugin, request_factory: RequestFactory
+    ) -> None:
+        """Test a trialing signup is emitted as trial_started, no payment claim."""
+        form_data = {
+            "event": "signup_success",
+            "payload[subscription][id]": "sub_12345",
+            "payload[subscription][state]": "trialing",
+            "payload[subscription][total_revenue_in_cents]": "0",
+            "payload[subscription][customer][id]": "cust_456",
+            "payload[subscription][customer][email]": "test@example.com",
+            "payload[subscription][product][name]": "Premium Plan",
+            "created_at": "2024-01-15T10:30:00Z",
+        }
+
+        result = provider.parse_webhook(_mock_chargify_request(form_data))
+
+        assert result is not None
+        assert result["type"] == "trial_started"
+        assert result["metadata"]["is_trial"] is True
+        assert "is_signup_payment" not in result["metadata"]
+        assert "amount" not in result
+
+    def test_signup_success_without_revenue_makes_no_payment_claim(
+        self, provider: ChargifySourcePlugin, request_factory: RequestFactory
+    ) -> None:
+        """Test a signup with zero/missing revenue stays a plain subscription event.
+
+        A lagging or absent revenue counter must lose the insight, never
+        fabricate one.
+        """
+        for revenue_value in ("0", None):
+            form_data = {
+                "event": "signup_success",
+                "payload[subscription][id]": "sub_12345",
+                "payload[subscription][state]": "active",
+                "payload[subscription][customer][id]": "cust_456",
+                "payload[subscription][customer][email]": "test@example.com",
+                "payload[subscription][product][name]": "Premium Plan",
+                "created_at": "2024-01-15T10:30:00Z",
+            }
+            if revenue_value is not None:
+                form_data["payload[subscription][total_revenue_in_cents]"] = (
+                    revenue_value
+                )
+
+            result = provider.parse_webhook(_mock_chargify_request(form_data))
+
+            assert result is not None
+            assert result["type"] == "subscription_created"
+            assert "is_signup_payment" not in result["metadata"]
+            assert "amount" not in result
+
+    def test_signup_success_malformed_revenue_does_not_reject(
+        self, provider: ChargifySourcePlugin, request_factory: RequestFactory
+    ) -> None:
+        """Test a malformed revenue field is ignored, not a 400.
+
+        Rejecting a legitimate signup event would make Chargify retry it
+        forever; the optional revenue field must never take the event down.
+        """
+        form_data = {
+            "event": "signup_success",
+            "payload[subscription][id]": "sub_12345",
+            "payload[subscription][state]": "active",
+            "payload[subscription][total_revenue_in_cents]": "not-a-number",
+            "payload[subscription][customer][id]": "cust_456",
+            "payload[subscription][customer][email]": "test@example.com",
+            "created_at": "2024-01-15T10:30:00Z",
+        }
+
+        result = provider.parse_webhook(_mock_chargify_request(form_data))
+
+        assert result is not None
+        assert result["type"] == "subscription_created"
+        assert "is_signup_payment" not in result["metadata"]
+        # The malformed value must also be skipped as LTV, not defaulted
+        assert "total_spent" not in result["customer_data"]
+
     def test_invalid_content_type_rejected(self, provider, request_factory):
         """Test rejection of invalid content type"""
         request = request_factory.post(

--- a/tests/test_chargify_webhooks_comprehensive.py
+++ b/tests/test_chargify_webhooks_comprehensive.py
@@ -342,6 +342,24 @@ class TestChargifyWebhookParsing:
             assert "is_signup_payment" not in result["metadata"]
             assert "amount" not in result
 
+    def test_total_spent_respects_zero_decimal_currency(
+        self, provider: ChargifySourcePlugin
+    ) -> None:
+        """Test total_spent uses per-currency minor units, not a fixed /100.
+
+        JPY has no minor unit: 5000 in the payload is ¥5,000, and a
+        hardcoded /100 would report ¥50.
+        """
+        provider._current_webhook_data = {
+            "payload[subscription][currency]": "JPY",
+            "payload[subscription][total_revenue_in_cents]": "5000",
+            "payload[subscription][customer][email]": "test@example.com",
+        }
+
+        customer_data = provider.get_customer_data("cust_456")
+
+        assert customer_data["total_spent"] == 5000.0
+
     def test_signup_success_malformed_revenue_does_not_reject(
         self, provider: ChargifySourcePlugin, request_factory: RequestFactory
     ) -> None:

--- a/tests/test_chargify_webhooks_comprehensive.py
+++ b/tests/test_chargify_webhooks_comprehensive.py
@@ -318,9 +318,9 @@ class TestChargifyWebhookParsing:
         """Test a signup with zero/missing revenue stays a plain subscription event.
 
         A lagging or absent revenue counter must lose the insight, never
-        fabricate one.
+        fabricate one. "" is how a form-encoded payload spells "absent".
         """
-        for revenue_value in ("0", None):
+        for revenue_value in ("0", "", None):
             form_data = {
                 "event": "signup_success",
                 "payload[subscription][id]": "sub_12345",

--- a/tests/test_insight_detector_fixes.py
+++ b/tests/test_insight_detector_fixes.py
@@ -240,6 +240,49 @@ class TestFirstPaymentFromStripeBillingReason:
         assert result is None
 
 
+class TestFirstPaymentFromChargifySignup:
+    """Chargify first payments are detected via signup_success revenue.
+
+    A signup creates the subscription, so revenue in a signup_success
+    payload can only have come from that signup - the parser marks it
+    with is_signup_payment metadata.
+    """
+
+    def test_signup_payment_is_first_payment(self, detector: InsightDetector) -> None:
+        """Test a paid Chargify signup fires the first-payment insight."""
+        event = {
+            "type": "subscription_created",
+            "provider": "chargify",
+            "amount": 29.99,
+            "currency": "USD",
+            "metadata": {"is_signup_payment": True},
+        }
+        customer_data = {"email": "ops@beta.example", "customer_id": "42"}
+
+        result = detector._detect_first_payment(event, customer_data)
+
+        assert result is not None
+        assert result.icon == "new"
+        assert result.text == "First payment for this subscription"
+
+    def test_signup_payment_without_amount_stays_silent(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test the flag alone is not enough - a positive amount is required."""
+        event = {
+            "type": "subscription_created",
+            "provider": "chargify",
+            "amount": 0.0,
+            "currency": "USD",
+            "metadata": {"is_signup_payment": True},
+        }
+        customer_data = {"email": "ops@beta.example", "customer_id": "42"}
+
+        result = detector._detect_first_payment(event, customer_data)
+
+        assert result is None
+
+
 class TestTrialInsightCurrencyAndInterval:
     """The trial insight honors the event currency and billing interval."""
 


### PR DESCRIPTION
Closes the Chargify gap in the first-payment insight (follow-up to #125). Chargify sends neither order history nor a billing_reason, so the insight could never fire — and per our rule, we never show what the payload can't prove.

## The truthful signal

Chargify's `signup_success` webhook was in `ACKNOWLEDGED_EVENT_TYPES` (logged and skipped). It's now routed as a real event, because it carries a provable first-payment signal: **the signup creates the subscription, so `payload[subscription][total_revenue_in_cents]` can only contain money collected by that signup** — prior payments are impossible on a brand-new subscription. The failure direction is safe by construction: a lagging or absent revenue counter loses the insight, but can never fabricate one.

- Paid signup (`state=active`, revenue > 0) → `subscription_created` event with `is_signup_payment` metadata → "New subscription!" headline + "First payment for this subscription" insight
- Trialing signup → emitted as `trial_started` (mirrors the Stripe parser's re-typing), no payment claim even if a setup fee collected revenue — conservative over clever
- Zero/missing/malformed revenue → plain `subscription_created`, no claim

No double notifications: the existing consolidation rule (`subscription_created` suppresses `payment_success` for the same `subscription_id` within 5 minutes) covers the payment webhook Chargify fires alongside a paid signup.

## Drive-by fix (found by the new tests)

A malformed `total_revenue_in_cents` crashed `get_customer_data` (bare `float()` inside the broad `except (KeyError, ValueError)`), rejecting the **entire webhook** with a 400 — which Chargify retries forever. The optional analytics field is now skipped with a warning instead.

The signal-availability matrix in `insight_detector.py` is updated (Chargify first-payment and trial rows).

## Testing

- 7 new tests: paid/trialing/zero-revenue/malformed-revenue signup parsing, detector fire/silent paths
- Full suite: 1749 passed; ruff and mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)