### PR TITLE
Server-side GA4 analytics via Measurement Protocol

### DIFF
--- a/app/core/admin.py
+++ b/app/core/admin.py
@@ -9,15 +9,47 @@ from typing import TYPE_CHECKING
 
 from django.contrib import admin, messages
 from django.contrib.admin import helpers
+from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.contrib.auth.models import User
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.html import format_html
 
+from . import analytics
 from .models import Company
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
     from django.http import HttpRequest
+
+
+admin.site.unregister(User)
+
+
+@admin.register(User)
+class UserAdmin(DjangoUserAdmin):
+    """Stock user admin plus the pseudonymous GA4 user id.
+
+    GA4 only ever receives the salted hash (never the pk or email), so
+    this column is the one place a GA4 ``user_id`` can be mapped back
+    to an account: copy the id from a GA4 report and search for it on
+    this page with the browser's find-in-page.
+    """
+
+    # mypy: Django declares these as per-instance generics, so extending
+    # them via the class is flagged as ambiguous; it's the documented way
+    # to extend a ModelAdmin.
+    list_display = (*DjangoUserAdmin.list_display, "ga4_user_id")  # type: ignore[misc]
+    readonly_fields = (*DjangoUserAdmin.readonly_fields, "ga4_user_id")  # type: ignore[misc]
+    fieldsets = (
+        *(DjangoUserAdmin.fieldsets or ()),
+        ("Analytics", {"fields": ("ga4_user_id",)}),
+    )
+
+    @admin.display(description="GA4 user ID")
+    def ga4_user_id(self, obj: User) -> str:
+        """Return the GA4 user_id hash this user appears as in reports."""
+        return analytics.hashed_user_id(obj)
 
 
 @admin.register(Company)

--- a/app/core/admin.py
+++ b/app/core/admin.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from django.contrib import admin, messages
 from django.contrib.admin import helpers
+from django.contrib.admin.exceptions import NotRegistered
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.contrib.auth.models import User
 from django.template.response import TemplateResponse
@@ -23,7 +24,12 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
 
 
-admin.site.unregister(User)
+try:
+    admin.site.unregister(User)
+except NotRegistered:
+    # Import order or another app may already have unregistered it;
+    # re-registering below is all that matters.
+    pass
 
 
 @admin.register(User)

--- a/app/core/analytics.py
+++ b/app/core/analytics.py
@@ -42,6 +42,7 @@ import hmac
 import logging
 import re
 import secrets
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -113,6 +114,12 @@ _BOT_UA_MARKERS = (
 _EXCLUDED_PATH_PREFIXES = ("/admin/", "/static/", "/webhook/")
 
 _executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="ga4")
+
+# Backpressure for the fire-and-forget queue: at most this many
+# payloads may be queued or in flight; beyond it, events are dropped.
+_MAX_PENDING_DELIVERIES = 1000
+_pending_deliveries = 0
+_pending_lock = threading.Lock()
 
 
 def is_configured() -> bool:
@@ -250,9 +257,32 @@ def _post(payload: dict[str, Any]) -> None:
         logger.warning(f"GA4 event delivery failed: {e!s}")
 
 
+def _release_pending_slot(_future: Any) -> None:
+    """Free a delivery slot once a payload finishes (done callback)."""
+    global _pending_deliveries
+    with _pending_lock:
+        _pending_deliveries -= 1
+
+
 def _submit(payload: dict[str, Any]) -> None:
-    """Queue a payload for asynchronous delivery."""
-    _executor.submit(_post, payload)
+    """Queue a payload for asynchronous delivery.
+
+    Bounded: when GA4 is slow or unreachable and the backlog reaches
+    ``_MAX_PENDING_DELIVERIES``, new events are dropped with a warning
+    instead of queueing without limit — losing analytics beats memory
+    pressure from an ever-growing work queue under sustained traffic.
+    """
+    global _pending_deliveries
+    with _pending_lock:
+        if _pending_deliveries >= _MAX_PENDING_DELIVERIES:
+            logger.warning("GA4 event dropped: delivery backlog full")
+            return
+        _pending_deliveries += 1
+    try:
+        _executor.submit(_post, payload).add_done_callback(_release_pending_slot)
+    except RuntimeError:
+        # Interpreter shutdown; the slot leaks but nothing runs anymore.
+        pass
 
 
 def hashed_user_id(user: Any) -> str:
@@ -275,9 +305,17 @@ def hashed_user_id(user: Any) -> str:
 
 
 def _redact_pii(value: Any) -> Any:
-    """Redact email-shaped substrings from a string param value."""
+    """Redact email-shaped substrings anywhere in a param value.
+
+    Recurses into dicts/lists/tuples so nested structures (e.g. the
+    ecommerce ``items`` list) get the same guarantee as flat strings.
+    """
     if isinstance(value, str):
         return _EMAIL_RE.sub("[redacted]", value)
