### PR TITLE
review: Slack listing follow-ups (shared finale helper, explicit full_page)

### DIFF
--- a/screenshots/conftest.py
+++ b/screenshots/conftest.py
@@ -595,10 +595,15 @@ SLACK_FINALE_HTML = """\
 """
 
 
-def play_slack_finale(page: Page, hold_ms: int = 4500) -> None:
-    """Swap the page for the Slack-style view and let the alert arrive."""
+def show_slack_finale(page: Page) -> None:
+    """Swap the page for the Slack-style view and wait for the alert."""
     page.set_content(SLACK_FINALE_HTML, wait_until="load")
     page.wait_for_selector("#incoming.shown", timeout=10_000)
+
+
+def play_slack_finale(page: Page, hold_ms: int = 4500) -> None:
+    """Show the Slack-style view and hold it on screen for recordings."""
+    show_slack_finale(page)
     pace(page, hold_ms)
 
 

--- a/screenshots/slack_listing.py
+++ b/screenshots/slack_listing.py
@@ -8,7 +8,7 @@ Slack-style window.
 """
 
 import pytest
-from conftest import OUTPUT_DIR, SLACK_FINALE_HTML, shoot
+from conftest import OUTPUT_DIR, shoot, show_slack_finale
 from playwright.sync_api import Page
 
 
@@ -21,8 +21,9 @@ def slack_listing(slack_listing_page: Page) -> None:
     shoot(page, "slack-listing-billing", "/billing/", full_page=False)
 
     # The notification arriving in a Slack-style window
-    page.set_content(SLACK_FINALE_HTML, wait_until="load")
-    page.wait_for_selector("#incoming.shown", timeout=10_000)
+    show_slack_finale(page)
     page.wait_for_timeout(500)
-    page.screenshot(path=str(OUTPUT_DIR / "slack-listing-notification.png"))
+    page.screenshot(
+        path=str(OUTPUT_DIR / "slack-listing-notification.png"), full_page=False
+    )
     print("captured slack-listing-notification.png")


### PR DESCRIPTION
## Summary

Follow-up to #139, addressing the two Copilot comments that arrived post-merge:

- The notification screenshot now passes `full_page=False` explicitly instead of relying on Playwright's default, so the exact-1600x1000 requirement can't silently regress.
- The Slack-finale setup is extracted into a shared `show_slack_finale()` helper; `play_slack_finale()` (used by the onboarding screencast) composes it, and `slack_listing.py` reuses it — no more duplicated selector/timing logic.

## Test plan

- `bin/record_screenshots.sh slack_listing.py` — all four captures verified exactly (1600, 1000)
- `bin/record_screenshots.sh onboarding.py` — screencast still records through the shared helper
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)