### PR TITLE
fix: fit Hunter.io enrichment values into Person columns

### DIFF
--- a/app/core/services/email_enrichment.py
+++ b/app/core/services/email_enrichment.py
@@ -59,6 +59,23 @@ class EmailEnrichmentService:
     # Cached person data is refreshed once it grows older than this many days.
     CACHE_DURATION_DAYS: int | None = 30
 
+    # Display-text fields: an overlong value is clipped to the column width.
+    TRUNCATABLE_FIELDS = (
+        "first_name",
+        "last_name",
+        "position",
+        "seniority",
+        "location",
+    )
+    # Link/identifier fields: a clipped value would point at the wrong
+    # profile or domain, so overlong values are dropped entirely.
+    DROP_IF_OVERLONG_FIELDS = (
+        "company_domain",
+        "linkedin_url",
+        "twitter_handle",
+        "github_handle",
+    )
+
     def __init__(self) -> None:
         """Initialize the email enrichment service."""
         self._hunter_plugin = HunterPlugin()
@@ -214,26 +231,54 @@ class EmailEnrichmentService:
         raw_data = data.get("_raw", {})
         raw_data["_enriched_at"] = datetime.now(timezone.utc).isoformat()
 
+        defaults: dict[str, Any] = {
+            field: self._fit_to_column(field, data.get(field) or "")
+            for field in self.TRUNCATABLE_FIELDS + self.DROP_IF_OVERLONG_FIELDS
+        }
+        defaults["hunter_data"] = raw_data
+
         person, created = Person.objects.update_or_create(
             workspace=workspace,
             email=email,
-            defaults={
-                "first_name": data.get("first_name", ""),
-                "last_name": data.get("last_name", ""),
-                "position": data.get("position", ""),
-                "seniority": data.get("seniority", ""),
-                "company_domain": data.get("company_domain", ""),
-                "linkedin_url": data.get("linkedin_url", ""),
-                "twitter_handle": data.get("twitter_handle", ""),
-                "github_handle": data.get("github_handle", ""),
-                "location": data.get("location", ""),
-                "hunter_data": raw_data,
-            },
+            defaults=defaults,
         )
 
         action = "Created" if created else "Updated"
         logger.debug(f"{action} person record for {email}")
         return person