+    if isinstance(value, dict):
+        return {key: _redact_pii(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redact_pii(item) for item in value]
     return value
 
 

--- a/app/core/analytics.py
+++ b/app/core/analytics.py
@@ -1,0 +1,451 @@
+"""Server-side Google Analytics 4 tracking via the Measurement Protocol.
+
+All analytics events are sent from the server, never from browser
+JavaScript: webhook-driven events (plan changes from Stripe) have no
+browser to send from, server-side events can't be dropped by ad
+blockers, and no third-party script runs on users' pages.
+
+Requires two settings (both empty disables tracking entirely):
+
+- ``GA4_MEASUREMENT_ID`` (``GA4_ID`` env var): the ``G-XXXXXXX`` id of
+  the GA4 web data stream.
+- ``GA4_API_SECRET`` (``GA4_API_SECRET`` env var): a Measurement
+  Protocol API secret created under Admin -> Data Streams -> stream ->
+  Measurement Protocol API secrets.
+
+Identity model: anonymous visitors get a first-party ``np_ga_cid``
+cookie holding a GA-style client id (minted by :class:`GA4Middleware`);
+if a ``_ga`` cookie from gtag.js ever exists it wins, so a client-side
+snippet can be added later and sessions will stitch together. Logged-in
+users additionally send ``user_id``. Events with no request context
+(Stripe webhooks) use the workspace UUID as a stable client id via
+:func:`track_workspace_event`.
+
+PII policy: nothing personally identifying is ever sent to Google.
+``user_id`` is a salted HMAC of the user's pk (``GA4_USER_ID_SALT``,
+falling back to ``SECRET_KEY`` — set the dedicated salt in production
+so key rotation doesn't reset user continuity), page locations are
+stripped to path + whitelisted campaign params so tokens and emails in
+query strings never leak, referrers are reduced to their origin, and
+any email-shaped string in event params is redacted as a last line of
+defense.
+
+Delivery is fire-and-forget on a small thread pool so a slow or down
+Google endpoint can never block a request or a webhook handler. Note
+the Measurement Protocol returns 2xx even for payloads it discards;
+use GA4's realtime report or the /debug/mp/collect endpoint when
+diagnosing missing events.
+"""
+
+import hashlib
+import hmac
+import logging
+import re
+import secrets
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import requests
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+
+logger = logging.getLogger(__name__)
+
+GA4_ENDPOINT = "https://www.google-analytics.com/mp/collect"
+
+# First-party cookie carrying the GA4 client id for visitors without a
+# gtag.js ``_ga`` cookie. HttpOnly: no JavaScript ever needs to read it.
+CLIENT_ID_COOKIE = "np_ga_cid"
+CLIENT_ID_COOKIE_MAX_AGE = 60 * 60 * 24 * 730  # 2 years, matching _ga
+
+# Django session key holding the GA4 session id (epoch seconds at first
+# tracked request — GA4's own session id convention).
+SESSION_KEY = "ga4_session_id"
+
+# Request attributes used to pass state between middleware, views and
+# signal receivers without mypy-visible monkeypatching.
+_CLIENT_ID_ATTR = "_ga4_client_id"
+_LOGIN_METHOD_ATTR = "_ga4_login_method"
+
+_REQUEST_TIMEOUT_SECONDS = 5
+
+# GA-style client id: two dot-separated integers.
+_CLIENT_ID_RE = re.compile(r"^[0-9]{1,20}\.[0-9]{1,20}$")
+
+# Loose email shape, used to redact PII that sneaks into param values.
+_EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+
+# Query params worth keeping on page_location: campaign attribution
+# only. Everything else (invitation tokens, Stripe session ids, email
+# prefills) is dropped before the URL leaves our infrastructure.
+_ALLOWED_QUERY_PARAMS = frozenset(
+    {
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+        "gclid",
+    }
+)
+
+# Substring markers of user agents that must not count as active users.
+# The Measurement Protocol has no bot filtering of its own (gtag relies
+# on browser signals we don't have), so this coarse filter is all that
+# keeps crawlers out of the page_view numbers.
+_BOT_UA_MARKERS = (
+    "bot",
+    "crawl",
+    "spider",
+    "slurp",
+    "curl",
+    "wget",
+    "python-requests",
+    "headless",
+    "monitor",
+    "pingdom",
+    "lighthouse",
+)
+
+# Path prefixes never tracked as page views: machine traffic, not users.
+_EXCLUDED_PATH_PREFIXES = ("/admin/", "/static/", "/webhook/")
+
+_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="ga4")
+
+
+def is_configured() -> bool:
+    """Return whether GA4 tracking is enabled.
+
+    Returns:
+        True when both the measurement id and API secret are set.
+    """
+    return bool(settings.GA4_MEASUREMENT_ID and settings.GA4_API_SECRET)
+
+
+def set_login_method(request: HttpRequest, method: str) -> None:
+    """Record which auth flow is logging the user in.
+
+    Custom login flows (Slack OIDC, passkeys) call this right before
+    ``django.contrib.auth.login`` so the ``user_logged_in`` signal
+    receiver can label the ``login`` event with the real method.
+
+    Args:
+        request: The current HTTP request.
+        method: Auth method label, e.g. ``"slack"`` or ``"passkey"``.
+    """
+    setattr(request, _LOGIN_METHOD_ATTR, method)
+
+
+def get_login_method(request: HttpRequest, default: str = "email") -> str:
+    """Return the auth method recorded by :func:`set_login_method`.
+
+    Args:
+        request: The current HTTP request.
+        default: Label to use when no flow recorded a method.
+
+    Returns:
+        The auth method label for the ``login`` event.
+    """
+    return getattr(request, _LOGIN_METHOD_ATTR, default)
+
+
+def _new_client_id() -> str:
+    """Mint a GA-style client id (``<random>.<epoch seconds>``)."""
+    return f"{secrets.randbelow(2**31)}.{int(time.time())}"
+
+
+def _client_id_from_cookies(cookies: dict[str, str]) -> str | None:
+    """Extract a GA4 client id from request cookies.
+
+    Prefers gtag.js's ``_ga`` cookie (``GA1.1.<random>.<epoch>``) so
+    server events stitch into client-side sessions if a snippet is ever
+    added, then falls back to our first-party cookie.
+
+    Args:
+        cookies: The request's cookie dict.
+
+    Returns:
+        The client id, or None when no usable cookie exists.
+    """
+    ga_cookie = cookies.get("_ga", "")
+    parts = ga_cookie.split(".")
+    if len(parts) >= 4:
+        candidate = ".".join(parts[-2:])
+        if _CLIENT_ID_RE.match(candidate):
+            return candidate
+
+    own = cookies.get(CLIENT_ID_COOKIE, "")
+    if _CLIENT_ID_RE.match(own):
+        return own
+    return None
+
+
+def _client_id_for_request(request: HttpRequest) -> str:
+    """Resolve (or mint) the GA4 client id for this request.
+
+    The resolved id is cached on the request so every event in the
+    request lifecycle — including a cookie-setting first visit — uses
+    the same id.
+
+    Args:
+        request: The current HTTP request.
+
+    Returns:
+        The GA4 client id.
+    """
+    cached = getattr(request, _CLIENT_ID_ATTR, None)
+    if cached:
+        return str(cached)
+
+    client_id = _client_id_from_cookies(request.COOKIES) or _new_client_id()
+    setattr(request, _CLIENT_ID_ATTR, client_id)
+    return client_id
+
+
+def _session_id_for_request(request: HttpRequest) -> str | None:
+    """Return the GA4 session id, creating one in the Django session.
+
+    Deliberately touches the session for anonymous visitors too:
+    without a session id GA4 cannot compute sessions or engagement for
+    the pre-signup half of the funnel, which is the part worth
+    measuring. The bot filter in the middleware keeps crawler traffic
+    from churning session storage.
+
+    Args:
+        request: The current HTTP request.
+
+    Returns:
+        Epoch-seconds session id, or None when the request has no
+        session (e.g. error handlers before middleware ran).
+    """
+    session = getattr(request, "session", None)
+    if session is None:
+        return None
+
+    session_id = session.get(SESSION_KEY)
+    if not session_id:
+        session_id = str(int(time.time()))
+        session[SESSION_KEY] = session_id
+    return str(session_id)
+
+
+def _post(payload: dict[str, Any]) -> None:
+    """Deliver one Measurement Protocol payload (runs on the pool)."""
+    try:
+        response = requests.post(
+            GA4_ENDPOINT,
+            params={
+                "measurement_id": settings.GA4_MEASUREMENT_ID,
+                "api_secret": settings.GA4_API_SECRET,
+            },
+            json=payload,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+        if response.status_code >= 300:
+            logger.warning(f"GA4 Measurement Protocol returned {response.status_code}")
+    except requests.RequestException as e:
+        # Analytics is never worth an error page or a webhook retry.
+        logger.warning(f"GA4 event delivery failed: {e!s}")
+
+
+def _submit(payload: dict[str, Any]) -> None:
+    """Queue a payload for asynchronous delivery."""
+    _executor.submit(_post, payload)
+
+
+def hashed_user_id(user: Any) -> str:
+    """Return the pseudonymous GA4 user id for a Django user.
+
+    A salted HMAC of the pk rather than a bare pk or an email hash:
+    it stays stable when the user changes their email, and cannot be
+    reversed or joined against other datasets without the salt. Also
+    shown in the Django admin user list so a GA4 user_id can be mapped
+    back to the account when needed.
+
+    Args:
+        user: An authenticated Django user.
+
+    Returns:
+        Hex digest to use as the GA4 ``user_id``.
+    """
+    salt = settings.GA4_USER_ID_SALT or settings.SECRET_KEY
+    return hmac.new(salt.encode(), str(user.pk).encode(), hashlib.sha256).hexdigest()
+
+
+def _redact_pii(value: Any) -> Any:
+    """Redact email-shaped substrings from a string param value."""
+    if isinstance(value, str):
+        return _EMAIL_RE.sub("[redacted]", value)
+    return value
+
+
+def sanitize_page_location(url: str) -> str:
+    """Strip a URL down to what analytics may see.
+
+    Keeps scheme, host and path; drops every query param except
+    campaign attribution and the fragment entirely. Invitation tokens,
+    Stripe session ids and prefilled emails all travel in query
+    strings, and none of them belong in Google's logs.
+
+    Args:
+        url: The full request URL.
+
+    Returns:
+        The sanitized URL.
+    """
+    parts = urlsplit(url)
+    kept = [
+        (key, value)
+        for key, value in parse_qsl(parts.query, keep_blank_values=True)
+        if key in _ALLOWED_QUERY_PARAMS
+    ]
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(kept), ""))
+
+
+def _build_event_params(
+    params: dict[str, Any] | None, session_id: str | None
+) -> dict[str, Any]:
+    """Assemble event params with the fields GA4 needs for reporting.
+
+    ``engagement_time_msec`` is what makes Measurement Protocol events
+    count toward active users; ``session_id`` is what groups them into
+    sessions. String values are scrubbed of email-shaped substrings as
+    a final PII guard.
+    """
+    event_params: dict[str, Any] = {"engagement_time_msec": 100}
+    if params:
+        event_params.update({k: _redact_pii(v) for k, v in params.items()})
+    if session_id:
+        event_params.setdefault("session_id", session_id)
+    return event_params
+
+
+def track_event(
+    request: HttpRequest, name: str, params: dict[str, Any] | None = None
+) -> None:
+    """Send a GA4 event attributed to the request's visitor.
+
+    Fire-and-forget: never raises, no-op when GA4 is not configured.
+
+    Args:
+        request: The current HTTP request (supplies client id, session
+            id and, for authenticated users, user id).
+        name: GA4 event name (recommended names like ``sign_up`` where
+            one exists, snake_case custom names otherwise).
+        params: Optional event parameters.
+    """
+    if not is_configured():
+        return
+
+    payload: dict[str, Any] = {
+        "client_id": _client_id_for_request(request),
+        "events": [
+            {
+                "name": name,
+                "params": _build_event_params(params, _session_id_for_request(request)),
+            }
+        ],
+    }
+
+    user = getattr(request, "user", None)
+    if user is not None and user.is_authenticated:
+        payload["user_id"] = hashed_user_id(user)
+
+    _submit(payload)
+
+
+def track_workspace_event(
+    workspace: Any, name: str, params: dict[str, Any] | None = None
+) -> None:
+    """Send a GA4 event with no browser context (webhook handlers).
+
+    Uses the workspace UUID as a stable client id so all server-driven
+    billing events for a workspace correlate, even though they can't be
+    stitched to a specific member's browsing session.
+
+    Args:
+        workspace: The Workspace the event belongs to.
+        name: GA4 event name.
+        params: Optional event parameters.
+    """
+    if not is_configured():
+        return
+
+    _submit(
+        {
+            "client_id": str(workspace.uuid),
+            "events": [{"name": name, "params": _build_event_params(params, None)}],
+        }
+    )
+
+
+def _is_bot(request: HttpRequest) -> bool:
+    """Return whether the request's user agent looks like a bot."""
+    user_agent = request.META.get("HTTP_USER_AGENT", "").lower()
+    if not user_agent:
+        # No UA at all is never a real browser.
+        return True
+    return any(marker in user_agent for marker in _BOT_UA_MARKERS)
+
+
+class GA4Middleware:
+    """Mints the client-id cookie and tracks page views server-side.
+
+    Must sit after session/auth middleware in ``MIDDLEWARE`` so events
+    can read ``request.session`` and ``request.user``.
+    """
+
+    def __init__(self, get_response: Any) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        if not is_configured():
+            response: HttpResponse = self.get_response(request)
+            return response
+
+        had_cookie = CLIENT_ID_COOKIE in request.COOKIES
+        client_id = _client_id_for_request(request)
+
+        response = self.get_response(request)
+
+        if not had_cookie:
+            response.set_cookie(
+                CLIENT_ID_COOKIE,
+                client_id,
+                max_age=CLIENT_ID_COOKIE_MAX_AGE,
+                secure=request.is_secure(),
+                httponly=True,
+                samesite="Lax",
+            )
+
+        if self._should_track_page_view(request, response):
+            params: dict[str, Any] = {
+                "page_location": sanitize_page_location(request.build_absolute_uri())
+            }
+            referrer = request.META.get("HTTP_REFERER")
+            if referrer:
+                # Origin only: referrer paths/queries can carry tokens.
+                referrer_parts = urlsplit(referrer)
+                if referrer_parts.scheme and referrer_parts.netloc:
+                    params["page_referrer"] = (
+                        f"{referrer_parts.scheme}://{referrer_parts.netloc}/"
+                    )
+            track_event(request, "page_view", params)
+
+        return response
+
+    @staticmethod
+    def _should_track_page_view(request: HttpRequest, response: HttpResponse) -> bool:
+        """Return whether this request/response pair is a real page view."""
+        if request.method != "GET":
+            return False
+        if not 200 <= response.status_code < 300:
+            return False
+        content_type = response.get("Content-Type", "")
+        if not content_type.startswith("text/html"):
+            return False
+        if request.path.startswith(_EXCLUDED_PATH_PREFIXES):
+            return False
+        return not _is_bot(request)

