### PR TITLE
feat: improve Slack notification UI/UX

### DIFF
--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -491,9 +491,12 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         amount_display: str = format_money(payment.amount, payment.currency)
         arr = payment.get_arr()
         if amount_display not in headline:
-            fields.append(f"*Amount*\n{payment.format_amount_with_arr()}")
+            # Sanitized because format_money falls back to the raw
+            # payload currency code for unknown currencies.
+            fields.append(f"*Amount*\n{safe_mrkdwn(payment.format_amount_with_arr())}")
         elif arr is not None:
-            fields.append(f"*ARR*\n{format_money(arr, payment.currency, 0)}")
+            arr_display = safe_mrkdwn(format_money(arr, payment.currency, 0))
+            fields.append(f"*ARR*\n{arr_display}")
 
         if payment.subscription_id:
             fields.append(f"*Subscription*\n#{safe_mrkdwn(payment.subscription_id)}")

--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -24,6 +24,7 @@ from webhooks.models.rich_notification import (
     PersonInfo,
     RichNotification,
 )
+from webhooks.utils.currency import format_money
 
 logger = logging.getLogger(__name__)
 
@@ -86,48 +87,10 @@ EMAIL_TAG_BADGES: dict[str, str] = {
     "disposable": ":wastebasket: Disposable email",
 }
 
-# Provider display icons
-PROVIDER_ICONS: dict[str, str] = {
-    # Payment providers
-    "shopify": "shopping_bags",
-    "chargify": "dollar",
-    "stripe": "credit_card",
-    "stripe_customer": "credit_card",
-    # Other providers
-    "intercom": "speech_balloon",
-    "zendesk": "ticket",
-    "segment": "bar_chart",
-    "mixpanel": "chart_with_upwards_trend",
-    "amplitude": "chart_with_upwards_trend",
-    "slack": "slack",
-    "github": "octocat",
-    "webhook": "link",
-    "api": "gear",
-    "system": "gear",
-    "unknown": "globe_with_meridians",
-}
-
-# Default icon for unknown providers (must be a valid Slack emoji)
-DEFAULT_PROVIDER_ICON = "globe_with_meridians"
-
-# Payment method icons
-PAYMENT_METHOD_ICONS: dict[str, str] = {
-    # Card brands
-    "visa": "credit_card",
-    "mastercard": "credit_card",
-    "amex": "credit_card",
-    "discover": "credit_card",
-    # Bank/ACH
-    "bank_account": "bank",
-    "us_bank_account": "bank",
-    "ach": "bank",
-    "sepa_debit": "bank",
-    # Digital wallets
-    "paypal": "paypal",
-    "apple_pay": "apple",
-    "google_pay": "iphone",
-    "shop_pay": "shopping_bags",
-}
+# Company descriptions are enrichment boilerplate; anything longer than
+# this dominates the message and can push the customer footer and action
+# buttons behind Slack's "Show more" collapse.
+MAX_DESCRIPTION_LENGTH = 160
 
 
 def _coerce_float(value: Any, default: float = 0.0) -> float:
@@ -155,6 +118,34 @@ def _coerce_float(value: Any, default: float = 0.0) -> float:
     if not math.isfinite(result):
         return default
     return result
+
+
+def _truncate_mrkdwn(text: str, max_length: int) -> str:
+    """Truncate mrkdwn text without breaking link syntax.
+
+    Cutting inside a ``<url|label>`` link would leave a dangling ``<``
+    that Slack renders as broken markup, so a partial link at the cut
+    point is dropped entirely. The cut then backs up to a word boundary
+    and an ellipsis is appended.
+
+    Args:
+        text: Already-sanitized mrkdwn text.
+        max_length: Maximum length of the result, including the ellipsis.
+
+    Returns:
+        The text unchanged if it fits, otherwise a truncated version
+        ending in an ellipsis.
+    """
+    if len(text) <= max_length:
+        return text
+    cut = text[: max_length - 1]
+    open_bracket = cut.rfind("<")
+    if open_bracket > cut.rfind(">"):
+        cut = cut[:open_bracket]
+    space = cut.rfind(" ")
+    if space > 0:
+        cut = cut[:space]
+    return cut.rstrip() + "…"
 
 
 # Severity to color mapping
@@ -209,7 +200,7 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             n: RichNotification to format.
 
         Returns:
-            Dict with 'blocks' and 'color' for Slack API.
+            Dict with fallback 'text' and 'attachments' for Slack API.
         """
         blocks: list[dict[str, Any]] = []
 
@@ -225,33 +216,21 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
 
         # Payment/order details (for payment events)
         if n.payment:
-            blocks.append(self._format_payment_details(n))
+            payment_block = self._format_payment_details(n)
+            if payment_block:
+                blocks.append(payment_block)
 
         # Generic detail sections (for non-payment events or extras)
         for section in n.detail_sections:
             blocks.append(self._format_detail_section(section))
 
-        # Divider before company/customer section
-        blocks.append({"type": "divider"})
-
-        # Company section with logo (if enriched)
-        if n.company:
-            blocks.append(self._format_company_section(n.company))
-            # Add website & LinkedIn links below company section
-            links_block = self._format_company_links(n.company)
-            if links_block:
-                blocks.append(links_block)
-
-        # Person section (if enriched via Hunter.io)
-        if n.person:
-            person_blocks = self._format_person_section(n.person)
-            blocks.extend(person_blocks)
-
-        # Customer footer (optional - only shown when there's meaningful data)
-        if n.customer:
-            customer_footer = self._format_customer_footer(n.customer)
-            if customer_footer:
-                blocks.append(customer_footer)
+        # Company/person/customer blocks, preceded by a divider only when
+        # at least one is present - sparse events (e.g. an integration
+        # error with no customer) must not end on a dangling rule.
+        tail = self._format_tail_blocks(n)
+        if tail:
+            blocks.append({"type": "divider"})
+            blocks.extend(tail)
 
         # Action buttons (if present)
         if n.actions:
@@ -261,6 +240,7 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         # Top-level "color" is invalid for incoming webhooks
         color = SEVERITY_COLORS.get(n.severity, "#17a2b8")
         return {
+            "text": self._format_fallback_text(n),
             "attachments": [
                 {
                     "color": color,
@@ -268,6 +248,60 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
                 }
             ],
         }
+
+    def _format_tail_blocks(self, n: RichNotification) -> list[dict[str, Any]]:
+        """Build the company/person/customer blocks shown after the divider.
+
+        Args:
+            n: RichNotification.
+
+        Returns:
+            List of Slack blocks; empty when no enrichment or customer
+            data is available.
+        """
+        tail: list[dict[str, Any]] = []
+
+        # Company section with logo (if enriched)
+        if n.company:
+            tail.append(self._format_company_section(n.company))
+            # Add LinkedIn link below company section
+            links_block = self._format_company_links(n.company)
+            if links_block:
+                tail.append(links_block)
+
+        # Person section (if enriched via Hunter.io). It absorbs the
+        # customer facts (email, tenure, LTV, flags) so the reader gets
+        # one person block instead of two overlapping ones.
+        if n.person:
+            tail.extend(self._format_person_section(n.person, n.customer))
+        # Standalone customer footer (only shown when there's meaningful
+        # data and no person section already carries it)
+        elif n.customer:
+            customer_footer = self._format_customer_footer(n.customer)
+            if customer_footer:
+                tail.append(customer_footer)
+
+        return tail
+
+    def _format_fallback_text(self, n: RichNotification) -> str:
+        """Build the top-level fallback text for the message.
+
+        Slack renders this text in mobile push banners, desktop
+        notifications, and the channel sidebar preview. Attachment
+        blocks are invisible on those surfaces, so without it every
+        event shows up as a generic "sent a message" line.
+
+        Args:
+            n: RichNotification.
+
+        Returns:
+            Plain one-line summary, sanitized for mrkdwn.
+        """
+        parts = [n.headline]
+        if n.insight:
+            parts.append(n.insight.text)
+        fallback: str = safe_mrkdwn(" — ".join(parts))
+        return fallback
 
     def send(self, formatted: Any, credentials: dict[str, Any]) -> bool:
         """Send formatted notification to Slack via webhook.
