### PR TITLE
fix: show the production webhook URL in marketing captures

### DIFF
--- a/screenshots/conftest.py
+++ b/screenshots/conftest.py
@@ -148,15 +148,21 @@ OFFICE_SPACE_EVENTS: list[dict[str, Any]] = [
 
 @pytest.fixture(autouse=True)
 def screenshot_settings(settings) -> None:
-    """Cache the seeded activity feed where the live server can read it.
+    """Marketing-friendly settings for every capture.
 
     ``test_settings`` uses DummyCache, which would leave the dashboard's
     Recent Activity empty. LocMemCache is shared across threads, so the
     live-server thread sees what the fixture seeds.
+
+    BASE_URL feeds the webhook URLs shown on the integration setup pages
+    (Stripe/Shopify/Chargify); the default would render
+    ``http://localhost:8000/...`` on camera, so use the production
+    domain instead.
     """
     settings.CACHES = {
         "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
     }
+    settings.BASE_URL = "https://app.notipus.com"
 
 
 def _seed_activity(workspace: Workspace) -> None:


### PR DESCRIPTION
## Summary

The integration setup pages render `settings.BASE_URL` into the webhook endpoint field, which put `http://localhost:8000/...` on camera in the onboarding screencast. The capture fixtures now set `BASE_URL` to `https://app.notipus.com`, so the Stripe setup step shows a production-looking endpoint (`https://app.notipus.com/webhook/customer/<uuid>/stripe/`) — same for the Shopify and Chargify pages if scenarios ever cover them.

## Test plan

- Re-recorded `onboarding.py` and verified the frame: the endpoint field reads `https://app.notipus.com/webhook/customer/…`
- ruff clean; no app code touched (capture fixtures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)