--- a/app/core/analytics.py
+++ b/app/core/analytics.py
@@ -448,7 +448,12 @@ class GA4Middleware:
 
         response = self.get_response(request)
 
-        if not had_cookie:
+        track_page_view = self._should_track_page_view(request, response)
+
+        # Only mint the cookie for responses that are actually tracked:
+        # Set-Cookie on excluded paths (static assets, webhooks) breaks
+        # response caching, and bot traffic never becomes a page view.
+        if not had_cookie and track_page_view:
             response.set_cookie(
                 CLIENT_ID_COOKIE,
                 client_id,
@@ -458,7 +463,7 @@ class GA4Middleware:
                 samesite="Lax",
             )
 
-        if self._should_track_page_view(request, response):
+        if track_page_view:
             params: dict[str, Any] = {
                 "page_location": sanitize_page_location(request.build_absolute_uri())
             }

--- a/app/core/signals.py
+++ b/app/core/signals.py
@@ -1,6 +1,9 @@
+from allauth.account.signals import user_signed_up
+from django.contrib.auth.signals import user_logged_in
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from . import analytics
 from .models import (
     NotificationSettings,
     Workspace,
@@ -12,3 +15,30 @@ def create_workspace_notification_settings(sender, instance, created, **kwargs):
     """Create notification settings when a new workspace is created."""
     if created:
         NotificationSettings.objects.create(workspace=instance)
+
+
+@receiver(user_signed_up)
+def track_sign_up(request, user, **kwargs):
+    """Send a GA4 sign_up event for allauth signups (email and social).
+
+    Custom flows that bypass allauth (Slack OIDC, passkeys) track their
+    own sign_up events at the point where they create the user.
+    """
+    sociallogin = kwargs.get("sociallogin")
+    method = sociallogin.account.provider if sociallogin else "email"
+    analytics.track_event(request, "sign_up", {"method": method})
+
+
+@receiver(user_logged_in)
+def track_login(sender, request, user, **kwargs):
+    """Send a GA4 login event for every authentication flow.
+
+    Django's user_logged_in signal fires for all flows (allauth, Slack
+    OIDC, passkeys); custom flows label themselves via
+    analytics.set_login_method before calling login().
+    """
+    if request is None:
+        return
+    analytics.track_event(
+        request, "login", {"method": analytics.get_login_method(request)}
+    )

--- a/app/core/signals.py
+++ b/app/core/signals.py
@@ -1,7 +1,11 @@
+from typing import Any
+
 from allauth.account.signals import user_signed_up
+from django.contrib.auth.models import User
 from django.contrib.auth.signals import user_logged_in
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.http import HttpRequest
 
 from . import analytics
 from .models import (
@@ -18,7 +22,7 @@ def create_workspace_notification_settings(sender, instance, created, **kwargs):
 
 
 @receiver(user_signed_up)
-def track_sign_up(request, user, **kwargs):
+def track_sign_up(request: HttpRequest, user: User, **kwargs: Any) -> None:
     """Send a GA4 sign_up event for allauth signups (email and social).
 
     Custom flows that bypass allauth (Slack OIDC, passkeys) track their
@@ -30,7 +34,9 @@ def track_sign_up(request, user, **kwargs):
 
 
 @receiver(user_logged_in)
-def track_login(sender, request, user, **kwargs):
+def track_login(
+    sender: Any, request: HttpRequest | None, user: User, **kwargs: Any
+) -> None:
     """Send a GA4 login event for every authentication flow.
 
     Django's user_logged_in signal fires for all flows (allauth, Slack

--- a/app/core/urls.py
+++ b/app/core/urls.py
@@ -20,9 +20,12 @@ urlpatterns = [
     path("billing/upgrade/", views.upgrade_plan, name="upgrade_plan"),
     path("billing/payment-methods/", views.payment_methods, name="payment_methods"),
     path("billing/history/", views.billing_history, name="billing_history"),
-    path("billing/checkout/<str:plan_name>/", views.checkout, name="checkout"),
+    # success/cancel must precede the <plan_name> route: Django takes the
+    # first match, so the other order routes Stripe's success/cancel
+    # redirects into checkout() with plan_name="success"/"cancel".
     path("billing/checkout/success/", views.checkout_success, name="checkout_success"),
     path("billing/checkout/cancel/", views.checkout_cancel, name="checkout_cancel"),
+    path("billing/checkout/<str:plan_name>/", views.checkout, name="checkout"),
     # Workspace management
     path("workspace/create/", views.create_workspace, name="create_workspace"),
     path("workspace/settings/", views.workspace_settings, name="workspace_settings"),

--- a/app/core/views/auth.py
+++ b/app/core/views/auth.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 
+from .. import analytics
 from ..models import UserProfile
 
 logger = logging.getLogger(__name__)
@@ -190,15 +191,18 @@ def slack_auth_callback(request: HttpRequest) -> HttpResponse | HttpResponseRedi
         logger.warning(f"Slack login rejected: email not verified (sub={slack_id})")
         return HttpResponse("Email address is not verified", status=400)
 
-    user = _resolve_user(slack_id, email, name)
+    user, created = _resolve_user(slack_id, email, name)
 
     # Log the user in
+    analytics.set_login_method(request, "slack")
     login(request, user)
+    if created:
+        analytics.track_event(request, "sign_up", {"method": "slack"})
 
     return redirect("core:dashboard")
 
 
-def _resolve_user(slack_id: str, email: str, name: str) -> User:
+def _resolve_user(slack_id: str, email: str, name: str) -> tuple[User, bool]:
     """Find or create the user and reconcile their Slack profile link.
 
     Args:
@@ -207,7 +211,7 @@ def _resolve_user(slack_id: str, email: str, name: str) -> User:
         name: The user's display name.
 
     Returns:
-        The resolved Django user.
+        Tuple of (resolved Django user, whether the user was created).
     """
     # Find or create user
     user, created = User.objects.get_or_create(
@@ -236,4 +240,4 @@ def _resolve_user(slack_id: str, email: str, name: str) -> User:
             # No profile exists - this is handled later when joining a team
             pass
 
-    return user
+    return user, created

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -15,6 +15,7 @@ from django.shortcuts import redirect, render
 from django.utils import timezone
 from webhooks.services.rate_limiter import rate_limiter
 
+from .. import analytics
 from ..models import Plan
 from ..permissions import get_workspace_for_user
 from .integrations.base import require_admin_role
@@ -41,6 +42,7 @@ def select_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
         # Validate against available plans
         if Plan.objects.filter(name=selected_plan, is_active=True).exists():
             request.session["selected_plan"] = selected_plan
+            analytics.track_event(request, "select_plan", {"plan": selected_plan})
             return redirect("core:plan_selected")
 
     # Get plans from database
@@ -440,6 +442,17 @@ def checkout(
             )
             return redirect("core:upgrade_plan")
 
+        analytics.track_event(
+            request,
+            "begin_checkout",
+            {
+                "plan": plan.name,
+                "currency": "USD",
+                "value": float(plan.price_monthly),
+                "items": [{"item_id": plan.name, "item_name": plan.display_name}],
+            },
+        )
+
         # Redirect to Stripe Checkout
         return redirect(checkout_session["url"])
 
@@ -545,6 +558,25 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
         messages.info(request, "Your subscription has been updated successfully.")
         return redirect("core:billing_dashboard")
 
+    # Track the conversion once per checkout session: Stripe redirects
+    # land here with a reusable URL, so a page refresh must not double
+    # count revenue. transaction_id also lets GA4 dedupe on its side.
+    purchase_tracked_key = f"ga4_purchase_{session_id}"
+    if not request.session.get(purchase_tracked_key):
+        request.session[purchase_tracked_key] = True
+        plan = Plan.objects.filter(name=plan_name, is_active=True).first()
+        analytics.track_event(
+            request,
+            "purchase",
+            {
+                "plan": plan_name,
+                "transaction_id": session_id,
+                "currency": "USD",
+                "value": float(plan.price_monthly) if plan else 0.0,
+                "items": [{"item_id": plan_name}],
+            },
+        )
+
     context: dict[str, Any] = {
         "plan_name": plan_name,
     }
@@ -561,4 +593,5 @@ def checkout_cancel(request: HttpRequest) -> HttpResponse:
     Returns:
         Checkout cancel page.
     """
+    analytics.track_event(request, "checkout_cancelled")
     return render(request, "core/checkout_cancel.html.j2")

--- a/app/core/views/dashboard.py
+++ b/app/core/views/dashboard.py
@@ -11,6 +11,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect, render
 
+from .. import analytics
 from ..models import UserProfile, Workspace, WorkspaceMember
 from .integrations.base import require_admin_role
 
@@ -163,12 +164,17 @@ def create_workspace(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
             if "selected_plan" in request.session:
                 del request.session["selected_plan"]
 
+            analytics.track_event(request, "workspace_created", {"plan": selected_plan})
+
             # For paid plans, redirect to Stripe checkout with trial period
             if selected_plan != "free":
                 checkout_url = _create_stripe_checkout_for_plan(
                     workspace, selected_plan
                 )
                 if checkout_url:
+                    analytics.track_event(
+                        request, "begin_checkout", {"plan": selected_plan}
+                    )
                     return redirect(checkout_url)
                 # Checkout creation failed - workspace is in trial status so user can
                 # still use the app; they can set up billing later from billing page

--- a/app/core/views/webauthn.py
+++ b/app/core/views/webauthn.py
@@ -15,6 +15,7 @@ from django.http import HttpRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
+from .. import analytics
 from ..models import WebAuthnCredential
 from ..services.webauthn import WebAuthnService
 
@@ -145,6 +146,7 @@ def webauthn_authenticate_complete(request: HttpRequest) -> JsonResponse:
 
         if user:
             # Log the user in
+            analytics.set_login_method(request, "passkey")
             login(request, user, backend=PASSKEY_LOGIN_BACKEND)
             return JsonResponse(
                 {
@@ -272,7 +274,9 @@ def webauthn_signup_complete(request: HttpRequest) -> JsonResponse:
 
         if user:
             # Log the user in
+            analytics.set_login_method(request, "passkey")
             login(request, user, backend=PASSKEY_LOGIN_BACKEND)
+            analytics.track_event(request, "sign_up", {"method": "passkey"})
 
             # Passkey signups are the one flow that needs outgoing email:
             # unlike Slack SSO (whose emails are provider-verified), a

--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -325,6 +325,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    # After session/auth middleware: GA4 events read request.session/user
+    "core.analytics.GA4Middleware",
 ]
 
 ROOT_URLCONF = "django_notipus.urls"
@@ -683,6 +685,18 @@ SLACK_CONNECT_REDIRECT_URI = os.environ.get("SLACK_CONNECT_REDIRECT_URI", "")
 SLACK_CLIENT_BOT_ID = os.environ.get("SLACK_CLIENT_BOT_ID", "")
 SLACK_CLIENT_BOT_SECRET = os.environ.get("SLACK_CLIENT_BOT_SECRET", "")
 SLACK_REDIRECT_BOT_URI = os.environ.get("SLACK_REDIRECT_BOT_URI", "")
+
+# Google Analytics 4, server-side via the Measurement Protocol (see
+# core.analytics). Tracking is disabled unless BOTH are set: the
+# Measurement Protocol rejects events without an API secret, which is
+# created in GA4 under Admin -> Data Streams -> stream -> Measurement
+# Protocol API secrets.
+GA4_MEASUREMENT_ID = os.environ.get("GA4_ID", "")
+GA4_API_SECRET = os.environ.get("GA4_API_SECRET", "")
+# Salt for the pseudonymous GA4 user_id (HMAC of the user pk). Falls
+# back to SECRET_KEY when unset; set it explicitly in production so a
+# SECRET_KEY rotation doesn't reset user continuity in GA4.
+GA4_USER_ID_SALT = os.environ.get("GA4_USER_ID_SALT", "")
 
 # Stripe configuration for Notipus billing (our revenue)
 STRIPE_SECRET_KEY = os.environ.get("STRIPE_SECRET_KEY", "sk_test_dev_key")

--- a/app/django_notipus/test_settings.py
+++ b/app/django_notipus/test_settings.py
@@ -17,6 +17,11 @@ MIDDLEWARE = [m for m in MIDDLEWARE if "whitenoise" not in m]
 
 # Override settings for tests
 DISABLE_BILLING = True
+
+# Keep GA4 off in tests regardless of the developer's environment;
+# individual tests opt in via override_settings.
+GA4_MEASUREMENT_ID = ""
+GA4_API_SECRET = ""
 # Note: Webhook secrets now managed per-tenant, not globally
 
 

--- a/app/webhooks/services/billing.py
+++ b/app/webhooks/services/billing.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from typing import Any, cast
 
 import stripe
+from core import analytics
 from core.models import Workspace
 from core.services.stripe import StripeAPI
 from django.db.models import Q
@@ -344,6 +345,18 @@ class BillingService:
 
         Workspace.objects.filter(id=workspace.id).update(**update_data)
 
+        # This sync is the single choke point where the plan actually
+        # changes state, whatever the trigger (checkout, billing portal,
+        # Stripe dashboard, API) — so it's where plan changes get
+        # reported to analytics.
+        previous_plan = workspace.subscription_plan
+        if plan_name and plan_name != previous_plan:
+            analytics.track_workspace_event(
+                workspace,
+                "plan_change",
+                {"previous_plan": previous_plan, "new_plan": plan_name},
+            )
+
         logger.info(
             f"Synced workspace {workspace.name} from Stripe: "
             f"status={internal_status}, plan={plan_name}"
@@ -532,6 +545,11 @@ class BillingService:
 
             Workspace.objects.filter(id=workspace.id).update(
                 subscription_status="cancelled"
+            )
+            analytics.track_workspace_event(
+                workspace,
+                "subscription_cancelled",
+                {"plan": workspace.subscription_plan},
             )
             logger.info(f"Marked subscription as cancelled for customer {customer_id}")
             # Reconcile: if another live subscription exists on Stripe

--- a/tests/test_ga4_analytics.py
+++ b/tests/test_ga4_analytics.py
@@ -6,6 +6,7 @@ page-view middleware, and the SaaS funnel events emitted by views,
 signals, and the Stripe billing sync.
 """
 
+import time
 from typing import Any, Generator
 from unittest.mock import MagicMock, patch
 
@@ -370,3 +371,93 @@ class TestBillingSyncEvents:
             assert BillingService.sync_workspace_from_stripe("cus_42")
 
         assert _events_named(ga4, "plan_change") == []
+
+    def test_subscription_cancelled_tracked_on_deletion(
+        self, ga4: MagicMock, db: None
+    ) -> None:
+        """Cancelling the workspace's subscription sends the event."""
+        from webhooks.services.billing import BillingService
+
+        workspace = Workspace.objects.create(
+            name="Acme",
+            stripe_customer_id="cus_42",
+            subscription_plan="pro",
+            stripe_subscription_id="sub_main",
+        )
+
+        with patch("webhooks.services.billing.StripeAPI") as mock_api_cls:
+            mock_api_cls.return_value.get_customer_subscriptions.return_value = []
+            BillingService.handle_subscription_deleted(
+                {"id": "sub_main", "customer": "cus_42"}
+            )
+
+        workspace.refresh_from_db()
+        assert workspace.subscription_status == "cancelled"
+        (event,) = _events_named(ga4, "subscription_cancelled")
+        assert event["params"]["plan"] == "pro"
+
+    def test_addon_deletion_does_not_track_cancellation(
+        self, ga4: MagicMock, db: None
+    ) -> None:
+        """Deleting a non-primary subscription must not emit the event."""
+        from webhooks.services.billing import BillingService
+
+        Workspace.objects.create(
+            name="Acme",
+            stripe_customer_id="cus_42",
+            subscription_plan="pro",
+            stripe_subscription_id="sub_main",
+        )
+
+        with patch("webhooks.services.billing.StripeAPI") as mock_api_cls:
+            mock_api_cls.return_value.get_customer_subscriptions.return_value = []
+            BillingService.handle_subscription_deleted(
+                {"id": "sub_addon", "customer": "cus_42"}
+            )
+
+        assert _events_named(ga4, "subscription_cancelled") == []
+
+
+class TestDeliveryBackpressure:
+    """The fire-and-forget queue is bounded, never unbounded."""
+
+    def test_events_dropped_when_backlog_full(self) -> None:
+        """At the pending cap, payloads are dropped, not queued."""
+        with override_settings(**GA4_TEST_SETTINGS):
+            with (
+                patch.object(analytics, "_MAX_PENDING_DELIVERIES", 0),
+                patch.object(analytics._executor, "submit") as mock_submit,
+            ):
+                analytics._submit({"client_id": "1.2", "events": []})
+            mock_submit.assert_not_called()
+
+    def test_slot_released_after_delivery(self) -> None:
+        """Completed deliveries free their slot for later events."""
+        with patch.object(analytics, "_post"):
+            baseline = analytics._pending_deliveries
+            analytics._submit({"client_id": "1.2", "events": []})
+            # The done callback runs synchronously once the (mocked)
+            # delivery finishes; poll briefly for the pool thread.
+            for _ in range(50):
+                if analytics._pending_deliveries == baseline:
+                    break
+                time.sleep(0.01)
+            assert analytics._pending_deliveries == baseline
+
+
+class TestNestedRedaction:
+    """PII redaction reaches nested param structures."""
+
+    def test_emails_redacted_inside_items(self) -> None:
+        """Email-shaped strings inside nested dicts/lists are scrubbed."""
+        params = analytics._build_event_params(
+            {
+                "items": [{"item_id": "pro", "note": "bought by user@example.com"}],
+                "meta": {"contact": ["ops@example.com", "plain text"]},
+            },
+            None,
+        )
+        assert "user@example.com" not in str(params)
+        assert "ops@example.com" not in str(params)
+        assert params["items"][0]["item_id"] == "pro"
+        assert params["meta"]["contact"][1] == "plain text"

--- a/tests/test_ga4_analytics.py
+++ b/tests/test_ga4_analytics.py
@@ -178,11 +178,21 @@ class TestMiddleware:
         assert event["params"]["page_location"].endswith(reverse("account_login"))
 
     def test_bot_requests_not_tracked(self, ga4: MagicMock, db: None) -> None:
-        """Crawler user agents never produce page views."""
+        """Crawlers get neither page views nor a client-id cookie."""
         client = Client()
-        client.get(reverse("account_login"), HTTP_USER_AGENT="Googlebot/2.1")
-        client.get(reverse("account_login"))  # no UA at all
+        bot = client.get(reverse("account_login"), HTTP_USER_AGENT="Googlebot/2.1")
+        no_ua = client.get(reverse("account_login"))  # no UA at all
         assert _events_named(ga4, "page_view") == []
+        assert analytics.CLIENT_ID_COOKIE not in bot.cookies
+        assert analytics.CLIENT_ID_COOKIE not in no_ua.cookies
+
+    def test_untracked_responses_get_no_cookie(self, ga4: MagicMock, db: None) -> None:
+        """No Set-Cookie on responses that aren't tracked page views."""
+        client = Client()
+        response = client.post(
+            reverse("account_login"), {}, HTTP_USER_AGENT="Mozilla/5.0"
+        )
+        assert analytics.CLIENT_ID_COOKIE not in response.cookies
 
     def test_should_track_page_view_filters(self) -> None:
         """Non-GET, non-HTML, error and excluded paths are skipped."""

--- a/tests/test_ga4_analytics.py
+++ b/tests/test_ga4_analytics.py
@@ -1,0 +1,372 @@
+"""Tests for server-side GA4 analytics (core.analytics).
+
+Covers the Measurement Protocol payload building, the PII filter
+(hashed user ids, page-location sanitizing, email redaction), the
+page-view middleware, and the SaaS funnel events emitted by views,
+signals, and the Stripe billing sync.
+"""
+
+from typing import Any, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core import analytics
+from core.models import Plan, Workspace, WorkspaceMember
+from django.contrib.auth.models import User
+from django.contrib.auth.signals import user_logged_in
+from django.test import Client, RequestFactory, override_settings
+from django.urls import reverse
+
+GA4_TEST_SETTINGS = {
+    "GA4_MEASUREMENT_ID": "G-TEST123",
+    "GA4_API_SECRET": "test-secret",
+}
+
+
+@pytest.fixture
+def ga4(request: pytest.FixtureRequest) -> Generator[MagicMock, None, None]:
+    """Enable GA4 settings and capture submitted payloads.
+
+    Yields:
+        Mock standing in for analytics._submit; payloads are inspected
+        via ``ga4.call_args_list``.
+    """
+    with override_settings(**GA4_TEST_SETTINGS):
+        with patch.object(analytics, "_submit") as mock_submit:
+            yield mock_submit
+
+
+def _payloads(mock_submit: MagicMock) -> list[dict[str, Any]]:
+    """Return all payloads captured by the ga4 fixture."""
+    return [call.args[0] for call in mock_submit.call_args_list]
+
+
+def _events_named(mock_submit: MagicMock, name: str) -> list[dict[str, Any]]:
+    """Return all captured events with the given GA4 event name."""
+    return [
+        event
+        for payload in _payloads(mock_submit)
+        for event in payload["events"]
+        if event["name"] == name
+    ]
+
+
+@pytest.fixture
+def user(db: None) -> User:
+    """Create a test user."""
+    return User.objects.create_user(
+        username="tracked@example.com",
+        email="tracked@example.com",
+        password="test-password-123",
+    )
+
+
+@pytest.fixture
+def logged_in_client(client: Client, user: User) -> Client:
+    """Return a test client with the test user logged in."""
+    client.force_login(user)
+    return client
+
+
+class TestPiiFilter:
+    """The PII filter: nothing personally identifying reaches Google."""
+
+    def test_hashed_user_id_is_stable_and_not_raw(self, user: User) -> None:
+        """The GA4 user id is a stable hash, never the pk or email."""
+        hashed = analytics.hashed_user_id(user)
+        assert hashed == analytics.hashed_user_id(user)
+        assert len(hashed) == 64
+        assert str(user.pk) != hashed
+        assert user.email not in hashed
+
+    def test_hashed_user_id_uses_dedicated_salt(self, user: User) -> None:
+        """Changing the salt changes the hash (salt actually applies)."""
+        baseline = analytics.hashed_user_id(user)
+        with override_settings(GA4_USER_ID_SALT="other-salt"):
+            assert analytics.hashed_user_id(user) != baseline
+
+    def test_sanitize_page_location_drops_secret_params(self) -> None:
+        """Tokens and emails are stripped; campaign params survive."""
+        url = (
+            "https://notipus.com/invite/?token=secret123"
+            "&email=a@b.com&utm_source=news&utm_campaign=launch"
+        )
+        sanitized = analytics.sanitize_page_location(url)
+        assert "secret123" not in sanitized
+        assert "a@b.com" not in sanitized
+        assert "utm_source=news" in sanitized
+        assert "utm_campaign=launch" in sanitized
+        assert sanitized.startswith("https://notipus.com/invite/")
+
+    def test_event_params_redact_email_shapes(self) -> None:
+        """Email-shaped strings in params are redacted before sending."""
+        params = analytics._build_event_params(
+            {"plan": "pro", "note": "contact me at user@example.com"}, None
+        )
+        assert params["plan"] == "pro"
+        assert "user@example.com" not in params["note"]
+        assert "[redacted]" in params["note"]
+
+
+class TestTrackEvent:
+    """track_event payload construction."""
+
+    def test_noop_when_unconfigured(self) -> None:
+        """No payload is submitted when GA4 settings are empty."""
+        request = RequestFactory().get("/")
+        with patch.object(analytics, "_submit") as mock_submit:
+            analytics.track_event(request, "sign_up", {"method": "email"})
+        mock_submit.assert_not_called()
+
+    def test_payload_shape(self, ga4: MagicMock, user: User) -> None:
+        """Client id, hashed user id, session id and engagement land."""
+        request = RequestFactory().get("/")
+        request.COOKIES[analytics.CLIENT_ID_COOKIE] = "12345.67890"
+        request.session = {}  # type: ignore[assignment]
+        request.user = user
+
+        analytics.track_event(request, "select_plan", {"plan": "pro"})
+
+        (payload,) = _payloads(ga4)
+        assert payload["client_id"] == "12345.67890"
+        assert payload["user_id"] == analytics.hashed_user_id(user)
+        (event,) = payload["events"]
+        assert event["name"] == "select_plan"
+        assert event["params"]["plan"] == "pro"
+        assert event["params"]["engagement_time_msec"] == 100
+        assert event["params"]["session_id"]
+
+    def test_prefers_ga_cookie_for_stitching(self, ga4: MagicMock) -> None:
+        """A gtag.js _ga cookie wins over our first-party cookie."""
+        request = RequestFactory().get("/")
+        request.COOKIES["_ga"] = "GA1.1.111.222"
+        request.COOKIES[analytics.CLIENT_ID_COOKIE] = "999.888"
+
+        analytics.track_event(request, "page_view")
+
+        (payload,) = _payloads(ga4)
+        assert payload["client_id"] == "111.222"
+
+    def test_workspace_event_uses_workspace_uuid(
+        self, ga4: MagicMock, db: None
+    ) -> None:
+        """Webhook-driven events use the workspace uuid as client id."""
+        workspace = Workspace.objects.create(name="Acme")
+        analytics.track_workspace_event(
+            workspace, "plan_change", {"previous_plan": "free", "new_plan": "pro"}
+        )
+
+        (payload,) = _payloads(ga4)
+        assert payload["client_id"] == str(workspace.uuid)
+        assert "user_id" not in payload
+        (event,) = payload["events"]
+        assert event["params"]["new_plan"] == "pro"
+
+
+class TestMiddleware:
+    """GA4Middleware: cookie minting and server-side page views."""
+
+    def test_page_view_tracked_and_cookie_set(self, ga4: MagicMock, db: None) -> None:
+        """An HTML GET mints the client-id cookie and sends page_view."""
+        client = Client()
+        response = client.get(reverse("account_login"), HTTP_USER_AGENT="Mozilla/5.0")
+        assert response.status_code == 200
+        assert analytics.CLIENT_ID_COOKIE in response.cookies
+
+        (event,) = _events_named(ga4, "page_view")
+        assert event["params"]["page_location"].endswith(reverse("account_login"))
+
+    def test_bot_requests_not_tracked(self, ga4: MagicMock, db: None) -> None:
+        """Crawler user agents never produce page views."""
+        client = Client()
+        client.get(reverse("account_login"), HTTP_USER_AGENT="Googlebot/2.1")
+        client.get(reverse("account_login"))  # no UA at all
+        assert _events_named(ga4, "page_view") == []
+
+    def test_should_track_page_view_filters(self) -> None:
+        """Non-GET, non-HTML, error and excluded paths are skipped."""
+        factory = RequestFactory()
+        should_track = analytics.GA4Middleware._should_track_page_view
+
+        def html_response(status: int = 200) -> Any:
+            response = MagicMock()
+            response.status_code = status
+            response.get.return_value = "text/html; charset=utf-8"
+            return response
+
+        browser = {"HTTP_USER_AGENT": "Mozilla/5.0"}
+        assert should_track(factory.get("/dashboard/", **browser), html_response())
+        assert not should_track(factory.post("/dashboard/", **browser), html_response())
+        assert not should_track(
+            factory.get("/dashboard/", **browser), html_response(status=404)
+        )
+        assert not should_track(
+            factory.get("/webhook/stripe/", **browser), html_response()
+        )
+        assert not should_track(factory.get("/admin/core/", **browser), html_response())
+
+        json_response = MagicMock()
+        json_response.status_code = 200
+        json_response.get.return_value = "application/json"
+        assert not should_track(factory.get("/dashboard/", **browser), json_response)
+
+
+class TestAuthEvents:
+    """sign_up and login events from the auth signals."""
+
+    def test_login_signal_tracks_login(self, ga4: MagicMock, user: User) -> None:
+        """Django's user_logged_in signal produces a login event."""
+        request = RequestFactory().get("/")
+        request.session = {}  # type: ignore[assignment]
+        request.user = user
+        analytics.set_login_method(request, "passkey")
+
+        user_logged_in.send(sender=User, request=request, user=user)
+
+        (event,) = _events_named(ga4, "login")
+        assert event["params"]["method"] == "passkey"
+
+    def test_allauth_signup_signal_tracks_sign_up(
+        self, ga4: MagicMock, user: User
+    ) -> None:
+        """allauth's user_signed_up signal produces a sign_up event."""
+        from allauth.account.signals import user_signed_up
+
+        request = RequestFactory().get("/")
+        request.session = {}  # type: ignore[assignment]
+        request.user = user
+
+        user_signed_up.send(sender=User, request=request, user=user)
+
+        (event,) = _events_named(ga4, "sign_up")
+        assert event["params"]["method"] == "email"
+
+
+class TestFunnelEvents:
+    """Funnel events emitted by the billing and workspace views."""
+
+    def test_select_plan_tracked(
+        self, ga4: MagicMock, logged_in_client: Client, db: None
+    ) -> None:
+        """A valid plan selection sends select_plan with the plan name."""
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 29,
+                "is_active": True,
+            },
+        )
+        response = logged_in_client.post(reverse("core:select_plan"), {"plan": "pro"})
+        assert response.status_code == 302
+
+        (event,) = _events_named(ga4, "select_plan")
+        assert event["params"]["plan"] == "pro"
+
+    def test_invalid_plan_not_tracked(
+        self, ga4: MagicMock, logged_in_client: Client, db: None
+    ) -> None:
+        """Rejected plan selections must not produce funnel events."""
+        logged_in_client.post(reverse("core:select_plan"), {"plan": "bogus"})
+        assert _events_named(ga4, "select_plan") == []
+
+    def test_workspace_created_tracked(
+        self, ga4: MagicMock, logged_in_client: Client, db: None
+    ) -> None:
+        """Creating a workspace sends workspace_created with the plan."""
+        response = logged_in_client.post(
+            reverse("core:create_workspace"), {"name": "Acme"}
+        )
+        assert response.status_code == 302
+
+        (event,) = _events_named(ga4, "workspace_created")
+        assert event["params"]["plan"] == "free"
+
+    def test_checkout_cancel_tracked(
+        self, ga4: MagicMock, logged_in_client: Client, db: None
+    ) -> None:
+        """Landing on the checkout cancel page sends checkout_cancelled."""
+        response = logged_in_client.get(reverse("core:checkout_cancel"))
+        assert response.status_code == 200
+        assert len(_events_named(ga4, "checkout_cancelled")) == 1
+
+    def test_purchase_tracked_once(
+        self, ga4: MagicMock, logged_in_client: Client, user: User, db: None
+    ) -> None:
+        """checkout_success sends purchase once, even when refreshed."""
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 29,
+                "is_active": True,
+            },
+        )
+        workspace = Workspace.objects.create(name="Acme", stripe_customer_id="cus_123")
+        WorkspaceMember.objects.create(user=user, workspace=workspace, role="owner")
+
+        with patch("core.services.stripe.StripeAPI") as mock_api_cls:
+            mock_api_cls.return_value.retrieve_checkout_session.return_value = {
+                "customer": "cus_123",
+                "metadata": {"plan_name": "pro"},
+            }
+            url = reverse("core:checkout_success")
+            first = logged_in_client.get(url, {"session_id": "cs_test_1"})
+            second = logged_in_client.get(url, {"session_id": "cs_test_1"})
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        (event,) = _events_named(ga4, "purchase")
+        assert event["params"]["transaction_id"] == "cs_test_1"
+        assert event["params"]["value"] == 29.0
+        assert event["params"]["currency"] == "USD"
+        assert event["params"]["plan"] == "pro"
+
+
+class TestBillingSyncEvents:
+    """Server-side events from the Stripe webhook sync path."""
+
+    def test_plan_change_tracked_on_sync(self, ga4: MagicMock, db: None) -> None:
+        """A plan change during Stripe sync sends plan_change."""
+        from webhooks.services.billing import BillingService
+
+        workspace = Workspace.objects.create(
+            name="Acme", stripe_customer_id="cus_42", subscription_plan="free"
+        )
+
+        with patch("webhooks.services.billing.StripeAPI") as mock_api_cls:
+            mock_api_cls.return_value.get_customer_subscriptions.return_value = [
+                {
+                    "id": "sub_1",
+                    "status": "active",
+                    "items": [{"plan_name": "Pro"}],
+                }
+            ]
+            assert BillingService.sync_workspace_from_stripe("cus_42")
+
+        (event,) = _events_named(ga4, "plan_change")
+        assert event["params"]["previous_plan"] == "free"
+        assert event["params"]["new_plan"] == "pro"
+        assert _payloads(ga4)[0]["client_id"] == str(workspace.uuid)
+
+    def test_no_plan_change_event_when_plan_unchanged(
+        self, ga4: MagicMock, db: None
+    ) -> None:
+        """Re-syncing the same plan must not emit plan_change."""
+        from webhooks.services.billing import BillingService
+
+        Workspace.objects.create(
+            name="Acme", stripe_customer_id="cus_42", subscription_plan="pro"
+        )
+
+        with patch("webhooks.services.billing.StripeAPI") as mock_api_cls:
+            mock_api_cls.return_value.get_customer_subscriptions.return_value = [
+                {
+                    "id": "sub_1",
+                    "status": "active",
+                    "items": [{"plan_name": "Pro"}],
+                }
+            ]
+            assert BillingService.sync_workspace_from_stripe("cus_42")
+
+        assert _events_named(ga4, "plan_change") == []