+
+    def _fit_to_column(self, field_name: str, value: str) -> str:
+        """Fit an enrichment value into its Person column.
+
+        Hunter.io occasionally returns values longer than our columns,
+        which would abort the whole insert with a DataError. Display-text
+        fields are truncated to the column width; link/identifier fields
+        are dropped instead, since a clipped URL or handle would point at
+        the wrong place.
+
+        Args:
+            field_name: Name of the Person model field.
+            value: The value from the normalized Hunter.io response.
+
+        Returns:
+            A value guaranteed to fit the column.
+        """
+        max_length = Person._meta.get_field(field_name).max_length
+        if not max_length or len(value) <= max_length:
+            return value
+
+        if field_name in self.DROP_IF_OVERLONG_FIELDS:
+            logger.warning(
+                f"Dropping overlong {field_name} from Hunter.io "
+                f"({len(value)} chars > {max_length})"
+            )
+            return ""
+
+        logger.warning(
+            f"Truncating overlong {field_name} from Hunter.io "
+            f"({len(value)} chars > {max_length})"
+        )
+        return value[:max_length]
 
     def refresh_enrichment(self, email: str, workspace: "Workspace") -> Person | None:
         """Force refresh enrichment for an email.

--- a/tests/test_email_enrichment_field_limits.py
+++ b/tests/test_email_enrichment_field_limits.py
@@ -1,0 +1,118 @@
+"""Tests for fitting Hunter.io enrichment values into Person columns.
+
+Hunter.io occasionally returns values longer than the Person model's
+columns (e.g. a 100+ char name), which used to abort the whole insert
+with a DataError. Display-text fields are now truncated to the column
+width and link/identifier fields are dropped instead.
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from core.models import Person, Workspace
+from core.services.email_enrichment import EmailEnrichmentService
+
+
+@pytest.fixture
+def workspace(db: None) -> Workspace:
+    """Create a Pro-plan test workspace."""
+    return Workspace.objects.create(
+        name="Workspace",
+        subscription_plan="pro",
+        subscription_status="active",
+    )
+
+
+@pytest.fixture
+def enrichment_service() -> EmailEnrichmentService:
+    """Create an EmailEnrichmentService for testing."""
+    return EmailEnrichmentService()
+
+
+def _enrich(
+    service: EmailEnrichmentService,
+    workspace: Workspace,
+    api_data: dict[str, Any],
+    email: str = "john@example.com",
+) -> Person | None:
+    """Run enrich_email with tier/API-key checks and the API call mocked.
+
+    Args:
+        service: The enrichment service under test.
+        workspace: The workspace making the request.
+        api_data: The normalized payload the mocked Hunter.io call returns.
+        email: The email address to enrich.
+
+    Returns:
+        The Person returned by the service, or None.
+    """
+    with (
+        patch.object(service, "_check_tier", return_value=True),
+        patch.object(service, "_get_hunter_api_key", return_value="test-key"),
+        patch.object(service, "_call_hunter_api", return_value=api_data),
+    ):
+        return service.enrich_email(email, workspace)
+
+
+@pytest.mark.django_db
+class TestEnrichmentFieldLimits:
+    """Tests for overlong Hunter.io values being fitted to the columns."""
+
+    def test_overlong_name_is_truncated_not_fatal(
+        self, enrichment_service: EmailEnrichmentService, workspace: Workspace
+    ) -> None:
+        """A 100+ char name is clipped to the column width instead of erroring."""
+        api_data = {
+            "first_name": "J" * 250,
+            "last_name": "Doe",
+            "_raw": {},
+        }
+
+        person = _enrich(enrichment_service, workspace, api_data)
+
+        assert person is not None
+        assert person.first_name == "J" * 100
+        assert person.last_name == "Doe"
+
+    def test_overlong_identifier_fields_are_dropped(
+        self, enrichment_service: EmailEnrichmentService, workspace: Workspace
+    ) -> None:
+        """Overlong URLs/handles are dropped, not clipped into wrong links."""
+        api_data = {
+            "first_name": "John",
+            "linkedin_url": "https://linkedin.com/in/" + "x" * 600,
+            "twitter_handle": "t" * 150,
+            "github_handle": "g" * 150,
+            "company_domain": "d" * 300 + ".com",
+            "_raw": {},
+        }
+
+        person = _enrich(enrichment_service, workspace, api_data)
+
+        assert person is not None
+        assert person.linkedin_url == ""
+        assert person.twitter_handle == ""
+        assert person.github_handle == ""
+        assert person.company_domain == ""
+
+    def test_values_within_limits_are_stored_unchanged(
+        self, enrichment_service: EmailEnrichmentService, workspace: Workspace
+    ) -> None:
+        """Normal-length values pass through untouched."""
+        api_data = {
+            "first_name": "John",
+            "last_name": "Doe",
+            "position": "VP of Engineering",
+            "linkedin_url": "https://linkedin.com/in/johndoe",
+            "twitter_handle": "johndoe",
+            "_raw": {},
+        }
+
+        person = _enrich(enrichment_service, workspace, api_data)
+
+        assert person is not None
+        assert person.first_name == "John"
+        assert person.position == "VP of Engineering"
+        assert person.linkedin_url == "https://linkedin.com/in/johndoe"
+        assert person.twitter_handle == "johndoe"


### PR DESCRIPTION
## Summary
Production error seen on Fly (2026-07-21 14:36 UTC): `psycopg2.errors.StringDataRightTruncation: value too long for type character varying(100)` in `EmailEnrichmentService._update_person`. Hunter.io returned a person value longer than a `Person` varchar(100) column, the insert aborted, and the person was never cached — so every webhook for that email would retry and re-fail the Hunter.io call.

## Fix
- New `_fit_to_column` helper reads each field's `max_length` from the model and fits values before `update_or_create`.
- Display-text fields (`first_name`, `last_name`, `position`, `seniority`, `location`) are truncated to the column width.
- Link/identifier fields (`linkedin_url`, `twitter_handle`, `github_handle`, `company_domain`) are dropped when overlong — a clipped URL or handle would point at the wrong profile.
- Both cases log a warning.

## Testing
- New `tests/test_email_enrichment_field_limits.py`: overlong name truncated, overlong identifiers dropped, in-limit values untouched.
- All enrichment tests pass; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)