### PR TITLE
feat(slack): surface customer identity above the fold

### DIFF
--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -93,7 +93,7 @@ EMAIL_TAG_BADGES: dict[str, str] = {
 }
 
 # Company descriptions are enrichment boilerplate; anything longer than
-# this dominates the message and can push the customer footer and action
+# this dominates the message and can push the payment details and action
 # buttons behind Slack's "Show more" collapse.
 MAX_DESCRIPTION_LENGTH = 160
 
@@ -219,23 +219,28 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         # Provider badge (adapts based on event type)
         blocks.append(self._format_provider_badge(n))
 
+        # Who this is about comes before the payment details: Slack
+        # collapses tall attachments behind "Show more", and the customer
+        # identity is the one thing that must never fall below that fold.
+        identity = self._format_identity_blocks(n)
+        blocks.extend(identity)
+
         # Payment/order details (for payment events)
+        detail_blocks: list[dict[str, Any]] = []
         if n.payment:
             payment_block = self._format_payment_details(n)
             if payment_block:
-                blocks.append(payment_block)
+                detail_blocks.append(payment_block)
 
         # Generic detail sections (for non-payment events or extras)
         for section in n.detail_sections:
-            blocks.append(self._format_detail_section(section))
+            detail_blocks.append(self._format_detail_section(section))
 
-        # Company/person/customer blocks, preceded by a divider only when
-        # at least one is present - sparse events (e.g. an integration
-        # error with no customer) must not end on a dangling rule.
-        tail = self._format_tail_blocks(n)
-        if tail:
+        # Divider only when it actually separates identity from details -
+        # sparse events must not start or end on a dangling rule.
+        if identity and detail_blocks:
             blocks.append({"type": "divider"})
-            blocks.extend(tail)
+        blocks.extend(detail_blocks)
 
         # Action buttons (if present)
         if n.actions:
@@ -254,8 +259,8 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             ],
         }
 
-    def _format_tail_blocks(self, n: RichNotification) -> list[dict[str, Any]]:
-        """Build the company/person/customer blocks shown after the divider.
+    def _format_identity_blocks(self, n: RichNotification) -> list[dict[str, Any]]:
+        """Build the company/person/customer blocks shown above the details.
 
         Args:
             n: RichNotification.
@@ -264,29 +269,29 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             List of Slack blocks; empty when no enrichment or customer
             data is available.
         """
-        tail: list[dict[str, Any]] = []
+        identity: list[dict[str, Any]] = []
 
         # Company section with logo (if enriched)
         if n.company:
-            tail.append(self._format_company_section(n.company))
+            identity.append(self._format_company_section(n.company))
             # Add LinkedIn link below company section
             links_block = self._format_company_links(n.company)
             if links_block:
-                tail.append(links_block)
+                identity.append(links_block)
 
         # Person section (if enriched via Hunter.io). It absorbs the
         # customer facts (email, tenure, LTV, flags) so the reader gets
         # one person block instead of two overlapping ones.
         if n.person:
-            tail.extend(self._format_person_section(n.person, n.customer))
-        # Standalone customer footer (only shown when there's meaningful
+            identity.extend(self._format_person_section(n.person, n.customer))
+        # Standalone customer line (only shown when there's meaningful
         # data and no person section already carries it)
         elif n.customer:
             customer_footer = self._format_customer_footer(n.customer)
             if customer_footer:
-                tail.append(customer_footer)
+                identity.append(customer_footer)
 
-        return tail
+        return identity
 
     def _format_fallback_text(self, n: RichNotification) -> str:
         """Build the top-level fallback text for the message.