### PR DESCRIPTION
## Summary

Tracks regular SaaS metrics in Google Analytics 4 — the signup funnel, plan changes, purchases, and active users — entirely **server-side** via the GA4 Measurement Protocol (no client-side JavaScript). Server-side means ad blockers can't drop events, and plan changes that happen with no browser involved (Stripe portal / dashboard / API, delivered by webhook) are still captured.

## Events

| Event | Source |
|---|---|
| `page_view` | `GA4Middleware` on every successful HTML GET (bot-filtered, `/admin/`, `/static/`, `/webhook/` excluded) |
| `sign_up` (method: email/social/slack/passkey) | allauth signal + Slack OIDC + passkey flows |
| `login` (method) | Django `user_logged_in` signal, all flows |
| `select_plan`, `workspace_created` | funnel views |
| `begin_checkout` | both checkout entry points |
| `purchase` (transaction_id, value, currency) | checkout success, deduped per Stripe session |
| `checkout_cancelled` | checkout cancel page |
| `plan_change`, `subscription_cancelled` | Stripe webhook billing sync (`sync_workspace_from_stripe` is the single choke point where the plan changes state) |

## PII filter

Nothing personally identifying is sent to Google:
- `user_id` is a **salted HMAC of the user pk** (`GA4_USER_ID_SALT`, falls back to `SECRET_KEY`). The hash is shown in the Django admin user list ("GA4 user ID" column) so a GA4 report id can be mapped back to an account.
- `page_location` is stripped to path + whitelisted campaign params (`utm_*`, `gclid`) — invitation tokens, Stripe session ids, and email prefills never leave our infra; referrers reduced to origin.
- Email-shaped strings in any event param are redacted as a last line of defense.

