### PR TITLE
feat: add exact 1600x1000 Slack App Directory listing screenshots

### DIFF
--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -60,3 +60,8 @@ def my_page(page: Page) -> None:
 Keep captures at the fixture defaults (1920x1080 desktop frame and
 390x844 mobile frame, both at 2x — output is 3840px / 780px wide, so
 Full HD is the floor) so the set stays visually consistent.
+
+`slack_listing.py` is the exception: the Slack App Directory requires
+screenshots that are exactly 1600x1000, so its captures come from the
+`slack_listing_page` fixture (1600x1000 viewport at 1:1) with
+`full_page=False`.

--- a/screenshots/conftest.py
+++ b/screenshots/conftest.py
@@ -55,6 +55,10 @@ os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
 # grow taller as the page requires.
 DESKTOP_VIEWPORT = {"width": 1920, "height": 1080}
 MOBILE_VIEWPORT = {"width": 390, "height": 844}
+# Slack App Directory listing requirement: screenshots must be exactly
+# 1600x1000 pixels — captured at 1:1 scale, viewport only (no
+# full-page scrolling).
+SLACK_LISTING_VIEWPORT = {"width": 1600, "height": 1000}
 OUTPUT_DIR = Path(__file__).parent / "output"
 
 # Initech's customers, straight from the movie
@@ -295,6 +299,27 @@ def mobile_page(
         device_scale_factor=2,  # retina-density, matches real phones
         is_mobile=True,
         has_touch=True,
+    )
+    yield context.new_page()
+    context.close()
+
+
+@pytest.fixture
+def slack_listing_page(
+    browser: Browser, live_server, session_cookie: dict[str, str]
+) -> Generator[Page, Any, None]:
+    """Authenticated page sized for Slack App Directory listings.
+
+    The directory rejects anything that isn't exactly 1600x1000, so
+    captures from this page must use ``full_page=False`` (the default
+    ``shoot`` full-page mode would grow taller than 1000px).
+    """
+    context = _new_context(
+        browser,
+        live_server,
+        session_cookie,
+        viewport=SLACK_LISTING_VIEWPORT,
+        device_scale_factor=1,
     )
     yield context.new_page()
     context.close()

--- a/screenshots/slack_listing.py
+++ b/screenshots/slack_listing.py
@@ -1,0 +1,28 @@
+"""Capture Slack App Directory listing screenshots.
+
+The directory requires screenshots that are exactly 1600x1000 pixels,
+so every capture here is a viewport crop (``full_page=False``) from the
+``slack_listing_page`` fixture. The set covers the dashboard hero, the
+integrations page, billing, and the notification landing in a
+Slack-style window.
+"""
+
+import pytest
+from conftest import OUTPUT_DIR, SLACK_FINALE_HTML, shoot
+from playwright.sync_api import Page
+
+
+@pytest.mark.django_db(transaction=True)
+def slack_listing(slack_listing_page: Page) -> None:
+    page = slack_listing_page
+
+    shoot(page, "slack-listing-dashboard", "/dashboard/", full_page=False)
+    shoot(page, "slack-listing-integrations", "/integrations/", full_page=False)
+    shoot(page, "slack-listing-billing", "/billing/", full_page=False)
+
+    # The notification arriving in a Slack-style window
+    page.set_content(SLACK_FINALE_HTML, wait_until="load")
+    page.wait_for_selector("#incoming.shown", timeout=10_000)
+    page.wait_for_timeout(500)
+    page.screenshot(path=str(OUTPUT_DIR / "slack-listing-notification.png"))
+    print("captured slack-listing-notification.png")


### PR DESCRIPTION
## Summary

The Slack App Directory requires listing screenshots that are **exactly 1600x1000 pixels**. This adds a `slack_listing.py` scenario with a dedicated `slack_listing_page` fixture (1600x1000 viewport, 1:1 pixels) capturing viewport crops (`full_page=False`) of:

- `slack-listing-dashboard.png` — the Initech dashboard with the activity feed
- `slack-listing-integrations.png` — connected Slack/Stripe integrations
- `slack-listing-billing.png` — the Pro-trial billing view
- `slack-listing-notification.png` — the Notipus notification landing in a Slack-style `#billing-alerts` window

## Test plan

- `bin/record_screenshots.sh slack_listing.py` — passes; all four captures verified as exactly (1600, 1000) with Pillow
- Full capture run still produces all 12 assets; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)