### PR TITLE
feat: onboarding screencast + fix broken passkey signup/login

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       screenshot:
-        description: 'Screenshot to capture (e.g. dashboard.py, or "all")'
+        description: 'Scenario to capture (e.g. dashboard.py, onboarding.py, or "all")'
         required: false
         default: 'all'
 
@@ -42,26 +42,12 @@ jobs:
       - name: Capture screenshots
         run: bin/record_screenshots.sh "${{ github.event.inputs.screenshot }}"
 
-      - name: Upload to Cloudflare R2
-        if: ${{ always() && env.R2_BUCKET != '' }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-          R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-        run: |
-          aws s3 sync screenshots/output/ "s3://${R2_BUCKET}/screenshots/" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --content-type image/png \
-            --cache-control "public, max-age=300" \
-            --exclude "*" --include "*.png" \
-            --no-progress
-
       - name: Upload screenshots artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: screenshots
-          path: screenshots/output/*.png
+          path: |
+            screenshots/output/*.png
+            screenshots/output/*.webm
           if-no-files-found: warn

--- a/app/core/services/webauthn.py
+++ b/app/core/services/webauthn.py
@@ -59,6 +59,23 @@ class WebAuthnService:
         self.rp_name = "Notipus"
         self.origin = self._get_origin()
 
+    @staticmethod
+    def _pad_challenge(challenge_str: str) -> str:
+        """Re-pad a client-supplied base64url challenge for DB lookup.
+
+        ``options_to_json`` serializes challenges as unpadded base64url,
+        which is what clients echo back, but stored challenges are padded
+        (``base64.urlsafe_b64encode``). Without normalization the lookup
+        can never match.
+
+        Args:
+            challenge_str: Challenge string as received from the client.
+
+        Returns:
+            The challenge string with base64 padding restored.
+        """
+        return challenge_str + "=" * (-len(challenge_str) % 4)
+
     def _get_rp_id(self) -> str:
         """Get the Relying Party ID from settings or environment.
 
@@ -168,6 +185,8 @@ class WebAuthnService:
                 logger.error("No challenge in credential data")
                 return False
 
+            challenge_str = self._pad_challenge(challenge_str)
+
             challenge = WebAuthnChallenge.objects.get(
                 challenge=challenge_str,
                 user=user,
@@ -276,6 +295,8 @@ class WebAuthnService:
             if not challenge_str:
                 logger.error("No challenge in credential data")
                 return None
+
+            challenge_str = self._pad_challenge(challenge_str)
 
             challenge = WebAuthnChallenge.objects.get(
                 challenge=challenge_str,
@@ -413,6 +434,8 @@ class WebAuthnService:
             if not challenge_str:
                 logger.error("No challenge in credential data")
                 return None
+
+            challenge_str = self._pad_challenge(challenge_str)
 
             # Find challenge for signup registration
             challenge = WebAuthnChallenge.objects.get(

--- a/app/core/templates/account/login.html.j2
+++ b/app/core/templates/account/login.html.j2
@@ -97,6 +97,11 @@
 
                 const options = beginData.options;
 
+                // Keep the original base64url challenge: options aliases
+                // beginData.options, so the ArrayBuffer conversion below
+                // would otherwise clobber the string the server expects back.
+                const challengeB64url = options.challenge;
+
                 // Convert base64url strings to ArrayBuffers for WebAuthn API
                 options.challenge = base64urlToArrayBuffer(options.challenge);
                 if (options.allowCredentials) {
@@ -126,7 +131,7 @@
                         userHandle: credential.response.userHandle ? arrayBufferToBase64url(credential.response.userHandle) : null
                     },
                     type: credential.type,
-                    challenge: beginData.options.challenge
+                    challenge: challengeB64url
                 };
 
                 const completeResponse = await fetch('/webauthn/authenticate/complete/', {

--- a/app/core/templates/account/signup.html.j2
+++ b/app/core/templates/account/signup.html.j2
@@ -168,6 +168,11 @@
 
                 const options = beginData.options;
 
+                // Keep the original base64url challenge: options aliases
+                // beginData.options, so the ArrayBuffer conversion below
+                // would otherwise clobber the string the server expects back.
+                const challengeB64url = options.challenge;
+
                 // Convert base64url strings to ArrayBuffers for WebAuthn API
                 options.challenge = base64urlToArrayBuffer(options.challenge);
                 options.user.id = base64urlToArrayBuffer(options.user.id);
@@ -190,7 +195,7 @@
                         clientDataJSON: arrayBufferToBase64url(credential.response.clientDataJSON),
                     },
                     type: credential.type,
-                    challenge: beginData.options.challenge
+                    challenge: challengeB64url
                 };
 
                 const completeResponse = await fetch('/webauthn/signup/complete/', {

--- a/bin/record_screenshots.sh
+++ b/bin/record_screenshots.sh
@@ -11,8 +11,8 @@ build_frontend() {
 }
 
 ensure_browser() {
-    echo "Ensuring Playwright Chromium is installed..."
-    uv run playwright install chromium
+    echo "Ensuring Playwright Chromium and ffmpeg are installed..."
+    uv run playwright install chromium ffmpeg
 }
 
 run_screenshot() {

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -1,9 +1,16 @@
-# Marketing Screenshots
+# Marketing Screenshots & Screencasts
 
-Programmatic, reproducible screenshots of the app for the marketing
-site, docs, and app-store listings. Every capture boots the real app
-against a seeded demo workspace, so screenshots stay current with the
-UI instead of rotting in a design folder.
+Programmatic, reproducible screenshots and screencasts of the app for
+the marketing site, docs, and app-store listings. Every capture boots
+the real app against a seeded demo workspace, so assets stay current
+with the UI instead of rotting in a design folder.
+
+`onboarding.py` records a Full HD webm of the entire zero-to-configured
+journey: passkey signup (a real WebAuthn ceremony against a CDP virtual
+authenticator), plan selection, workspace creation, connecting Slack
+(OAuth short-circuited at the network edge, server API mocked
+in-process), choosing a channel, connecting Stripe, and a finale where
+the notification lands in a Slack-style window.
 
 The demo data is Office Space themed: the **Initech** workspace is
 owned by Peter Gibbons, with Samir Nagheenanajar as a member and a
@@ -28,8 +35,8 @@ external services required.
 
 The **Marketing Screenshots** workflow is manual-only: trigger it from
 the Actions tab (workflow_dispatch), optionally naming a single
-scenario file. Captures are uploaded as a build artifact, and synced to
-Cloudflare R2 when the `R2_*` secrets are configured.
+scenario file. Captures are attached to the run as a `screenshots`
+build artifact.
 
 ## Adding a scenario
 

--- a/screenshots/conftest.py
+++ b/screenshots/conftest.py
@@ -355,7 +355,10 @@ def intercept_slack_oauth(page: Page) -> None:
                 )
                 return
             url = urljoin(url, location)
-        route.continue_()
+        # Never fall through to the real network: if the authorize hop
+        # wasn't found, abort so the scenario fails fast and loudly
+        # instead of the browser leaving the machine (or hanging CI).
+        route.abort("failed")
 
     page.route("**/integrate/slack/", handle)
 

--- a/screenshots/conftest.py
+++ b/screenshots/conftest.py
@@ -1,10 +1,16 @@
-"""Fixtures for capturing marketing screenshots.
+"""Fixtures for capturing marketing screenshots and screencasts.
 
 Boots the app against the test database via pytest-django's
 ``live_server``, seeds a fully Office Space-themed demo workspace
 (Initech), logs in as Peter Gibbons through a forged session cookie
 (the app itself only offers passkey/Slack OAuth), and hands scenarios
 authenticated Playwright pages at marketing-friendly viewports.
+
+Screencast scenarios instead use ``recording_page`` — an
+unauthenticated Full HD page whose session is recorded to webm, with a
+CDP virtual authenticator so the real passkey signup ceremony can run
+on camera, and a mocked Slack API so the OAuth dance completes without
+leaving the machine.
 
 Run via ``bin/record_screenshots.sh`` — the suite is intentionally
 outside pytest's ``testpaths`` so normal test runs never collect it.
@@ -14,7 +20,8 @@ import os
 import time
 from pathlib import Path
 from typing import Any, Generator
-from urllib.parse import urlparse
+from unittest.mock import patch
+from urllib.parse import parse_qs, urljoin, urlparse
 
 import pytest
 from core.models import (
@@ -31,8 +38,10 @@ from django.utils import timezone
 from playwright.sync_api import (
     Browser,
     BrowserContext,
+    Locator,
     Page,
     Playwright,
+    Route,
     sync_playwright,
 )
 
@@ -283,6 +292,275 @@ def mobile_page(
     )
     yield context.new_page()
     context.close()
+
+
+# ---------------------------------------------------------------------------
+# Screencast recording
+# ---------------------------------------------------------------------------
+
+
+def pace(page: Page, ms: int = 700) -> None:
+    """Pause for a natural beat between actions so viewers can follow."""
+    page.wait_for_timeout(ms)
+
+
+def hover_and_click(page: Page, locator: Locator, pause_ms: int = 300) -> None:
+    """Move the cursor to the element, pause, then click.
+
+    Without the pause, Playwright clicks land in a single video frame
+    and the action is impossible to follow.
+    """
+    box = locator.bounding_box()
+    if box:
+        page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
+        page.wait_for_timeout(pause_ms)
+    locator.click()
+
+
+def type_text(locator: Locator, text: str, delay: int = 60) -> None:
+    """Type character-by-character for a human-like feel."""
+    locator.press_sequentially(text, delay=delay)
+
+
+def intercept_slack_oauth(page: Page) -> None:
+    """Short-circuit the Slack OAuth hop back into the app.
+
+    Route handlers don't fire on redirect hops, so intercepting
+    slack.com directly never triggers. Instead the first hop
+    (``/api/connect/slack/``) is replayed through the context's request
+    API — sharing the cookie jar, so the CSRF state the server mints
+    still lands in the session — and the browser is sent straight to the
+    app's callback with the ``state`` and ``redirect_uri`` the server
+    put in its authorize URL. The browser never leaves the machine.
+    """
+
+    def handle(route: Route) -> None:
+        url = route.request.url
+        for _ in range(5):
+            response = page.request.get(url, max_redirects=0)
+            location = response.headers.get("location", "")
+            if not location:
+                break
+            if location.startswith("https://slack.com/"):
+                query = parse_qs(urlparse(location).query)
+                redirect_uri = query["redirect_uri"][0]
+                state = query["state"][0]
+                route.fulfill(
+                    status=302,
+                    headers={
+                        "Location": (
+                            f"{redirect_uri}?code=demo-oauth-code&state={state}"
+                        )
+                    },
+                )
+                return
+            url = urljoin(url, location)
+        route.continue_()
+
+    page.route("**/integrate/slack/", handle)
+
+
+class _FakeSlackResponse:
+    """Minimal requests.Response stand-in for the mocked Slack API."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _fake_slack_post(url: str, **kwargs: Any) -> _FakeSlackResponse:
+    # oauth.v2.access token exchange
+    return _FakeSlackResponse(
+        {
+            "ok": True,
+            "access_token": "xoxb-demo-token",
+            "team": {"id": "T0INITECH", "name": "Initech"},
+            "incoming_webhook": {
+                "channel": "#general",
+                "url": "https://hooks.slack.com/services/demo",
+            },
+        }
+    )
+
+
+def _fake_slack_get(url: str, **kwargs: Any) -> _FakeSlackResponse:
+    # conversations.list channel listing
+    return _FakeSlackResponse(
+        {
+            "ok": True,
+            "channels": [
+                {"id": "C01", "name": "general"},
+                {"id": "C02", "name": "billing-alerts"},
+                {"id": "C03", "name": "tps-reports"},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+    )
+
+
+@pytest.fixture
+def mock_slack_api() -> Generator[None, Any, None]:
+    """Fake the server-side Slack API calls.
+
+    ``live_server`` runs in this process, so patching the ``requests``
+    module used by the Slack views affects the serving thread too.
+    """
+    with (
+        patch("core.views.integrations.slack.requests.post", _fake_slack_post),
+        patch("core.views.integrations.slack.requests.get", _fake_slack_get),
+    ):
+        yield
+
+
+@pytest.fixture
+def recording_page(
+    request: pytest.FixtureRequest, browser: Browser, live_server, settings
+) -> Generator[Page, Any, None]:
+    """Unauthenticated Full HD page recorded to ``output/<test>.webm``.
+
+    Configures WebAuthn and the Slack redirect URI for the live server's
+    ephemeral port, and attaches a CDP virtual authenticator so
+    ``navigator.credentials.create()`` succeeds without hardware.
+    """
+    settings.WEBAUTHN_RP_ID = "localhost"
+    settings.WEBAUTHN_ORIGIN = live_server.url
+    settings.SLACK_CONNECT_REDIRECT_URI = (
+        f"{live_server.url}/api/connect/slack/callback/"
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    context = browser.new_context(
+        base_url=live_server.url,
+        viewport=DESKTOP_VIEWPORT,
+        record_video_dir=str(OUTPUT_DIR),
+        record_video_size=DESKTOP_VIEWPORT,
+    )
+    page = context.new_page()
+
+    cdp = context.new_cdp_session(page)
+    cdp.send("WebAuthn.enable")
+    cdp.send(
+        "WebAuthn.addVirtualAuthenticator",
+        {
+            "options": {
+                "protocol": "ctap2",
+                "transport": "internal",
+                "hasResidentKey": True,
+                "hasUserVerification": True,
+                "isUserVerified": True,
+                "automaticPresenceSimulation": True,
+            }
+        },
+    )
+
+    yield page
+
+    video = page.video
+    context.close()  # finalizes the recording
+    if video:
+        Path(video.path()).rename(OUTPUT_DIR / f"{request.node.name}.webm")
+
+
+# Slack-style finale for the onboarding screencast: a #billing-alerts
+# channel where the Notipus notification slides in after a beat. Uses
+# the app's own logo (relative URL, served by the live server since the
+# page keeps the app origin after set_content).
+SLACK_FINALE_HTML = """\
+<!doctype html><html><head><meta charset="utf-8"><style>
+  * { margin: 0; box-sizing: border-box; font-family: -apple-system,
+      BlinkMacSystemFont, "Segoe UI", Lato, sans-serif; }
+  body { display: flex; height: 100vh; overflow: hidden; }
+  .sidebar { width: 260px; background: #3F0E40; color: #cfc3cf;
+             padding: 16px 0; flex-shrink: 0; }
+  .team { color: #fff; font-weight: 900; font-size: 18px;
+          padding: 0 16px 14px; border-bottom: 1px solid #522653;
+          margin-bottom: 12px; }
+  .section { padding: 4px 16px; font-size: 15px; }
+  .channel { padding: 4px 16px; font-size: 15px; }
+  .channel.active { background: #1164A3; color: #fff; }
+  .main { flex: 1; display: flex; flex-direction: column; }
+  .header { padding: 12px 20px; border-bottom: 1px solid #e2e2e2;
+            font-weight: 900; font-size: 18px; color: #1d1c1d; }
+  .header small { display: block; font-weight: 400; font-size: 13px;
+                  color: #616061; margin-top: 2px; }
+  .messages { flex: 1; padding: 20px; display: flex;
+              flex-direction: column; justify-content: flex-end; }
+  .msg { display: flex; gap: 10px; margin-top: 18px; }
+  .avatar { width: 38px; height: 38px; border-radius: 5px;
+            background: #fff; border: 1px solid #e2e2e2;
+            display: flex; align-items: center; justify-content: center; }
+  .avatar img { width: 30px; height: 30px; }
+  .author { font-weight: 900; color: #1d1c1d; font-size: 15px; }
+  .app-badge { background: #e8e8e8; color: #616061; font-size: 10px;
+               font-weight: 700; padding: 1px 4px; border-radius: 3px;
+               vertical-align: middle; }
+  .ts { color: #616061; font-size: 12px; margin-left: 6px; }
+  .attachment { border-left: 4px solid #2eb67d; background: #f8f8f8;
+                border-radius: 0 6px 6px 0; padding: 10px 14px;
+                margin-top: 6px; max-width: 640px; }
+  .attachment.gray { border-left-color: #868686; }
+  .headline { font-weight: 700; color: #1d1c1d; font-size: 15px; }
+  .meta { color: #616061; font-size: 13px; margin-top: 4px; }
+  .insight { color: #2eb67d; font-size: 13px; font-weight: 600;
+             margin-top: 6px; }
+  #incoming { opacity: 0; transform: translateY(14px); }
+  #incoming.shown { opacity: 1; transform: none;
+                    transition: all 420ms ease-out; }
+</style></head><body>
+  <div class="sidebar">
+    <div class="team">Initech</div>
+    <div class="section">Channels</div>
+    <div class="channel"># general</div>
+    <div class="channel"># tps-reports</div>
+    <div class="channel active"># billing-alerts</div>
+  </div>
+  <div class="main">
+    <div class="header"># billing-alerts
+      <small>Payment events from Notipus</small></div>
+    <div class="messages">
+      <div class="msg">
+        <div class="avatar"><img src="/static/img/notipus-logo.png"></div>
+        <div>
+          <span class="author">Notipus</span>
+          <span class="app-badge">APP</span><span class="ts">9:12 AM</span>
+          <div class="attachment gray">
+            <div class="headline">Trial started for Swingline</div>
+            <div class="meta">Stapler Tier &middot; milton@swingline.com</div>
+          </div>
+        </div>
+      </div>
+      <div class="msg" id="incoming">
+        <div class="avatar"><img src="/static/img/notipus-logo.png"></div>
+        <div>
+          <span class="author">Notipus</span>
+          <span class="app-badge">APP</span><span class="ts">9:57 AM</span>
+          <div class="attachment">
+            <div class="headline">&#128176; Payment received from Initrode</div>
+            <div class="meta">$4,999.00 &middot; TPS Premium &middot;
+              billing@initrode.com</div>
+            <div class="insight">&#128200; 3rd successful payment in a row</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    setTimeout(() => {
+      document.getElementById('incoming').classList.add('shown');
+    }, 1600);
+  </script>
+</body></html>
+"""
+
+
+def play_slack_finale(page: Page, hold_ms: int = 4500) -> None:
+    """Swap the page for the Slack-style view and let the alert arrive."""
+    page.set_content(SLACK_FINALE_HTML, wait_until="load")
+    page.wait_for_selector("#incoming.shown", timeout=10_000)
+    pace(page, hold_ms)
 
 
 def shoot(target: Page, name: str, path: str, full_page: bool = True) -> None:

--- a/screenshots/conftest.py
+++ b/screenshots/conftest.py
@@ -370,6 +370,9 @@ class _FakeSlackResponse:
     def json(self) -> dict[str, Any]:
         return self._payload
 
+    def raise_for_status(self) -> None:
+        """Always a 200 — nothing to raise."""
+
 
 def _fake_slack_post(url: str, **kwargs: Any) -> _FakeSlackResponse:
     # oauth.v2.access token exchange
@@ -425,7 +428,9 @@ def recording_page(
     ephemeral port, and attaches a CDP virtual authenticator so
     ``navigator.credentials.create()`` succeeds without hardware.
     """
-    settings.WEBAUTHN_RP_ID = "localhost"
+    # RP ID must be the effective domain of the origin, whatever host
+    # the live server actually bound (localhost vs 127.0.0.1).
+    settings.WEBAUTHN_RP_ID = urlparse(live_server.url).hostname
     settings.WEBAUTHN_ORIGIN = live_server.url
     settings.SLACK_CONNECT_REDIRECT_URI = (
         f"{live_server.url}/api/connect/slack/callback/"

--- a/screenshots/onboarding.py
+++ b/screenshots/onboarding.py
@@ -1,0 +1,112 @@
+"""Record the zero-to-configured onboarding screencast.
+
+Drives the full journey a new customer takes: passkey signup as Peter
+Gibbons → pick the Pro trial → create the Initech workspace → connect
+Slack (OAuth mocked server-side, passkey ceremony real via a virtual
+authenticator) → pick the #billing-alerts channel → connect Stripe with
+a webhook signing secret → land on a dashboard full of activity.
+"""
+
+import pytest
+from conftest import (
+    _seed_activity,
+    hover_and_click,
+    intercept_slack_oauth,
+    mock_slack_api,  # noqa: F401  (fixture)
+    pace,
+    play_slack_finale,
+    type_text,
+)
+from core.models import Workspace
+from playwright.sync_api import Page
+
+
+@pytest.mark.django_db(transaction=True)
+def onboarding(recording_page: Page, mock_slack_api: None) -> None:  # noqa: F811
+    page = recording_page
+
+    # --- Sign up with a passkey -------------------------------------------
+    page.goto("/accounts/signup/", wait_until="networkidle")
+    pace(page, 1500)
+
+    hover_and_click(page, page.locator("#passkey-signup"))
+    pace(page, 800)
+
+    type_text(page.locator("#modal-username"), "peter")
+    pace(page, 300)
+    type_text(page.locator("#modal-email"), "peter.gibbons@initech.com")
+    pace(page, 500)
+
+    # The virtual authenticator approves the passkey ceremony instantly
+    hover_and_click(page, page.locator("#create-with-passkey"))
+    page.wait_for_url("**/select-plan/", timeout=15_000)
+    page.wait_for_load_state("networkidle")
+    pace(page, 1500)
+
+    # --- Choose the Pro trial ---------------------------------------------
+    pro_button = page.locator(
+        "form:has(input[name='plan'][value='pro']) button[type='submit']"
+    )
+    hover_and_click(page, pro_button)
+    page.wait_for_load_state("networkidle")
+    pace(page, 1200)
+
+    # Plan confirmation → continue to workspace creation
+    hover_and_click(page, page.get_by_role("link", name="Go to Dashboard"))
+    page.wait_for_url("**/workspace/create/", timeout=15_000)
+    pace(page, 1000)
+
+    # --- Create the workspace ---------------------------------------------
+    type_text(page.locator("input[name='name']"), "Initech")
+    pace(page, 300)
+    type_text(page.locator("input[name='shop_domain']"), "initech.com")
+    pace(page, 500)
+    hover_and_click(page, page.get_by_role("button", name="Create Workspace"))
+    page.wait_for_url("**/dashboard/", timeout=15_000)
+    page.wait_for_load_state("networkidle")
+    pace(page, 2000)
+
+    # --- Connect Slack (OAuth round-trip, mocked at the edges) ------------
+    intercept_slack_oauth(page)
+    hover_and_click(page, page.get_by_role("link", name="Integrations").first)
+    page.wait_for_load_state("networkidle")
+    pace(page, 1500)
+
+    hover_and_click(page, page.locator("a[href*='integrate/slack']"))
+    page.wait_for_load_state("networkidle")
+    pace(page, 1500)
+
+    # Pick a notification channel
+    hover_and_click(page, page.get_by_role("button", name="Configure"))
+    channel_select = page.locator("#slack-channel-select")
+    channel_select.wait_for(state="visible", timeout=10_000)
+    pace(page, 600)
+    channel_select.select_option("#billing-alerts")
+    pace(page, 600)
+    hover_and_click(page, page.locator("#slack-config-save"))
+    pace(page, 1500)
+
+    # --- Connect Stripe ----------------------------------------------------
+    hover_and_click(page, page.locator("a[href*='integrate/stripe']"))
+    page.wait_for_url("**/integrate/stripe/", timeout=15_000)
+    page.wait_for_load_state("networkidle")
+    pace(page, 1500)
+
+    secret_input = page.locator("input[name='webhook_secret']")
+    secret_input.scroll_into_view_if_needed()
+    pace(page, 800)
+    type_text(secret_input, "whsec_9wK2mDemoSigningSecret", delay=30)
+    pace(page, 500)
+    submit = page.get_by_role("button", name="Connect Stripe")
+    submit.scroll_into_view_if_needed()
+    hover_and_click(page, submit)
+    page.wait_for_load_state("networkidle")
+    pace(page, 1800)
+
+    # --- The payoff: a dashboard full of activity --------------------------
+    _seed_activity(Workspace.objects.get(name="Initech"))
+    page.goto("/dashboard/", wait_until="networkidle")
+    pace(page, 3000)
+
+    # --- And the notification landing in Slack -----------------------------
+    play_slack_finale(page)

--- a/tests/test_webauthn_challenge_padding.py
+++ b/tests/test_webauthn_challenge_padding.py
@@ -1,0 +1,57 @@
+"""Regression tests for WebAuthn challenge base64url padding.
+
+Stored challenges are padded (``base64.urlsafe_b64encode``) while
+``options_to_json`` serializes the challenge the client receives — and
+echoes back — as *unpadded* base64url. The service must normalize the
+client-supplied form before the database lookup, otherwise every real
+passkey ceremony fails at the complete step even though unit tests that
+round-trip padded strings pass.
+"""
+
+import base64
+
+import pytest
+from core.models import WebAuthnChallenge
+from core.services.webauthn import WebAuthnService
+
+
+def test_pad_challenge_restores_stripped_padding() -> None:
+    """An unpadded base64url string is restored to its padded form."""
+    raw = b"\x01\x02\x03\x04\x05" * 13  # 65 bytes -> padded encoding
+    padded = base64.urlsafe_b64encode(raw).decode()
+    unpadded = padded.rstrip("=")
+
+    assert padded.endswith("=")
+    assert WebAuthnService._pad_challenge(unpadded) == padded
+
+
+def test_pad_challenge_is_noop_for_padded_input() -> None:
+    """Already-padded challenges (legacy clients, tests) pass through."""
+    padded = base64.urlsafe_b64encode(b"\xffthirty-two-bytes-of-challenge!").decode()
+
+    assert WebAuthnService._pad_challenge(padded) == padded
+
+
+@pytest.mark.django_db
+def test_unpadded_client_challenge_matches_stored_signup_challenge() -> None:
+    """The challenge a signup client echoes back must find the stored row.
+
+    ``generate_signup_registration_options`` stores the padded form and
+    hands the client the unpadded form via ``options_to_json``; after
+    normalization the two must address the same database row.
+    """
+    service = WebAuthnService()
+    options = service.generate_signup_registration_options(
+        "peter", "peter.gibbons@initech.com"
+    )
+
+    client_challenge = options["challenge"]
+    # py_webauthn emits unpadded base64url — the shape that regressed.
+    assert "=" not in client_challenge
+
+    normalized = service._pad_challenge(client_challenge)
+    assert WebAuthnChallenge.objects.filter(
+        challenge=normalized, challenge_type="signup_registration"
+    ).exists()
+    # Without normalization the lookup misses: this is the regression.
+    assert not WebAuthnChallenge.objects.filter(challenge=client_challenge).exists()


### PR DESCRIPTION
## Summary

Expands the marketing capture suite with a **zero-to-configured onboarding screencast**, and fixes two real bugs it flushed out: **passkey signup and login were broken end to end** in production.

### The screencast (`screenshots/onboarding.py`)

Records a Full HD (1920x1080, 25fps, ~45s) webm of the whole journey:

1. Passkey signup as Peter Gibbons — a **real WebAuthn ceremony** performed against a CDP virtual authenticator, on camera
2. Choosing the Pro trial and creating the Initech workspace
3. Connecting Slack: the OAuth redirect chain is short-circuited at the network edge (Playwright can't intercept redirect hops, so the first hop is replayed through the context's request API — cookie jar shared, CSRF state preserved) and the server-side Slack API (`oauth.v2.access`, `conversations.list`) is mocked in-process
4. Picking the `#billing-alerts` channel in the config modal
5. Connecting Stripe by pasting a webhook signing secret
6. Finale: the dashboard full of Office Space activity, then a **Slack-style window where the Initrode payment notification slides in**

Runner installs Playwright's ffmpeg; the workflow artifact now includes webm files. Per review direction, the Cloudflare R2 sync is removed — **GitHub artifacts are the only output**.

### The passkey fix (first commit)

Recording the signup ceremony revealed that every real-world passkey flow 400s at the complete step:

- **Frontend** (signup + login JS): `options.challenge` was converted to an ArrayBuffer in place, then `beginData.options.challenge` — the same object — was sent back, so the server received `{}`. The original base64url string is now captured before conversion.
- **Backend** (`WebAuthnService`): stored challenges are padded (`base64.urlsafe_b64encode`) while `options_to_json` emits unpadded base64url — what clients echo back — so the challenge lookup could never match. Client-supplied challenges are re-padded before lookup (a no-op for already-padded values, so existing tests pass unchanged).

## Test plan

- `bin/record_screenshots.sh` — all 6 scenarios pass; onboarding.webm verified frame-by-frame (passkey modal, Stripe secret entry, Slack finale with the sliding notification)
- `uv run pytest` — 1696 passed
- ruff / mypy / djlint all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)