@@ -331,27 +365,31 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
     def _format_insight(self, insight: InsightInfo) -> dict[str, Any]:
         """Format the insight/milestone line.
 
+        Insights (milestones, failure reasons, retry dates) are the
+        highest-value line in the message, so they render as a full-size
+        section block rather than muted context text.
+
         Args:
             insight: InsightInfo object.
 
         Returns:
-            Slack context block dict.
+            Slack section block dict.
         """
         emoji_name = SLACK_ICONS.get(insight.icon, "star")
         return {
-            "type": "context",
-            "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": f":{emoji_name}: *{insight.text}*",
-                }
-            ],
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f":{emoji_name}: *{safe_mrkdwn(insight.text)}*",
+            },
         }
 
     def _format_provider_badge(self, n: RichNotification) -> dict[str, Any]:
         """Format the provider/source badge.
 
-        Adapts based on whether this is a payment event or not.
+        Adapts based on whether this is a payment event or not. Kept
+        emoji-free so the headline severity emoji stays the only icon
+        above the fold.
 
         Args:
             n: RichNotification.
@@ -359,15 +397,14 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         Returns:
             Slack context block dict.
         """
-        provider_emoji = PROVIDER_ICONS.get(n.provider, DEFAULT_PROVIDER_ICON)
-        elements = [f":{provider_emoji}: {n.provider_display}"]
+        elements = [n.provider_display]
 
         # Only add payment-specific badges for payment events
         if n.is_payment_event:
             # Check for trial events - show "Trial" badge instead of payment type
             if n.type in TRIAL_NOTIFICATION_TYPES:
-                elements.append(":rocket: Trial")
-            # Add payment type (recurring/one-time) without extra emojis
+                elements.append("Trial")
+            # Add payment type (recurring/one-time)
             elif n.is_recurring:
                 if n.billing_interval:
                     elements.append(f"Recurring ({n.billing_interval.title()})")
@@ -376,27 +413,15 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             elif n.payment:
                 elements.append("One-Time")
 
-            # Add payment method if available (keep credit_card emoji for clarity)
+            # Add payment method if available
             if n.payment and n.payment.payment_method:
-                pm_emoji = PAYMENT_METHOD_ICONS.get(
-                    n.payment.payment_method.lower(), "credit_card"
-                )
                 pm_display = n.payment.payment_method.title()
                 if n.payment.card_last4:
                     pm_display += f" ••••{n.payment.card_last4}"
-                elements.append(f":{pm_emoji}: {pm_display}")
+                elements.append(pm_display)
         else:
             # For non-payment events, add category badge
-            category = n.category.value.title()
-            category_icons = {
-                "usage": "bar_chart",
-                "support": "ticket",
-                "customer": "bust_in_silhouette",
-                "system": "gear",
-                "custom": "link",
-            }
-            cat_emoji = category_icons.get(n.category.value, "information_source")
-            elements.append(f":{cat_emoji}: {category}")
+            elements.append(n.category.value.title())
 
         return {
             "type": "context",
@@ -405,51 +430,75 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             ],
         }
 
-    def _format_payment_details(self, n: RichNotification) -> dict[str, Any]:
+    def _format_payment_details(self, n: RichNotification) -> dict[str, Any] | None:
         """Format payment/order details section.
 
         Args:
             n: RichNotification with payment info.
 
         Returns:
-            Slack section block dict.
+            Slack section block dict, or None when there is nothing to
+            show beyond what the headline already carries.
         """
         payment = n.payment
         if not payment:
-            return {"type": "section", "text": {"type": "mrkdwn", "text": ""}}
+            return None
 
         # Check if this is e-commerce (has order number or line items)
         is_ecommerce = payment.order_number or payment.line_items
 
         if is_ecommerce:
             return self._format_ecommerce_details(payment)
-        return self._format_subscription_details(payment)
+        return self._format_subscription_details(payment, n.headline)
 
-    def _format_subscription_details(self, payment: PaymentInfo) -> dict[str, Any]:
-        """Format SaaS subscription payment details.
+    def _format_subscription_details(
+        self, payment: PaymentInfo, headline: str
+    ) -> dict[str, Any] | None:
+        """Format SaaS subscription payment details as a two-column grid.
+
+        The headline usually carries the base amount already (e.g.
+        "$299.00 received"), so repeating it here would be noise - in
+        that case only the ARR is surfaced. Headlines without an amount
+        (e.g. "New subscription!") get the full amount-with-ARR field so
+        the money is never lost.
 
         Args:
             payment: PaymentInfo object.
+            headline: The notification headline, used to detect whether
+                the amount is already visible.
 
         Returns:
-            Slack section block dict.
+            Slack section block dict with a ``fields`` grid, or None
+            when every detail would duplicate the headline.
         """
-        lines = ["*Payment Details*"]
-
-        # Amount with ARR
-        lines.append(f"*Amount:* {payment.format_amount_with_arr()}")
+        fields: list[str] = []
 
         if payment.plan_name:
-            lines.append(f"*Plan:* {safe_mrkdwn(payment.plan_name)}")
-        if payment.subscription_id:
-            lines.append(f"*Subscription:* #{safe_mrkdwn(payment.subscription_id)}")
-        if payment.failure_reason:
-            lines.append(f":x: *Reason:* {safe_mrkdwn(payment.failure_reason)}")
+            fields.append(f"*Plan*\n{safe_mrkdwn(payment.plan_name)}")
 
-        return {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": "\n".join(lines)},
-        }
+        amount_display: str = format_money(payment.amount, payment.currency)
+        arr = payment.get_arr()
+        if amount_display not in headline:
+            fields.append(f"*Amount*\n{payment.format_amount_with_arr()}")
+        elif arr is not None:
+            fields.append(f"*ARR*\n{format_money(arr, payment.currency, 0)}")
+
+        if payment.subscription_id:
+            fields.append(f"*Subscription*\n#{safe_mrkdwn(payment.subscription_id)}")
+
+        block: dict[str, Any] = {"type": "section"}
+        if fields:
+            block["fields"] = [{"type": "mrkdwn", "text": f} for f in fields]
+        # The failure insight does not always carry the reason (it may
+        # show retry info instead), so the reason stays here as well.
+        if payment.failure_reason:
+            block["text"] = {
+                "type": "mrkdwn",
+                "text": f":x: *Reason:* {safe_mrkdwn(payment.failure_reason)}",
+            }
+        if "fields" not in block and "text" not in block:
+            return None
+        return block
 
     def _format_ecommerce_details(self, payment: PaymentInfo) -> dict[str, Any]:
         """Format e-commerce order details with line items.
@@ -540,13 +589,19 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
     def _format_company_section(self, company: CompanyInfo) -> dict[str, Any]:
         """Format company enrichment section with logo.
 
+        The company domain is linked inline next to the name, so the
+        website does not need its own action button.
+
         Args:
             company: CompanyInfo object.
 
         Returns:
             Slack section block dict.
         """