@@ -303,6 +308,9 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             Plain one-line summary, sanitized for mrkdwn.
         """
         parts = [n.headline]
+        who = self._identity_display(n)
+        if who and who not in n.headline:
+            parts.append(who)
         if n.insight:
             parts.append(n.insight.text)
         # Collapse all whitespace (payload-derived strings like failure
@@ -310,6 +318,31 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         one_line = " ".join(" — ".join(parts).split())
         fallback: str = safe_mrkdwn(one_line)
         return fallback
+
+    def _identity_display(self, n: RichNotification) -> str | None:
+        """Pick the best short identity string for previews.
+
+        Prefers the enriched company name, then the customer email,
+        name, or payload-provided company name. Used in the fallback
+        text so mobile push banners and sidebar previews say who the
+        event is about, not just what happened.
+
+        Args:
+            n: RichNotification.
+
+        Returns:
+            Identity string, or None when nothing identifies the
+            customer.
+        """
+        if n.company and n.company.name:
+            company_name: str = n.company.name
+            return company_name
+        if n.customer:
+            customer_display: str | None = (
+                n.customer.email or n.customer.name or n.customer.company_name
+            )
+            return customer_display
+        return None
 
     def send(self, formatted: Any, credentials: dict[str, Any]) -> bool:
         """Send formatted notification to Slack via webhook.
@@ -632,8 +665,8 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             text_parts.append(f"_{' • '.join(details)}_")
 
         # Description as blockquote, truncated so enrichment boilerplate
-        # cannot dominate the message or push the actions behind Slack's
-        # "Show more" collapse.
+        # cannot dominate the message or push the payment details and
+        # actions behind Slack's "Show more" collapse.
         if company.description:
             desc = html_to_slack_mrkdwn(company.description)
             desc = _truncate_mrkdwn(desc, MAX_DESCRIPTION_LENGTH)

--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -309,7 +309,9 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         """
         parts = [n.headline]
         who = self._identity_display(n)
-        if who and who not in n.headline:
+        # Case-insensitive so a headline carrying "Alice@acme.com" does
+        # not get "alice@acme.com" appended again.
+        if who and who.casefold() not in n.headline.casefold():
             parts.append(who)
         if n.insight:
             parts.append(n.insight.text)

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -1113,6 +1113,15 @@ class TestSlackDestinationPluginFallbackText:
 
         assert result["text"].count("alice@acme.com") == 1
 
+    def test_fallback_text_identity_dedup_is_case_insensitive(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test dedup holds when the headline cases the email differently."""
+        basic_notification.headline = "$299.00 from Alice@Acme.com"
+        result = formatter.format(basic_notification)
+
+        assert result["text"].casefold().count("alice@acme.com") == 1
+
 
 class TestSlackDestinationPluginEcommerceDetails:
     """Test e-commerce order details formatting."""

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -969,6 +969,7 @@ class TestSlackDestinationPluginDivider:
     ) -> None:
         """Test no divider when identity has no details below it."""
         basic_notification.payment = None
+        basic_notification.detail_sections = []
         result = formatter.format(basic_notification)
 
         divider_blocks = [b for b in get_blocks(result) if b["type"] == "divider"]

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -964,6 +964,74 @@ class TestSlackDestinationPluginDivider:
         divider_blocks = [b for b in get_blocks(result) if b["type"] == "divider"]
         assert len(divider_blocks) == 0
 