## Identity / sessions

Anonymous visitors get a first-party `np_ga_cid` HttpOnly cookie with a GA-style client id; a gtag.js `_ga` cookie wins if one ever exists, so a client snippet can be added later and sessions will stitch. `engagement_time_msec` + session ids make MP events count toward active users. Delivery is fire-and-forget on a small thread pool — Google being slow or down can never block a request or webhook.

## Bug fix

`billing/checkout/<plan_name>/` was declared before `billing/checkout/success|cancel/`, so Django routed Stripe's success/cancel redirects into `checkout()` with `plan_name="success"/"cancel"` — both pages were unreachable. Routes reordered.

## Config

- `GA4_ID` (already provisioned) — measurement id of the web data stream
- `GA4_API_SECRET` — **new, required**: GA4 Admin → Data Streams → stream → Measurement Protocol API secrets
- `GA4_USER_ID_SALT` — optional; set in production so SECRET_KEY rotation doesn't reset GA4 user continuity

Known limitations of MP-only tracking: no device/geo dimensions (Google doesn't derive them without gtag.js), and bot filtering is a UA heuristic. Adding a client-side `page_view`-only snippet later would fill those in without changing any of this.

## Testing

20 new tests (`tests/test_ga4_analytics.py`) covering payload construction, the PII filter, middleware filtering, funnel events, purchase dedupe, and webhook-driven plan changes. Full suite: 1809 passed; ruff/mypy clean; no migration drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)