-        text_parts = [f":office: *{safe_mrkdwn(company.name)}*"]
+        name_line = f"*{safe_mrkdwn(company.name)}*"
+        if company.domain:
+            name_line += f" · <https://{company.domain}|{safe_mrkdwn(company.domain)}>"
+        text_parts = [name_line]
 
         # Company details line
         details: list[str] = []
@@ -559,9 +614,12 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         if details:
             text_parts.append(f"_{' • '.join(details)}_")
 
-        # Description as blockquote
+        # Description as blockquote, truncated so enrichment boilerplate
+        # cannot dominate the message or push the actions behind Slack's
+        # "Show more" collapse.
         if company.description:
             desc = html_to_slack_mrkdwn(company.description)
+            desc = _truncate_mrkdwn(desc, MAX_DESCRIPTION_LENGTH)
             text_parts.append(f">{desc}")
 
         block: dict[str, Any] = {
@@ -594,34 +652,38 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         if not company.linkedin_url:
             return None
 
-        link_text = f":briefcase: <{company.linkedin_url}|LinkedIn>"
+        link_text = f"<{company.linkedin_url}|LinkedIn>"
         return {
             "type": "context",
             "elements": [{"type": "mrkdwn", "text": link_text}],
         }
 
-    def _format_person_section(self, person: PersonInfo) -> list[dict[str, Any]]:
+    def _format_person_section(
+        self, person: PersonInfo, customer: CustomerInfo | None = None
+    ) -> list[dict[str, Any]]:
         """Format person enrichment section (from Hunter.io).
 
         Displays person information from email enrichment, including
-        name, job title, seniority, location, and social links.
+        name, job title, seniority, location, and social links. When
+        customer info is passed, its facts line (email, tenure, LTV,
+        flags) is folded in below the person so the message shows a
+        single merged person block instead of a separate footer.
 
         Args:
             person: PersonInfo object from Hunter.io enrichment.
+            customer: Optional CustomerInfo to merge into this section.
 
         Returns:
-            List of Slack blocks (section and optional context block).
+            List of Slack blocks (section and optional context blocks).
         """
         blocks: list[dict[str, Any]] = []
 
         # Build main text content
         text_parts: list[str] = []
 
-        # Person name with icon
+        # Person name with icon, job info (title + seniority) inline
         display_name = person.full_name or person.email
-        text_parts.append(f":bust_in_silhouette: *{display_name}*")
-
-        # Job info line (title + seniority)
+        name_line = f":bust_in_silhouette: *{display_name}*"
         job_parts: list[str] = []
         if person.position:
             job_parts.append(person.position)
@@ -629,7 +691,8 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             # Capitalize seniority for display (e.g., "senior" -> "Senior")
             job_parts.append(person.seniority.title())
         if job_parts:
-            text_parts.append(f"_{' • '.join(job_parts)}_")
+            name_line += f" — _{' • '.join(job_parts)}_"
+        text_parts.append(name_line)
 
         # Location line
         if person.location:
@@ -643,42 +706,67 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             }
         )
 
-        # Social links as context block
-        links: list[str] = []
-        if person.linkedin_url:
-            links.append(f":briefcase: <{person.linkedin_url}|LinkedIn>")
-        if person.twitter_handle:
-            twitter_url = f"https://twitter.com/{person.twitter_handle}"
-            links.append(f":bird: <{twitter_url}|Twitter>")
-        if person.github_handle:
-            github_url = f"https://github.com/{person.github_handle}"
-            links.append(f":octocat: <{github_url}|GitHub>")
+        # Customer facts folded in under the person (icon suppressed -
+        # the name line above already carries it)
+        if customer:
+            customer_facts = self._format_customer_footer(customer, include_icon=False)
+            if customer_facts:
+                blocks.append(customer_facts)
 
-        if links:
-            blocks.append(
-                {
-                    "type": "context",
-                    "elements": [{"type": "mrkdwn", "text": " | ".join(links)}],
-                }
-            )
+        # Social links as context block
+        links_block = self._format_person_links(person)
+        if links_block:
+            blocks.append(links_block)
 
         return blocks
 
-    def _format_customer_footer(self, customer: CustomerInfo) -> dict[str, Any] | None:
+    def _format_person_links(self, person: PersonInfo) -> dict[str, Any] | None:
+        """Format the person's social links as a context block.
+
+        Args:
+            person: PersonInfo object from Hunter.io enrichment.
+
+        Returns:
+            Slack context block dict, or None when no links available.
+        """
+        links: list[str] = []
+        if person.linkedin_url:
+            links.append(f"<{person.linkedin_url}|LinkedIn>")
+        if person.twitter_handle:
+            twitter_url = f"https://twitter.com/{person.twitter_handle}"
+            links.append(f"<{twitter_url}|Twitter>")
+        if person.github_handle:
+            github_url = f"https://github.com/{person.github_handle}"
+            links.append(f"<{github_url}|GitHub>")
+
+        if not links:
+            return None
+        return {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": " · ".join(links)}],
+        }
+
+    def _format_customer_footer(
+        self, customer: CustomerInfo, include_icon: bool = True
+    ) -> dict[str, Any] | None:
         """Format customer info footer.
 
         Args:
             customer: CustomerInfo object.
+            include_icon: Whether to prefix the email/name with the
+                person icon. Pass False when a person section already
+                shows it, so the icon appears once per message.
 
         Returns:
             Slack context block dict, or None if no meaningful data.
         """
         elements: list[str] = []
+        icon_prefix = ":bust_in_silhouette: " if include_icon else ""
 
         # Email, with compact domain-type badges (e.g.
         # ":bust_in_silhouette: jane@stanford.edu · :mortar_board: Education")
         if customer.email:
-            email_parts = [f":bust_in_silhouette: {safe_mrkdwn(customer.email)}"]
+            email_parts = [f"{icon_prefix}{safe_mrkdwn(customer.email)}"]
             email_parts.extend(
                 EMAIL_TAG_BADGES[tag]
                 for tag in customer.email_tags
@@ -688,7 +776,7 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
 
         # Name if no email
         if not customer.email and customer.name:
-            elements.append(f":bust_in_silhouette: {safe_mrkdwn(customer.name)}")
+            elements.append(f"{icon_prefix}{safe_mrkdwn(customer.name)}")
 
         # Tenure (no emoji for cleaner look)
         if customer.tenure_display:

--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -7,11 +7,16 @@ format and sends them via Slack's incoming webhook API.
 import logging
 import math
 from typing import Any
+from urllib.parse import quote
 
 import requests
 from plugins.base import PluginCapability, PluginMetadata, PluginType
 from plugins.destinations.base import BaseDestinationPlugin
-from plugins.destinations.slack_utils import html_to_slack_mrkdwn, safe_mrkdwn
+from plugins.destinations.slack_utils import (
+    html_to_slack_mrkdwn,
+    safe_mrkdwn,
+    safe_mrkdwn_link,
+)
 from webhooks.models.rich_notification import (
     ActionButton,
     CompanyInfo,
@@ -426,10 +431,14 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             # For non-payment events, add category badge
             elements.append(n.category.value.title())
 
+        # Provider display, billing interval, and payment method all
+        # derive from webhook payload data, so each element is sanitized
+        # before joining into mrkdwn.
+        badge_text = " • ".join(safe_mrkdwn(e) for e in elements)
         return {
             "type": "context",
             "elements": [
-                {"type": "mrkdwn", "text": " • ".join(elements)},
+                {"type": "mrkdwn", "text": badge_text},
             ],
         }
 
@@ -603,7 +612,9 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         """
         name_line = f"*{safe_mrkdwn(company.name)}*"
         if company.domain:
-            name_line += f" · <https://{company.domain}|{safe_mrkdwn(company.domain)}>"
+            domain_link = safe_mrkdwn_link(f"https://{company.domain}", company.domain)
+            if domain_link:
+                name_line += f" · {domain_link}"
         text_parts = [name_line]
 
         # Company details line
@@ -652,10 +663,10 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         Returns:
             Slack context block dict, or None if no LinkedIn available.
         """
-        if not company.linkedin_url:
+        link_text = safe_mrkdwn_link(company.linkedin_url, "LinkedIn")
+        if not link_text:
             return None
 
-        link_text = f"<{company.linkedin_url}|LinkedIn>"
         return {
             "type": "context",
             "elements": [{"type": "mrkdwn", "text": link_text}],
@@ -734,15 +745,26 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         Returns:
             Slack context block dict, or None when no links available.
         """
-        links: list[str] = []
-        if person.linkedin_url:
-            links.append(f"<{person.linkedin_url}|LinkedIn>")
-        if person.twitter_handle:
-            twitter_url = f"https://twitter.com/{person.twitter_handle}"
-            links.append(f"<{twitter_url}|Twitter>")
-        if person.github_handle:
-            github_url = f"https://github.com/{person.github_handle}"
-            links.append(f"<{github_url}|GitHub>")
+        # Enrichment URLs are untrusted; handles are percent-encoded so
+        # they cannot smuggle mrkdwn or path segments into the URL.
+        candidates = [
+            (person.linkedin_url, "LinkedIn"),
+            (
+                f"https://twitter.com/{quote(person.twitter_handle, safe='')}"
+                if person.twitter_handle
+                else None,
+                "Twitter",
+            ),
+            (
+                f"https://github.com/{quote(person.github_handle, safe='')}"
+                if person.github_handle
+                else None,
+                "GitHub",
+            ),
+        ]
+        links = [
+            link for url, label in candidates if (link := safe_mrkdwn_link(url, label))
+        ]
 
         if not links:
             return None

--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -300,7 +300,10 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         parts = [n.headline]
         if n.insight:
             parts.append(n.insight.text)
-        fallback: str = safe_mrkdwn(" — ".join(parts))
+        # Collapse all whitespace (payload-derived strings like failure
+        # reasons can contain newlines) so the preview stays one line.
+        one_line = " ".join(" — ".join(parts).split())
+        fallback: str = safe_mrkdwn(one_line)
         return fallback
 
     def send(self, formatted: Any, credentials: dict[str, Any]) -> bool:
@@ -681,22 +684,24 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         # Build main text content
         text_parts: list[str] = []
 
-        # Person name with icon, job info (title + seniority) inline
+        # Person name with icon, job info (title + seniority) inline.
+        # Hunter.io enrichment data is third-party input, so every field
+        # is sanitized before interpolation into mrkdwn.
         display_name = person.full_name or person.email
-        name_line = f":bust_in_silhouette: *{display_name}*"
+        name_line = f":bust_in_silhouette: *{safe_mrkdwn(display_name)}*"
         job_parts: list[str] = []
         if person.position:
-            job_parts.append(person.position)
+            job_parts.append(safe_mrkdwn(person.position))
         if person.seniority:
             # Capitalize seniority for display (e.g., "senior" -> "Senior")
-            job_parts.append(person.seniority.title())
+            job_parts.append(safe_mrkdwn(person.seniority.title()))
         if job_parts:
             name_line += f" — _{' • '.join(job_parts)}_"
         text_parts.append(name_line)
 
         # Location line
         if person.location:
-            text_parts.append(f":round_pushpin: {person.location}")
+            text_parts.append(f":round_pushpin: {safe_mrkdwn(person.location)}")
 
         # Main section block
         blocks.append(

--- a/app/plugins/destinations/slack_utils.py
+++ b/app/plugins/destinations/slack_utils.py
@@ -279,6 +279,35 @@ def safe_mrkdwn(text: str | None) -> str:
     return _escape_slack_mrkdwn(text)
 
 
+def safe_mrkdwn_link(url: str | None, label: str) -> str | None:
+    """Build a Slack ``<url|label>`` mrkdwn link from an untrusted URL.
+
+    Enrichment sources (Brandfetch, Hunter.io) and webhook payloads
+    supply the URLs shown in notifications; a crafted value containing
+    ``<``, ``>``, ``|``, or whitespace could break out of the link
+    syntax and inject arbitrary mrkdwn (fake links, mentions). Those
+    characters are invalid in a properly-encoded URL, so URLs carrying
+    them are rejected rather than repaired. Only http/https schemes are
+    allowed, and the label is escaped for the link-text position.
+
+    Args:
+        url: The untrusted URL. May be None.
+        label: Human-readable link text.
+
+    Returns:
+        A safe ``<url|label>`` string, or None when the URL is missing
+        or unusable.
+    """
+    if not url:
+        return None
+    url = _clean_control_characters(url.strip())
+    if _sanitize_url(url) is None:
+        return None
+    if any(c in url for c in "<>|") or any(c.isspace() for c in url):
+        return None
+    return f"<{url}|{_escape_slack_link_text(label)}>"
+
+
 def _escape_slack_link_text(text: str) -> str:
     """Escape text for use inside Slack link display text.
 

--- a/app/plugins/destinations/slack_utils.py
+++ b/app/plugins/destinations/slack_utils.py
@@ -301,7 +301,13 @@ def safe_mrkdwn_link(url: str | None, label: str) -> str | None:
     if not url:
         return None
     url = _clean_control_characters(url.strip())
-    if _sanitize_url(url) is None:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    # Require a host as well as an http(s) scheme - a bare "https://"
+    # would render as a broken link.
+    if parsed.scheme.lower() not in ("http", "https") or not parsed.netloc:
         return None
     if any(c in url for c in "<>|") or any(c.isspace() for c in url):
         return None

--- a/app/webhooks/services/notification_builder.py
+++ b/app/webhooks/services/notification_builder.py
@@ -45,6 +45,33 @@ _CHARGIFY_SUBDOMAIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 _SHOPIFY_SHOP_DOMAIN_RE = re.compile(r"^[a-z0-9][a-z0-9\-_]*\.myshopify\.com$")
 
 
+# The contact button interpolates the customer email into a mailto:
+# URL. Payload emails can carry whitespace, control characters, or
+# mailto query syntax ("?cc=..."), which would break the button or
+# add unintended recipients, so only a plain single-address shape is
+# accepted. Conservative allowlist; rejecting an exotic-but-valid
+# address just omits the button.
+_MAILTO_EMAIL_RE = re.compile(r"^[A-Za-z0-9._+-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$")
+
+
+def _normalize_contact_email(value: Any) -> str | None:
+    """Normalize and validate a customer email for a mailto: link.
+
+    Args:
+        value: Raw email value from customer data.
+
+    Returns:
+        The normalized email, or None when the value is missing or not
+        a safe plain address.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not _MAILTO_EMAIL_RE.fullmatch(normalized):
+        return None
+    return normalized
+
+
 def _normalize_chargify_subdomain(value: Any) -> str | None:
     """Normalize and validate a Chargify site subdomain.
 
@@ -687,7 +714,7 @@ class NotificationBuilder:
         # On a payment failure the account-saving action is contacting
         # the customer, so it takes the primary style and first position;
         # the dashboard link becomes secondary.
-        email = customer_data.get("email")
+        email = _normalize_contact_email(customer_data.get("email"))
         if event_type == "payment_failure" and email:
             actions.append(
                 ActionButton(

--- a/app/webhooks/services/notification_builder.py
+++ b/app/webhooks/services/notification_builder.py
@@ -672,35 +672,35 @@ class NotificationBuilder:
         Returns:
             List of ActionButton objects.
         """
+        # Note: the company website is linked inline in the Slack company
+        # section, so it no longer gets its own button - buttons are
+        # reserved for actions.
+        _ = company
+
         event_type = event_data.get("type", "")
 
         actions: list[ActionButton] = []
 
         # Provider-specific dashboard link
         dashboard_action = self._build_provider_dashboard_action(event_data)
-        if dashboard_action:
-            actions.append(dashboard_action)
 
-        # Add company website link if enriched
-        if company and company.domain:
-            actions.append(
-                ActionButton(
-                    text="Website",
-                    url=f"https://{company.domain}",
-                    style="default",
-                )
-            )
-
-        # Add contact customer link for failures
+        # On a payment failure the account-saving action is contacting
+        # the customer, so it takes the primary style and first position;
+        # the dashboard link becomes secondary.
         email = customer_data.get("email")
         if event_type == "payment_failure" and email:
             actions.append(
                 ActionButton(
                     text="Contact Customer",
                     url=f"mailto:{email}",
-                    style="default",
+                    style="primary",
                 )
             )
+            if dashboard_action:
+                dashboard_action.style = "default"
+                actions.append(dashboard_action)
+        elif dashboard_action:
+            actions.append(dashboard_action)
 
         return actions
 

--- a/tests/test_email_enrichment.py
+++ b/tests/test_email_enrichment.py
@@ -443,8 +443,8 @@ class TestSlackPersonSection:
         assert len(blocks) == 2
         links_block = blocks[1]
 
-        assert ":briefcase:" in links_block["elements"][0]["text"]
         assert "linkedin.com" in links_block["elements"][0]["text"]
+        assert "|LinkedIn>" in links_block["elements"][0]["text"]
 
     def test_person_section_has_twitter_link(
         self, slack_plugin, person_info: PersonInfo
@@ -453,8 +453,8 @@ class TestSlackPersonSection:
         blocks = slack_plugin._format_person_section(person_info)
         links_block = blocks[1]
 
-        assert ":bird:" in links_block["elements"][0]["text"]
         assert "twitter.com/johndoe" in links_block["elements"][0]["text"]
+        assert "|Twitter>" in links_block["elements"][0]["text"]
 
     def test_person_section_has_github_link(
         self, slack_plugin, person_info: PersonInfo
@@ -463,8 +463,8 @@ class TestSlackPersonSection:
         blocks = slack_plugin._format_person_section(person_info)
         links_block = blocks[1]
 
-        assert ":octocat:" in links_block["elements"][0]["text"]
         assert "github.com/johndoe" in links_block["elements"][0]["text"]
+        assert "|GitHub>" in links_block["elements"][0]["text"]
 
     def test_person_section_no_links_without_data(self, slack_plugin) -> None:
         """Test person section without social links."""

--- a/tests/test_notification_builder.py
+++ b/tests/test_notification_builder.py
@@ -658,6 +658,44 @@ class TestActionButtons:
         assert contact_buttons[0].style == "primary"
         assert result.actions[0].text == "Contact Customer"
 
+    @pytest.mark.parametrize(
+        "bad_email",
+        [
+            "foo?cc=victim@evil.com",  # mailto query injection
+            "a b@example.com",  # interior whitespace
+            "not-an-email",  # no @/domain
+            "<script>@example.com",  # markup characters
+            "a@b",  # no domain dot
+            "   ",  # whitespace only
+            12345,  # non-string
+        ],
+    )
+    def test_contact_button_omitted_for_unsafe_email(
+        self,
+        builder: NotificationBuilder,
+        payment_failure_event: dict,
+        bad_email: object,
+    ) -> None:
+        """Test unsafe emails never reach the mailto: button URL."""
+        customer_data = {"email": bad_email, "first_name": "X", "last_name": "Y"}
+        result = builder.build(payment_failure_event, customer_data)
+
+        action_texts = [a.text for a in result.actions]
+        assert "Contact Customer" not in action_texts
+
+    def test_contact_email_normalized_before_use(
+        self,
+        builder: NotificationBuilder,
+        payment_failure_event: dict,
+    ) -> None:
+        """Test surrounding whitespace is normalized, not rejected."""
+        customer_data = {"email": "  alice@acme.com  ", "first_name": "Alice"}
+        result = builder.build(payment_failure_event, customer_data)
+
+        contact_buttons = [a for a in result.actions if a.text == "Contact Customer"]
+        assert len(contact_buttons) == 1
+        assert contact_buttons[0].url == "mailto:alice@acme.com"
+
     def test_dashboard_secondary_on_failure(
         self, builder: NotificationBuilder, customer_data: dict
     ) -> None:

--- a/tests/test_notification_builder.py
+++ b/tests/test_notification_builder.py
@@ -627,30 +627,61 @@ class TestActionButtons:
             == "https://acme-corp.chargify.com/subscriptions/sub_456"
         )
 
-    def test_website_button_with_company(
+    def test_no_website_button_with_company(
         self,
         builder: NotificationBuilder,
         payment_success_event: dict,
         customer_data: dict,
         mock_company: MagicMock,
     ) -> None:
-        """Test website button added when company is enriched."""
+        """Test no website button - the domain is linked inline instead.
+
+        Buttons are reserved for actions; the company website is shown
+        as an inline link in the Slack company section.
+        """
         result = builder.build(payment_success_event, customer_data, mock_company)
 
         action_texts = [a.text for a in result.actions]
-        assert "Website" in action_texts
+        assert "Website" not in action_texts
 
-    def test_contact_button_on_failure(
+    def test_contact_button_primary_on_failure(
         self,
         builder: NotificationBuilder,
         payment_failure_event: dict,
         customer_data: dict,
     ) -> None:
-        """Test contact customer button on payment failure."""
+        """Test contact customer is the primary action on payment failure."""
         result = builder.build(payment_failure_event, customer_data)
 
+        contact_buttons = [a for a in result.actions if a.text == "Contact Customer"]
+        assert len(contact_buttons) == 1
+        assert contact_buttons[0].style == "primary"
+        assert result.actions[0].text == "Contact Customer"
+
+    def test_dashboard_secondary_on_failure(
+        self, builder: NotificationBuilder, customer_data: dict
+    ) -> None:
+        """Test the dashboard link is demoted to secondary on failures.
+
+        The account-saving action on a failure is contacting the
+        customer, so the provider dashboard link loses the primary
+        style and second position it has on other events.
+        """
+        event = {
+            "type": "payment_failure",
+            "provider": "stripe",
+            "customer_id": "cus_123",
+            "amount": 99.00,
+            "currency": "USD",
+            "metadata": {"failure_reason": "Card declined"},
+        }
+        result = builder.build(event, customer_data)
+
         action_texts = [a.text for a in result.actions]
-        assert "Contact Customer" in action_texts
+        assert action_texts == ["Contact Customer", "View in Stripe"]
+        styles = {a.text: a.style for a in result.actions}
+        assert styles["Contact Customer"] == "primary"
+        assert styles["View in Stripe"] == "default"
 
 
 class TestInsightDetection:

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -326,6 +326,19 @@ class TestSlackDestinationPluginProviderBadge:
                     return
         pytest.fail("Payment type not found in badge")
 
+    def test_provider_badge_sanitized(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test payload-derived badge elements cannot inject Slack syntax."""
+        assert basic_notification.payment is not None
+        basic_notification.payment.payment_method = "<!channel> card"
+        result = formatter.format(basic_notification)
+
+        for block in get_blocks(result):
+            if block["type"] == "context":
+                text = str(block.get("elements", [{}])[0].get("text", ""))
+                assert "<!channel>" not in text
+
 
 def get_fields_text(result: dict[str, Any]) -> str:
     """Collect the text of all section-block fields in the message.
@@ -581,6 +594,24 @@ class TestSlackDestinationPluginCompanySection:
                 return
         pytest.fail("Company section not found")
 
+    def test_company_section_skips_unsafe_domain_link(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test an unsafe domain renders no link but keeps the name."""
+        basic_notification.company = CompanyInfo(
+            name="Evil Corp",
+            domain="evil.com/|<!channel>",
+        )
+        result = formatter.format(basic_notification)
+
+        for block in get_blocks(result):
+            if block["type"] == "section" and "Evil Corp" in str(block.get("text", {})):
+                text = str(block.get("text", {}).get("text", ""))
+                assert "<https://" not in text
+                assert "<!channel>" not in text
+                return
+        pytest.fail("Company section not found")
+
 
 class TestSlackDestinationPluginCompanyLinks:
     """Test company links formatting."""
@@ -655,6 +686,23 @@ class TestSlackDestinationPluginCompanyLinks:
                     assert "Website" not in text
                     return
         pytest.fail("LinkedIn-only links block not found")
+
+    def test_company_links_rejects_unsafe_linkedin_url(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test a LinkedIn URL that could break link syntax is dropped."""
+        basic_notification.company = CompanyInfo(
+            name="Test Corp",
+            domain="",
+            linkedin_url="https://evil.example/|<https://phish.example",
+        )
+        result = formatter.format(basic_notification)
+
+        for block in get_blocks(result):
+            if block["type"] == "context":
+                text = str(block.get("elements", [{}])[0].get("text", ""))
+                assert "LinkedIn" not in text
+                assert "phish.example" not in text
 
     def test_no_company_links_without_data(
         self, formatter: SlackDestinationPlugin, basic_notification: RichNotification

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -760,6 +760,25 @@ class TestSlackDestinationPluginCustomerFooter:
         ]
         assert len(email_contexts) == 1
 
+    def test_person_fields_sanitized(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test Hunter.io person fields cannot inject Slack syntax."""
+        basic_notification.person = PersonInfo(
+            email="alice@acme.com",
+            first_name="<!channel>",
+            last_name="Smith",
+            position="<https://evil.example|CEO>",
+            location="<!here> HQ",
+        )
+        result = formatter.format(basic_notification)
+
+        for block in get_blocks(result):
+            text = str(block)
+            assert "<!channel>" not in text
+            assert "<!here>" not in text
+            assert "<https://evil.example|" not in text
+
     def test_customer_footer_shows_risk_flag(
         self, formatter: SlackDestinationPlugin
     ) -> None:
@@ -921,6 +940,20 @@ class TestSlackDestinationPluginFallbackText:
         result = formatter.format(basic_notification)
 
         assert "<!channel>" not in result["text"]
+
+    def test_fallback_text_is_single_line(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test whitespace in payload-derived text collapses to one line."""
+        basic_notification.insight = InsightInfo(
+            icon="warning",
+            text="Card declined:\ninsufficient\tfunds",
+        )
+        result = formatter.format(basic_notification)
+
+        assert "\n" not in result["text"]
+        assert "\t" not in result["text"]
+        assert "Card declined: insufficient funds" in result["text"]
 
 
 class TestSlackDestinationPluginEcommerceDetails:

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -422,6 +422,17 @@ class TestSlackDestinationPluginPaymentDetails:
 
         assert get_fields_text(result) == ""
 
+    def test_amount_fields_sanitize_currency(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test a malformed payload currency cannot inject Slack syntax."""
+        basic_notification.headline = "New subscription!"
+        assert basic_notification.payment is not None
+        basic_notification.payment.currency = "<!channel>"
+        result = formatter.format(basic_notification)
+
+        assert "<!channel>" not in get_fields_text(result).lower()
+
     def test_failure_reason_shown_with_fields(
         self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
     ) -> None:

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -17,6 +17,7 @@ from webhooks.models.rich_notification import (
     NotificationSeverity,
     NotificationType,
     PaymentInfo,
+    PersonInfo,
     RichNotification,
 )
 
@@ -242,15 +243,16 @@ class TestSlackDestinationPluginInsight:
         formatter: SlackDestinationPlugin,
         notification_with_insight: RichNotification,
     ) -> None:
-        """Test insight block is present when notification has insight."""
+        """Test insight renders as a full-size section block."""
         result = formatter.format(notification_with_insight)
 
-        # Find context block with insight
+        # Insights are the highest-value line, so they are promoted to a
+        # section block rather than muted context text
         insight_blocks = [
             b
             for b in get_blocks(result)
-            if b["type"] == "context"
-            and any("lifetime" in str(e.get("text", "")) for e in b.get("elements", []))
+            if b["type"] == "section"
+            and "lifetime" in str(b.get("text", {}).get("text", ""))
         ]
         assert len(insight_blocks) == 1
 
@@ -264,11 +266,11 @@ class TestSlackDestinationPluginInsight:
 
         # Find the insight block
         for block in get_blocks(result):
-            if block["type"] == "context":
-                for element in block.get("elements", []):
-                    if "lifetime" in str(element.get("text", "")):
-                        assert "$5,000" in element["text"]
-                        return
+            if block["type"] == "section":
+                text = str(block.get("text", {}).get("text", ""))
+                if "lifetime" in text:
+                    assert "$5,000" in text
+                    return
         pytest.fail("Insight text not found")
 
     def test_no_insight_block_without_insight(
@@ -278,9 +280,8 @@ class TestSlackDestinationPluginInsight:
         basic_notification.insight = None
         result = formatter.format(basic_notification)
 
-        # Count context blocks - should only have provider badge and customer footer
-        context_blocks = [b for b in get_blocks(result) if b["type"] == "context"]
-        assert len(context_blocks) == 2  # Provider badge + customer footer
+        for block in get_blocks(result):
+            assert "lifetime" not in str(block)
 
 
 class TestSlackDestinationPluginProviderBadge:
@@ -326,32 +327,55 @@ class TestSlackDestinationPluginProviderBadge:
         pytest.fail("Payment type not found in badge")
 
 
+def get_fields_text(result: dict[str, Any]) -> str:
+    """Collect the text of all section-block fields in the message.
+
+    Args:
+        result: Formatted Slack message dict.
+
+    Returns:
+        Newline-joined text of every field across all section blocks.
+    """
+    texts: list[str] = []
+    for block in get_blocks(result):
+        if block.get("type") == "section":
+            for field in block.get("fields", []):
+                texts.append(str(field.get("text", "")))
+    return "\n".join(texts)
+
+
 class TestSlackDestinationPluginPaymentDetails:
-    """Test payment details section formatting."""
+    """Test payment details fields grid formatting."""
 
-    def test_payment_details_present(
+    def test_payment_details_fields_present(
         self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
     ) -> None:
-        """Test payment details section is present."""
+        """Test payment details render as a fields grid."""
         result = formatter.format(basic_notification)
 
-        # Find section with payment details
-        section_blocks = [b for b in get_blocks(result) if b["type"] == "section"]
-        assert len(section_blocks) >= 1
+        assert get_fields_text(result) != ""
 
-    def test_payment_details_contains_amount(
+    def test_amount_not_repeated_when_in_headline(
         self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
     ) -> None:
-        """Test payment details contains amount."""
+        """Test the grid skips the amount the headline already shows."""
+        # Headline is "$299.00 from Acme Inc" - the amount is visible
         result = formatter.format(basic_notification)
 
-        for block in get_blocks(result):
-            if block["type"] == "section":
-                text = str(block.get("text", {}).get("text", ""))
-                if "299" in text or "Amount" in text:
-                    assert "299" in text
-                    return
-        pytest.fail("Amount not found in payment details")
+        fields_text = get_fields_text(result)
+        assert "*Amount*" not in fields_text
+        assert "*ARR*" in fields_text
+
+    def test_amount_shown_when_headline_lacks_it(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test the grid carries the amount for amount-less headlines."""
+        basic_notification.headline = "New subscription!"
+        result = formatter.format(basic_notification)
+
+        fields_text = get_fields_text(result)
+        assert "*Amount*" in fields_text
+        assert "$299.00/mo = $3,588 ARR" in fields_text
 
     def test_payment_details_contains_arr(
         self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
@@ -359,12 +383,46 @@ class TestSlackDestinationPluginPaymentDetails:
         """Test payment details contains ARR for monthly subscriptions."""
         result = formatter.format(basic_notification)
 
+        fields_text = get_fields_text(result)
+        assert "ARR" in fields_text
+        assert "$3,588" in fields_text
+
+    def test_payment_details_contains_plan_and_subscription(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test plan and subscription id render as grid fields."""
+        result = formatter.format(basic_notification)
+
+        fields_text = get_fields_text(result)
+        assert "*Plan*\nEnterprise" in fields_text
+        assert "*Subscription*\n#sub_123" in fields_text
+
+    def test_payment_details_skipped_when_all_duplicate(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test no details block when every field would repeat the headline."""
+        basic_notification.headline = "$50.00 received"
+        basic_notification.payment = PaymentInfo(amount=50.00, currency="USD")
+        basic_notification.is_recurring = False
+        basic_notification.billing_interval = None
+        result = formatter.format(basic_notification)
+
+        assert get_fields_text(result) == ""
+
+    def test_failure_reason_shown_with_fields(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test the failure reason renders as text above the grid."""
+        assert basic_notification.payment is not None
+        basic_notification.payment.failure_reason = "Card declined"
+        result = formatter.format(basic_notification)
+
         for block in get_blocks(result):
-            if block["type"] == "section":
+            if block.get("type") == "section" and "fields" in block:
                 text = str(block.get("text", {}).get("text", ""))
-                if "ARR" in text:
-                    return
-        pytest.fail("ARR not found in payment details")
+                assert "Card declined" in text
+                return
+        pytest.fail("Payment details block with failure reason not found")
 
 
 class TestSlackDestinationPluginCompanySection:
@@ -465,11 +523,11 @@ class TestSlackDestinationPluginCompanySection:
                 return
         pytest.fail("Company section not found")
 
-    def test_company_section_description_full(
+    def test_company_section_description_truncated(
         self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
     ) -> None:
-        """Test long descriptions are shown in full (not truncated)."""
-        long_description = "A" * 200  # 200 character description
+        """Test long descriptions are truncated with an ellipsis."""
+        long_description = "word " * 60  # ~300 characters
         basic_notification.company = CompanyInfo(
             name="Long Corp",
             domain="long.com",
@@ -480,8 +538,46 @@ class TestSlackDestinationPluginCompanySection:
         for block in get_blocks(result):
             if block["type"] == "section" and "Long Corp" in str(block.get("text", {})):
                 text = str(block.get("text", {}).get("text", ""))
-                # Full description should be present (not truncated)
-                assert long_description in text
+                assert long_description.strip() not in text
+                assert "…" in text
+                return
+        pytest.fail("Company section not found")
+
+    def test_company_section_short_description_not_truncated(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test short descriptions are shown in full."""
+        basic_notification.company = CompanyInfo(
+            name="Short Corp",
+            domain="short.com",
+            description="Builds developer tools.",
+        )
+        result = formatter.format(basic_notification)
+
+        for block in get_blocks(result):
+            if block["type"] == "section" and "Short Corp" in str(
+                block.get("text", {})
+            ):
+                text = str(block.get("text", {}).get("text", ""))
+                assert "Builds developer tools." in text
+                assert "…" not in text
+                return
+        pytest.fail("Company section not found")
+
+    def test_company_section_links_domain(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test company domain is linked inline next to the name."""
+        basic_notification.company = CompanyInfo(
+            name="Test Corp",
+            domain="test.com",
+        )
+        result = formatter.format(basic_notification)
+
+        for block in get_blocks(result):
+            if block["type"] == "section" and "Test Corp" in str(block.get("text", {})):
+                text = str(block.get("text", {}).get("text", ""))
+                assert "<https://test.com|test.com>" in text
                 return
         pytest.fail("Company section not found")
 
@@ -519,7 +615,6 @@ class TestSlackDestinationPluginCompanyLinks:
                 text = str(block.get("elements", [{}])[0].get("text", ""))
                 if "LinkedIn" in text:
                     assert "https://linkedin.com/company/acme-corp" in text
-                    assert ":briefcase:" in text
                     return
         pytest.fail("LinkedIn link not found in company links")
 
@@ -617,6 +712,53 @@ class TestSlackDestinationPluginCustomerFooter:
         text = str(last_context.get("elements", [{}])[0].get("text", ""))
 
         assert "Since Mar 2024" in text
+
+    def test_customer_footer_icon_suppressed_with_person(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test footer drops the person icon when a person section shows it."""
+        basic_notification.person = PersonInfo(
+            email="alice@acme.com",
+            first_name="Alice",
+            last_name="Smith",
+        )
+        result = formatter.format(basic_notification)
+
+        context_blocks = [b for b in get_blocks(result) if b["type"] == "context"]
+        footer_text = str(context_blocks[-1].get("elements", [{}])[0].get("text", ""))
+
+        assert "alice@acme.com" in footer_text
+        assert ":bust_in_silhouette:" not in footer_text
+
+    def test_person_merge_includes_customer_facts(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test customer facts fold into the person block, not a footer."""
+        basic_notification.person = PersonInfo(
+            email="alice@acme.com",
+            first_name="Alice",
+            last_name="Smith",
+            position="CTO",
+        )
+        result = formatter.format(basic_notification)
+        blocks = get_blocks(result)
+
+        # Name and job title share one line in the person section
+        person_sections = [
+            b
+            for b in blocks
+            if b["type"] == "section" and "Alice Smith" in str(b.get("text", {}))
+        ]
+        assert len(person_sections) == 1
+        assert "*Alice Smith* — _CTO_" in person_sections[0]["text"]["text"]
+
+        # Exactly one context block carries the customer facts
+        email_contexts = [
+            b
+            for b in blocks
+            if b["type"] == "context" and "alice@acme.com" in str(b.get("elements", []))
+        ]
+        assert len(email_contexts) == 1
 
     def test_customer_footer_shows_risk_flag(
         self, formatter: SlackDestinationPlugin
@@ -721,6 +863,64 @@ class TestSlackDestinationPluginDivider:
 
         divider_blocks = [b for b in get_blocks(result) if b["type"] == "divider"]
         assert len(divider_blocks) >= 1
+
+    def test_no_dangling_divider_without_tail_blocks(
+        self, formatter: SlackDestinationPlugin
+    ) -> None:
+        """Test no divider when nothing follows it.
+
+        Sparse events (e.g. a system event with no customer, company,
+        or person data) must not end on a floating rule.
+        """
+        notification = RichNotification(
+            type=NotificationType.INTEGRATION_ERROR,
+            severity=NotificationSeverity.ERROR,
+            headline="Integration Error - Stripe",
+            headline_icon="error",
+            provider="system",
+            provider_display="System",
+            customer=None,
+        )
+        result = formatter.format(notification)
+
+        divider_blocks = [b for b in get_blocks(result) if b["type"] == "divider"]
+        assert len(divider_blocks) == 0
+
+
+class TestSlackDestinationPluginFallbackText:
+    """Test the top-level fallback text used for notification previews."""
+
+    def test_fallback_text_present(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test the payload carries a top-level text fallback."""
+        result = formatter.format(basic_notification)
+
+        assert "$299.00 from Acme Inc" in result["text"]
+
+    def test_fallback_text_includes_insight(
+        self,
+        formatter: SlackDestinationPlugin,
+        notification_with_insight: RichNotification,
+    ) -> None:
+        """Test the fallback text carries the insight when present."""
+        result = formatter.format(notification_with_insight)
+
+        assert "Crossed $5,000 lifetime!" in result["text"]
+
+    def test_fallback_text_sanitized(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test Slack injection in payload-derived text is neutralized.
+
+        Headlines and insights can embed payload data (plan names,
+        failure reasons), so the fallback must never carry raw Slack
+        special syntax like broadcast mentions.
+        """
+        basic_notification.headline = "Upgraded to <!channel> plan"
+        result = formatter.format(basic_notification)
+
+        assert "<!channel>" not in result["text"]
 
 
 class TestSlackDestinationPluginEcommerceDetails:

--- a/tests/test_slack_utils.py
+++ b/tests/test_slack_utils.py
@@ -568,6 +568,11 @@ class TestSafeMrkdwnLink:
         """Test javascript: URLs are rejected."""
         assert safe_mrkdwn_link("javascript:alert(1)", "Label") is None
 
+    def test_rejects_missing_host(self) -> None:
+        """Test scheme-only URLs with no host are rejected."""
+        assert safe_mrkdwn_link("https://", "Label") is None
+        assert safe_mrkdwn_link("https:///path-only", "Label") is None
+
     def test_rejects_pipe_in_url(self) -> None:
         """Test a pipe in the URL cannot break the link syntax."""
         assert safe_mrkdwn_link("https://evil.example/|phish", "Label") is None

--- a/tests/test_slack_utils.py
+++ b/tests/test_slack_utils.py
@@ -10,6 +10,7 @@ from plugins.destinations.slack_utils import (
     _sanitize_slack_injection,
     _sanitize_url,
     html_to_slack_mrkdwn,
+    safe_mrkdwn_link,
 )
 
 
@@ -545,3 +546,46 @@ class TestCleanControlCharacters:
     def test_remove_delete_character(self) -> None:
         """Test DEL character (0x7f) is removed."""
         assert _clean_control_characters("a\x7fb") == "ab"
+
+
+class TestSafeMrkdwnLink:
+    """Test safe_mrkdwn_link for untrusted URLs."""
+
+    def test_valid_https_url(self) -> None:
+        """Test a clean https URL builds a link."""
+        result = safe_mrkdwn_link("https://example.com/profile", "Profile")
+        assert result == "<https://example.com/profile|Profile>"
+
+    def test_none_url(self) -> None:
+        """Test None URL returns None."""
+        assert safe_mrkdwn_link(None, "Label") is None
+
+    def test_empty_url(self) -> None:
+        """Test empty URL returns None."""
+        assert safe_mrkdwn_link("", "Label") is None
+
+    def test_rejects_non_http_scheme(self) -> None:
+        """Test javascript: URLs are rejected."""
+        assert safe_mrkdwn_link("javascript:alert(1)", "Label") is None
+
+    def test_rejects_pipe_in_url(self) -> None:
+        """Test a pipe in the URL cannot break the link syntax."""
+        assert safe_mrkdwn_link("https://evil.example/|phish", "Label") is None
+
+    def test_rejects_angle_brackets_in_url(self) -> None:
+        """Test angle brackets in the URL cannot close the link early."""
+        assert safe_mrkdwn_link("https://evil.example/><!channel", "Label") is None
+
+    def test_rejects_interior_whitespace(self) -> None:
+        """Test interior whitespace in the URL is rejected."""
+        assert safe_mrkdwn_link("https://evil.example/a b", "Label") is None
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        """Test surrounding whitespace is normalized, not rejected."""
+        result = safe_mrkdwn_link("  https://example.com  ", "Site")
+        assert result == "<https://example.com|Site>"
+
+    def test_escapes_pipe_in_label(self) -> None:
+        """Test a pipe in the label cannot break the link syntax."""
+        result = safe_mrkdwn_link("https://example.com", "a|b")
+        assert result == "<https://example.com|a-b>"


### PR DESCRIPTION
## Summary

Implements all nine findings from a design review of the Slack notifications ([before/after mockups](https://claude.ai/code/artifact/15792e7d-374b-4a5a-b9e8-23f5ef51f40b)). Every change reuses data `RichNotification` already carries — no model or parser changes.

### Functional fixes
- **Fallback text**: the payload was only `attachments[].blocks`, so every mobile push, desktop banner, and sidebar preview showed a generic "sent a message" line. `format()` now emits a top-level `text` (headline + insight), run through `safe_mrkdwn()` so payload-derived strings can't smuggle mentions into notifications.
- **Dangling divider**: the divider was appended unconditionally, so sparse events (e.g. `integration_error` with no customer) ended on a floating rule. It now renders only when company/person/customer blocks follow.
- **Failure CTA hierarchy**: on `payment_failure` the green primary button was "View in Stripe" while "Contact Customer" was unstyled. Contact is now primary and first; the dashboard link is secondary.

### Layout & noise
- **Insights promoted**: milestones/failure-retry lines were 12px muted context text; they're now a full-size section block directly under the header (and sanitized — insight text can carry raw failure reasons).
- **Payment details as a fields grid**: the "Payment Details" stacked list becomes a two-column Block Kit `fields` grid. When the headline already shows the amount (e.g. "$299.00 received") the grid surfaces only ARR; amount-less headlines ("New subscription!") keep the full amount-with-ARR field so the money is never lost. If every field would repeat the headline, the block is skipped.
- **Emoji cleanup**: provider badge, company section, and link rows are emoji-free — fixes 💳 appearing twice in one line meaning two different things, and 👤 twice per message. The headline severity emoji stays the only icon above the fold.
- **Person/customer merge**: with Hunter.io enrichment, name and job title share one line, the customer facts line (email · tenure · LTV · flags) folds in beneath, then social links. The standalone footer renders only when there's no person section. No data dropped.
- **Description truncation**: Brandfetch descriptions (previously up to 2,000 chars) are cut at 160 at a word boundary, without breaking `<url|label>` links — this also keeps the action buttons out of Slack's "Show more" collapse.
- **Website inline**: the company domain is linked next to the company name; the "Website" button is gone — buttons are reserved for actions.

## Test plan

- [x] `uv run pytest` — 1802 passed (rebased on current master)
- [x] `uv run mypy app/` — clean
- [x] `uv run ruff check` / `ruff format` — clean
- Updated assertions that pinned old behavior (insight-as-context, link emoji, untruncated descriptions, Website button) and added coverage for fallback text presence/insight/sanitization, divider skipping, both amount-in-headline cases, grid fields, failure-reason placement, merged person block, and failure button order/styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)