+    def test_no_dangling_divider_without_detail_blocks(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test no divider when identity has no details below it."""
+        basic_notification.payment = None
+        result = formatter.format(basic_notification)
+
+        divider_blocks = [b for b in get_blocks(result) if b["type"] == "divider"]
+        assert len(divider_blocks) == 0
+
+
+class TestSlackDestinationPluginBlockOrder:
+    """Test that customer identity renders above the payment details.
+
+    The audience is CS/sales scanning a channel: Slack collapses tall
+    attachments behind "Show more", so who the event is about must sit
+    above the fold, before subscription IDs and amount grids.
+    """
+
+    def test_customer_before_payment_details(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test the customer block precedes the payment fields grid."""
+        blocks = get_blocks(formatter.format(basic_notification))
+
+        customer_idx = next(
+            i
+            for i, b in enumerate(blocks)
+            if b["type"] == "context" and "alice@acme.com" in str(b.get("elements", ""))
+        )
+        payment_idx = next(i for i, b in enumerate(blocks) if "fields" in b)
+
+        assert customer_idx < payment_idx
+
+    def test_company_before_payment_details(
+        self,
+        formatter: SlackDestinationPlugin,
+        notification_with_company: RichNotification,
+    ) -> None:
+        """Test the enriched company block precedes the payment fields grid."""
+        blocks = get_blocks(formatter.format(notification_with_company))
+
+        company_idx = next(
+            i
+            for i, b in enumerate(blocks)
+            if b["type"] == "section"
+            and "Acme Corporation" in str(b.get("text", {}).get("text", ""))
+        )
+        payment_idx = next(i for i, b in enumerate(blocks) if "fields" in b)
+
+        assert company_idx < payment_idx
+
+    def test_divider_separates_identity_from_details(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test the divider sits between the identity and the details."""
+        blocks = get_blocks(formatter.format(basic_notification))
+
+        divider_idx = next(i for i, b in enumerate(blocks) if b["type"] == "divider")
+        customer_idx = next(
+            i
+            for i, b in enumerate(blocks)
+            if b["type"] == "context" and "alice@acme.com" in str(b.get("elements", ""))
+        )
+        payment_idx = next(i for i, b in enumerate(blocks) if "fields" in b)
+
+        assert customer_idx < divider_idx < payment_idx
+
 
 class TestSlackDestinationPluginFallbackText:
     """Test the top-level fallback text used for notification previews."""
@@ -1013,6 +1081,36 @@ class TestSlackDestinationPluginFallbackText:
         assert "\n" not in result["text"]
         assert "\t" not in result["text"]
         assert "Card declined: insufficient funds" in result["text"]
+
+    def test_fallback_text_includes_customer_email(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test the preview says who the event is about."""
+        basic_notification.headline = "New subscription!"
+        result = formatter.format(basic_notification)
+
+        assert "alice@acme.com" in result["text"]
+
+    def test_fallback_text_prefers_company_name(
+        self,
+        formatter: SlackDestinationPlugin,
+        notification_with_company: RichNotification,
+    ) -> None:
+        """Test the enriched company name wins over the raw email."""
+        notification_with_company.headline = "New subscription!"
+        result = formatter.format(notification_with_company)
+
+        assert "Acme Corporation" in result["text"]
+        assert "alice@acme.com" not in result["text"]
+
+    def test_fallback_text_skips_identity_already_in_headline(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test no duplicate when the headline already names the customer."""
+        basic_notification.headline = "$299.00 from alice@acme.com"
+        result = formatter.format(basic_notification)
+
+        assert result["text"].count("alice@acme.com") == 1
 
 
 class TestSlackDestinationPluginEcommerceDetails:


### PR DESCRIPTION
## Problem

The Slack formatter rendered the customer identity (company block, person section, customer email footer) **last**, after the payment details. Slack collapses tall attachments behind "Show more", so a CS/sales person scanning the channel saw the event type and a subscription ID — but not *who* the event is about — without expanding the message. The lede was buried.

## Changes

- **Identity leads.** Block order is now: headline → insight → provider badge → **company/person/customer** → divider → payment details → actions. The audience is CS/sales who need to jump on (and celebrate) events at a glance; subscription IDs and payment-method plumbing are what fall behind the fold now, not the customer.
- **Push previews say who.** The top-level fallback text (mobile push banners, sidebar previews) now appends the customer identity — preferring the enriched company name, falling back to email/name/payload company name — and skips it when the headline already names the customer.
- The divider is only emitted when it actually separates identity blocks from detail blocks, so sparse events still never start or end on a dangling rule.

## Before / after (new subscription example)

Before: `🎉 New subscription!` → insight → badge → amount/ARR/sub-ID → *(fold)* → domain/email
After: `🎉 New subscription!` → insight → badge → **👤 customer** → amount/ARR/sub-ID

## Testing

- 8 new tests: block ordering (customer and company before payment fields), divider placement, no-dangling-divider without details, fallback identity incl. company-name preference and case-insensitive headline dedup.
- Full suite: 1859 passed; ruff and `mypy app/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
