### PR TITLE
feat(integrations): email setup instructions to a colleague

### DIFF
--- a/app/core/templates/core/emails/setup_instructions.html.j2
+++ b/app/core/templates/core/emails/setup_instructions.html.j2
@@ -5,7 +5,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description"
               content="Setup instructions for connecting {{ provider_name }} to Notipus">
-        <meta name="keywords" content="notipus, setup, webhook, {{ provider_name }}">
+        <meta name="keywords"
+              content="notipus, setup, webhook, {{ provider_name }}">
         <title>Connect {{ provider_name }} to Notipus</title>
         <style>
             body {

--- a/app/core/templates/core/emails/setup_instructions.html.j2
+++ b/app/core/templates/core/emails/setup_instructions.html.j2
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="description"
+              content="Setup instructions for connecting {{ provider_name }} to Notipus">
+        <meta name="keywords" content="notipus, setup, webhook, {{ provider_name }}">
+        <title>Connect {{ provider_name }} to Notipus</title>
+        <style>
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+                line-height: 1.6;
+                color: #333;
+                max-width: 600px;
+                margin: 0 auto;
+                padding: 20px;
+                background-color: #f5f5f5;
+            }
+
+            .container {
+                background-color: #ffffff;
+                border-radius: 8px;
+                padding: 40px;
+                box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            }
+
+            .header {
+                text-align: center;
+                margin-bottom: 30px;
+            }
+
+            .logo {
+                font-size: 24px;
+                font-weight: bold;
+                color: #6366f1;
+            }
+
+            h1 {
+                color: #1f2937;
+                font-size: 24px;
+                margin-bottom: 20px;
+            }
+
+            p {
+                color: #4b5563;
+                margin-bottom: 16px;
+            }
+
+            ol.steps {
+                color: #4b5563;
+                padding-left: 20px;
+            }
+
+            ol.steps li {
+                margin-bottom: 16px;
+            }
+
+            .step-title {
+                color: #1f2937;
+                font-weight: 600;
+            }
+
+            .code-box {
+                background-color: #f3f4f6;
+                border: 1px solid #e5e7eb;
+                border-radius: 8px;
+                padding: 12px 16px;
+                font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 13px;
+                word-break: break-all;
+                color: #1f2937;
+                margin-bottom: 16px;
+            }
+
+            .code-box ul {
+                margin: 0;
+                padding-left: 18px;
+            }
+
+            .label {
+                font-size: 13px;
+                font-weight: 600;
+                color: #6b7280;
+                text-transform: uppercase;
+                letter-spacing: 0.05em;
+                margin-bottom: 6px;
+            }
+
+            .footer {
+                margin-top: 40px;
+                padding-top: 20px;
+                border-top: 1px solid #e5e7eb;
+                font-size: 14px;
+                color: #6b7280;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <div class="header">
+                <div class="logo">Notipus</div>
+            </div>
+
+            <h1>Help connect {{ provider_name }} to Notipus</h1>
+
+            <p>
+                <strong>{{ requester_name }}</strong> is setting up
+                <strong>{{ provider_name }}</strong> notifications for
+                <strong>{{ workspace_name }}</strong> on Notipus and needs help
+                from someone with access to the {{ provider_name }} account.
+            </p>
+
+            <ol class="steps">
+                {% for step in steps %}
+                    <li>
+                        <span class="step-title">{{ step.title }}</span>
+                        <br>
+                        {{ step.description }}
+                    </li>
+                {% endfor %}
+            </ol>
+
+            <div class="label">Webhook URL</div>
+            <div class="code-box">{{ webhook_url }}</div>
+
+            {% if webhook_events %}
+                <div class="label">Events to select</div>
+                <div class="code-box">
+                    <ul>
+                        {% for event in webhook_events %}<li>{{ event }}</li>{% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
+
+            <div class="footer">
+                <p>If you weren't expecting this email, you can safely ignore it.</p>
+                <p>— The Notipus Team</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/app/core/templates/core/integrate_chargify.html.j2
+++ b/app/core/templates/core/integrate_chargify.html.j2
@@ -210,6 +210,29 @@
                 </div>
             </div>
 
+            <!-- Email instructions to a colleague -->
+            <div class="mt-8 bg-white shadow-lg rounded-xl border border-gray-100 p-8">
+                <h3 class="text-lg font-semibold text-gray-900 mb-2">✉️ Not the person with Chargify access?</h3>
+                <p class="text-sm text-gray-600 mb-4">
+                    Email these instructions to the teammate who manages your Chargify/Maxio account.
+                    They'll add the webhook and send you back the secret to paste above.
+                </p>
+                <form method="post"
+                      action="{% url 'core:email_setup_instructions' 'chargify' %}"
+                      class="flex flex-col sm:flex-row gap-3">
+                    {% csrf_token %}
+                    <input type="email"
+                           name="recipient_email"
+                           required
+                           placeholder="colleague@yourcompany.com"
+                           class="flex-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5">
+                    <button type="submit"
+                            class="inline-flex items-center justify-center px-4 py-2.5 text-sm font-medium rounded-lg text-primary-600 bg-primary-100 hover:bg-primary-200 transition-colors">
+                        Send instructions
+                    </button>
+                </form>
+            </div>
+
             <!-- Benefits -->
             <div class="mt-8 bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl p-6 border border-blue-200">
                 <h3 class="text-lg font-semibold text-blue-900 mb-4">🎯 What you'll get with Chargify/Maxio integration:</h3>

--- a/app/core/templates/core/integrate_chargify.html.j2
+++ b/app/core/templates/core/integrate_chargify.html.j2
@@ -224,6 +224,8 @@
                     <input type="email"
                            name="recipient_email"
                            required
+                           autocomplete="email"
+                           aria-label="Colleague's email address"
                            placeholder="colleague@yourcompany.com"
                            class="flex-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5">
                     <button type="submit"

--- a/app/core/templates/core/integrate_stripe.html.j2
+++ b/app/core/templates/core/integrate_stripe.html.j2
@@ -284,6 +284,32 @@
                     </div>
                 </div>
             </form>
+
+            <!-- Email instructions to a colleague -->
+            <div class="bg-white shadow-lg rounded-xl border border-gray-100 p-8 mb-8">
+                <h3 class="text-lg font-semibold text-gray-900 mb-2 flex items-center gap-2">
+                    <i class="ti ti-mail-forward text-[#635bff]"></i>
+                    Not the person with Stripe access?
+                </h3>
+                <p class="text-sm text-gray-600 mb-4">
+                    Email these instructions to the teammate who manages your Stripe account.
+                    They'll create the webhook endpoint and send you back the signing secret to paste above.
+                </p>
+                <form method="post"
+                      action="{% url 'core:email_setup_instructions' 'stripe' %}"
+                      class="flex flex-col sm:flex-row gap-3">
+                    {% csrf_token %}
+                    <input type="email"
+                           name="recipient_email"
+                           required
+                           placeholder="colleague@yourcompany.com"
+                           class="flex-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-[#635bff] focus:border-[#635bff] block w-full p-2.5">
+                    <button type="submit"
+                            class="inline-flex items-center justify-center px-4 py-2.5 text-sm font-medium rounded-lg text-[#635bff] bg-[#635bff]/10 hover:bg-[#635bff]/20 transition-colors">
+                        <i class="ti ti-send mr-2"></i> Send instructions
+                    </button>
+                </form>
+            </div>
         </div>
     </div>
 

--- a/app/core/templates/core/integrate_stripe.html.j2
+++ b/app/core/templates/core/integrate_stripe.html.j2
@@ -302,6 +302,8 @@
                     <input type="email"
                            name="recipient_email"
                            required
+                           autocomplete="email"
+                           aria-label="Colleague's email address"
                            placeholder="colleague@yourcompany.com"
                            class="flex-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-[#635bff] focus:border-[#635bff] block w-full p-2.5">
                     <button type="submit"

--- a/app/core/urls.py
+++ b/app/core/urls.py
@@ -64,6 +64,11 @@ urlpatterns = [
     path("integrate/chargify/", views.integrate_chargify, name="integrate_chargify"),
     path("integrate/stripe/", views.integrate_stripe, name="integrate_stripe"),
     path("integrate/hunter/", views.integrate_hunter, name="integrate_hunter"),
+    path(
+        "integrate/<str:provider>/email-instructions/",
+        views.email_setup_instructions,
+        name="email_setup_instructions",
+    ),
     # Legacy API endpoints (working views)
     path("api/auth/slack/", views.slack_auth, name="slack_auth"),
     path(

--- a/app/core/views/__init__.py
+++ b/app/core/views/__init__.py
@@ -36,6 +36,7 @@ from .integrations import (
     disconnect_shopify,
     disconnect_slack,
     disconnect_stripe,
+    email_setup_instructions,
     get_slack_channels,
     integrate_chargify,
     integrate_hunter,
@@ -85,6 +86,7 @@ __all__ = [
     "workspace_settings",
     # Integrations
     "integrations",
+    "email_setup_instructions",
     "integrate_slack",
     "integrate_shopify",
     "integrate_chargify",

--- a/app/core/views/integrations/__init__.py
+++ b/app/core/views/integrations/__init__.py
@@ -28,6 +28,7 @@ from ...models import UserProfile, WorkspaceMember
 
 # Import all integration views for re-export
 from .chargify import integrate_chargify
+from .email_instructions import email_setup_instructions
 from .hunter import disconnect_hunter, integrate_hunter
 from .shopify import (
     disconnect_shopify,
@@ -56,6 +57,8 @@ logger = logging.getLogger(__name__)
 __all__ = [
     # Main page
     "integrations",
+    # Shared
+    "email_setup_instructions",
     # Slack
     "integrate_slack",
     "slack_connect",

--- a/app/core/views/integrations/email_instructions.py
+++ b/app/core/views/integrations/email_instructions.py
@@ -74,7 +74,9 @@ PROVIDER_INSTRUCTIONS: dict[str, ProviderInstructions] = {
         display_name=STRIPE_DISPLAY_NAME,
         url_slug="stripe",
         integrate_route="core:integrate_stripe",
-        webhook_events=STRIPE_WEBHOOK_EVENTS,
+        # Copied so mutation through either alias cannot silently desync
+        # the setup page from the emailed instructions.
+        webhook_events=list(STRIPE_WEBHOOK_EVENTS),
         steps=[
             SetupStep(
                 title="Open the Stripe webhooks page",
@@ -225,7 +227,7 @@ def send_setup_instructions_email(
     )
 
     try:
-        send_mail(
+        sent_count = send_mail(
             subject=subject,
             message=text_message,
             from_email=settings.DEFAULT_FROM_EMAIL,
@@ -233,13 +235,17 @@ def send_setup_instructions_email(
             html_message=html_message,
             fail_silently=False,
         )
-        logger.info(
-            f"{instructions.display_name} setup instructions sent to {recipient}"
-        )
-        return True
-    except Exception as e:
-        logger.error(f"Failed to send setup instructions to {recipient}: {e}")
+    except Exception:
+        logger.exception(f"Failed to send setup instructions to {recipient}")
         return False
+    if sent_count == 0:
+        logger.error(
+            f"Email backend accepted no messages sending setup "
+            f"instructions to {recipient}"
+        )
+        return False
+    logger.info(f"{instructions.display_name} setup instructions sent to {recipient}")
+    return True
 
 
 @login_required

--- a/app/core/views/integrations/email_instructions.py
+++ b/app/core/views/integrations/email_instructions.py
@@ -174,10 +174,12 @@ def send_setup_instructions_email(
         f"{settings.BASE_URL}/webhook/customer/"
         f"{workspace.uuid}/{instructions.url_slug}/"
     )
+    # .replace() rather than .format(): instruction copy may grow
+    # literal braces (JSON snippets), which format() would choke on.
     steps = [
         SetupStep(
             title=step.title,
-            description=step.description.format(requester=requester_name),
+            description=step.description.replace("{requester}", requester_name),
         )
         for step in instructions.steps
     ]

--- a/app/core/views/integrations/email_instructions.py
+++ b/app/core/views/integrations/email_instructions.py
@@ -285,7 +285,7 @@ def email_setup_instructions(
         messages.error(request, "Please enter a valid email address.")
         return redirect(instructions.integrate_route)
 
-    requester_name = request.user.get_full_name() or request.user.email  # type: ignore[union-attr]
+    requester_name = request.user.get_full_name() or request.user.email
     sent = send_setup_instructions_email(
         recipient, workspace, requester_name, instructions
     )

--- a/app/core/views/integrations/email_instructions.py
+++ b/app/core/views/integrations/email_instructions.py
@@ -14,10 +14,12 @@ instructions to relay - the right tool there is a workspace invitation.
 
 import logging
 from dataclasses import dataclass, field
+from typing import cast
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.core.validators import validate_email
@@ -285,7 +287,10 @@ def email_setup_instructions(
         messages.error(request, "Please enter a valid email address.")
         return redirect(instructions.integrate_route)
 
-    requester_name = request.user.get_full_name() or request.user.email
+    # login_required plus the admin check above guarantee an
+    # authenticated concrete User here.
+    requester = cast(User, request.user)
+    requester_name = requester.get_full_name() or requester.email
     sent = send_setup_instructions_email(
         recipient, workspace, requester_name, instructions
     )

--- a/app/core/views/integrations/email_instructions.py
+++ b/app/core/views/integrations/email_instructions.py
@@ -1,0 +1,296 @@
+"""Email integration setup instructions to a colleague.
+
+The Notipus admin configuring an integration is often not the person
+with access to the payment provider's dashboard. This view lets the
+admin email the manual webhook-setup steps (endpoint URL, events to
+select, where to find the signing secret) to whoever does have access,
+so that person can create the webhook and hand the signing secret back
+to the admin to finish the connection.
+
+Only providers with a manual webhook setup are supported: Shopify uses
+OAuth and registers its webhooks automatically, so there are no
+instructions to relay - the right tool there is a workspace invitation.
+"""
+
+import logging
+from dataclasses import dataclass, field
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ValidationError
+from django.core.mail import send_mail
+from django.core.validators import validate_email
+from django.http import HttpRequest, HttpResponseRedirect
+from django.shortcuts import redirect
+from django.template.loader import render_to_string
+
+from ...models import Workspace
+from .base import require_admin_role, require_post_method
+from .chargify import DISPLAY_NAME as CHARGIFY_DISPLAY_NAME
+from .stripe import DISPLAY_NAME as STRIPE_DISPLAY_NAME
+from .stripe import STRIPE_WEBHOOK_EVENTS
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SetupStep:
+    """One numbered step in the emailed instructions.
+
+    Attributes:
+        title: Short step heading.
+        description: What to do. May contain a ``{requester}``
+            placeholder, replaced with the requesting admin's name.
+    """
+
+    title: str
+    description: str
+
+
+@dataclass(frozen=True)
+class ProviderInstructions:
+    """Emailable setup instructions for a manual-webhook provider.
+
+    Attributes:
+        display_name: Provider name shown to the recipient.
+        url_slug: Path segment of the workspace webhook URL.
+        integrate_route: Route name of the provider's setup page, used
+            as the redirect target after sending.
+        steps: Ordered setup steps.
+        webhook_events: Events the recipient must select, if the
+            provider requires choosing events (empty when not).
+    """
+
+    display_name: str
+    url_slug: str
+    integrate_route: str
+    steps: list[SetupStep]
+    webhook_events: list[str] = field(default_factory=list)
+
+
+PROVIDER_INSTRUCTIONS: dict[str, ProviderInstructions] = {
+    "stripe": ProviderInstructions(
+        display_name=STRIPE_DISPLAY_NAME,
+        url_slug="stripe",
+        integrate_route="core:integrate_stripe",
+        webhook_events=STRIPE_WEBHOOK_EVENTS,
+        steps=[
+            SetupStep(
+                title="Open the Stripe webhooks page",
+                description=(
+                    "In the Stripe Dashboard, go to Developers → Webhooks "
+                    "(https://dashboard.stripe.com/webhooks/create) and "
+                    'click "Add destination".'
+                ),
+            ),
+            SetupStep(
+                title="Select events",
+                description=(
+                    'Under "Events from", choose "Your account", then '
+                    "search for and select each event listed below. "
+                    'Click "Continue".'
+                ),
+            ),
+            SetupStep(
+                title="Choose destination type",
+                description='Select "Webhook endpoint" and click "Continue".',
+            ),
+            SetupStep(
+                title="Set the endpoint URL",
+                description=(
+                    "Paste the webhook URL below into the "
+                    '"Endpoint URL" field and click "Create destination".'
+                ),
+            ),
+            SetupStep(
+                title="Send back the signing secret",
+                description=(
+                    'Stripe now shows a "Signing secret" starting with '
+                    '"whsec_". Share it with {requester} over a secure '
+                    "channel (such as a password manager) - not by "
+                    "replying to this email. They will paste it into "
+                    "Notipus to finish the connection."
+                ),
+            ),
+        ],
+    ),
+    "chargify": ProviderInstructions(
+        display_name=CHARGIFY_DISPLAY_NAME,
+        url_slug="chargify",
+        integrate_route="core:integrate_chargify",
+        steps=[
+            SetupStep(
+                title="Open your webhook settings",
+                description=(
+                    "Log in to your Chargify dashboard (or Maxio Advanced "
+                    "Billing) and go to Settings → Webhooks."
+                ),
+            ),
+            SetupStep(
+                title="Add the webhook URL",
+                description=("Add the webhook URL below as a new webhook endpoint."),
+            ),
+            SetupStep(
+                title="Send back the webhook secret",
+                description=(
+                    "Copy the webhook secret shown on the same page and "
+                    "share it with {requester} over a secure channel "
+                    "(such as a password manager) - not by replying to "
+                    "this email. They will paste it into Notipus to "
+                    "finish the connection."
+                ),
+            ),
+            SetupStep(
+                title="Send a test webhook",
+                description=(
+                    "Once {requester} has finished the setup, send a test "
+                    "webhook from Chargify/Maxio to verify the connection."
+                ),
+            ),
+        ],
+    ),
+}
+
+
+def send_setup_instructions_email(
+    recipient: str,
+    workspace: Workspace,
+    requester_name: str,
+    instructions: ProviderInstructions,
+) -> bool:
+    """Send the provider setup instructions to a colleague.
+
+    Args:
+        recipient: Email address of the colleague with provider access.
+        workspace: The workspace the integration belongs to.
+        requester_name: Display name of the admin requesting help.
+        instructions: The provider's instruction set.
+
+    Returns:
+        True if the email was sent successfully, False otherwise.
+    """
+    webhook_url = (
+        f"{settings.BASE_URL}/webhook/customer/"
+        f"{workspace.uuid}/{instructions.url_slug}/"
+    )
+    steps = [
+        SetupStep(
+            title=step.title,
+            description=step.description.format(requester=requester_name),
+        )
+        for step in instructions.steps
+    ]
+
+    subject = (
+        f"Help connect {instructions.display_name} to Notipus for {workspace.name}"
+    )
+
+    text_lines = [
+        "Hi,",
+        "",
+        f"{requester_name} is setting up {instructions.display_name} "
+        f"notifications for {workspace.name} on Notipus and needs help "
+        f"from someone with access to the "
+        f"{instructions.display_name} account.",
+        "",
+    ]
+    for index, step in enumerate(steps, start=1):
+        text_lines.append(f"{index}. {step.title}")
+        text_lines.append(f"   {step.description}")
+    text_lines += ["", f"Webhook URL: {webhook_url}"]
+    if instructions.webhook_events:
+        text_lines += ["", "Events to select:"]
+        text_lines += [f"- {event}" for event in instructions.webhook_events]
+    text_lines += [
+        "",
+        "If you weren't expecting this email, you can safely ignore it.",
+        "",
+        "- The Notipus Team",
+    ]
+    text_message = "\n".join(text_lines)
+
+    html_message = render_to_string(
+        "core/emails/setup_instructions.html.j2",
+        {
+            "provider_name": instructions.display_name,
+            "workspace_name": workspace.name,
+            "requester_name": requester_name,
+            "steps": steps,
+            "webhook_url": webhook_url,
+            "webhook_events": instructions.webhook_events,
+        },
+    )
+
+    try:
+        send_mail(
+            subject=subject,
+            message=text_message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[recipient],
+            html_message=html_message,
+            fail_silently=False,
+        )
+        logger.info(
+            f"{instructions.display_name} setup instructions sent to {recipient}"
+        )
+        return True
+    except Exception as e:
+        logger.error(f"Failed to send setup instructions to {recipient}: {e}")
+        return False
+
+
+@login_required
+def email_setup_instructions(
+    request: HttpRequest, provider: str
+) -> HttpResponseRedirect:
+    """Email a provider's webhook setup instructions to a colleague.
+
+    Args:
+        request: The HTTP request object. POST with ``recipient_email``.
+        provider: Provider key from the URL (e.g. "stripe").
+
+    Returns:
+        Redirect to the provider's setup page (or integrations overview
+        on invalid provider/method).
+    """
+    error_redirect = require_post_method(request)
+    if error_redirect:
+        return error_redirect
+
+    workspace, redirect_response = require_admin_role(request)
+    if redirect_response:
+        return redirect_response
+    assert workspace is not None
+
+    instructions = PROVIDER_INSTRUCTIONS.get(provider)
+    if instructions is None:
+        messages.error(
+            request, "Setup instructions are not available for this integration."
+        )
+        return redirect("core:integrations")
+
+    recipient = request.POST.get("recipient_email", "").strip()
+    try:
+        validate_email(recipient)
+    except ValidationError:
+        messages.error(request, "Please enter a valid email address.")
+        return redirect(instructions.integrate_route)
+
+    requester_name = request.user.get_full_name() or request.user.email  # type: ignore[union-attr]
+    sent = send_setup_instructions_email(
+        recipient, workspace, requester_name, instructions
+    )
+    if sent:
+        messages.success(
+            request,
+            f"Setup instructions sent to {recipient}. Once they send you "
+            "the secret, paste it here to finish the connection.",
+        )
+    else:
+        messages.warning(
+            request,
+            f"Could not send the email to {recipient}. Please try again, "
+            "or copy the instructions manually.",
+        )
+    return redirect(instructions.integrate_route)

--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -746,8 +746,10 @@ SHOPIFY_REDIRECT_URI = os.environ.get(
 SHOPIFY_API_VERSION = "2025-01"  # Stable API version for webhook management
 SHOPIFY_SCOPES = "read_orders,read_customers,write_webhooks"
 
-# Base URL for webhook endpoints (used in OAuth callbacks)
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000")
+# Base URL for webhook endpoints (used in OAuth callbacks). Trailing
+# slash stripped so f"{BASE_URL}/webhook/..." concatenations cannot
+# produce a double slash when the env var carries one.
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000").rstrip("/")
 
 # ============================================================================
 # Unified Plugin Configuration

--- a/tests/core/test_email_instructions.py
+++ b/tests/core/test_email_instructions.py
@@ -177,12 +177,14 @@ class TestSendSetupInstructionsEmail:
         assert "Alice Admin" in message.body
         assert "Alice Admin" in message.alternatives[0][0]
 
-    def test_email_never_contains_a_secret_value(self, workspace: Workspace) -> None:
-        """Test instructions ask for a secure channel, not email replies.
+    def test_email_directs_secret_handover_to_secure_channel(
+        self, workspace: Workspace
+    ) -> None:
+        """Test both bodies steer the secret handover off email.
 
-        The email must instruct the colleague where to FIND the secret,
-        never carry one itself, and steer the handover to a secure
-        channel.
+        The email instructs the colleague where to FIND the secret; the
+        wording asserted here is what steers them to hand it over via a
+        secure channel instead of an email reply.
         """
         send_setup_instructions_email(
             "cfo@example.com",

--- a/tests/core/test_email_instructions.py
+++ b/tests/core/test_email_instructions.py
@@ -144,9 +144,10 @@ class TestSendSetupInstructionsEmail:
     """Test the content of the generated instruction email."""
 
     def test_stripe_email_contains_webhook_url_and_events(
-        self, workspace: Workspace
+        self, workspace: Workspace, settings
     ) -> None:
-        """Test the Stripe email carries the URL and every event."""
+        """Test the Stripe email carries the full URL and every event."""
+        settings.BASE_URL = "https://notipus.example.com"
         result = send_setup_instructions_email(
             "cfo@example.com",
             workspace,
@@ -156,7 +157,9 @@ class TestSendSetupInstructionsEmail:
 
         assert result is True
         message = mail.outbox[0]
-        expected_url = f"/webhook/customer/{workspace.uuid}/stripe/"
+        expected_url = (
+            f"https://notipus.example.com/webhook/customer/{workspace.uuid}/stripe/"
+        )
         html_body = message.alternatives[0][0]
         assert expected_url in message.body
         assert expected_url in html_body

--- a/tests/core/test_email_instructions.py
+++ b/tests/core/test_email_instructions.py
@@ -1,0 +1,208 @@
+"""Tests for emailing integration setup instructions to a colleague.
+
+Covers the email_setup_instructions view (permissions, validation,
+provider gating) and the send_setup_instructions_email helper (content
+of the generated email).
+"""
+
+import pytest
+from core.models import Workspace, WorkspaceMember
+from core.views.integrations.email_instructions import (
+    PROVIDER_INSTRUCTIONS,
+    send_setup_instructions_email,
+)
+from django.core import mail
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.fixture(autouse=True)
+def locmem_email(settings) -> None:
+    """Route all emails to the in-memory outbox."""
+    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+
+@pytest.fixture
+def owner_client(owner_user, owner_member) -> Client:
+    """Client logged in as the workspace owner."""
+    client = Client()
+    client.force_login(owner_user)
+    return client
+
+
+@pytest.fixture
+def member_client(regular_user, workspace) -> Client:
+    """Client logged in as a non-admin workspace member."""
+    WorkspaceMember.objects.create(user=regular_user, workspace=workspace, role="user")
+    client = Client()
+    client.force_login(regular_user)
+    return client
+
+
+class TestEmailSetupInstructionsView:
+    """Test the POST endpoint that emails setup instructions."""
+
+    def test_sends_email_for_stripe(
+        self, owner_client: Client, workspace: Workspace
+    ) -> None:
+        """Test a valid request sends one email to the colleague."""
+        response = owner_client.post(
+            reverse("core:email_setup_instructions", args=["stripe"]),
+            {"recipient_email": "cfo@example.com"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrate_stripe")
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == ["cfo@example.com"]
+
+    def test_sends_email_for_chargify(
+        self, owner_client: Client, workspace: Workspace
+    ) -> None:
+        """Test the Chargify variant sends and redirects to its page."""
+        response = owner_client.post(
+            reverse("core:email_setup_instructions", args=["chargify"]),
+            {"recipient_email": "billing@example.com"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrate_chargify")
+        assert len(mail.outbox) == 1
+
+    def test_unknown_provider_rejected(
+        self, owner_client: Client, workspace: Workspace
+    ) -> None:
+        """Test an unsupported provider sends nothing."""
+        response = owner_client.post(
+            reverse("core:email_setup_instructions", args=["shopify"]),
+            {"recipient_email": "cfo@example.com"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrations")
+        assert len(mail.outbox) == 0
+
+    def test_invalid_email_rejected(
+        self, owner_client: Client, workspace: Workspace
+    ) -> None:
+        """Test a malformed recipient address sends nothing."""
+        response = owner_client.post(
+            reverse("core:email_setup_instructions", args=["stripe"]),
+            {"recipient_email": "not-an-email"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrate_stripe")
+        assert len(mail.outbox) == 0
+
+    def test_missing_email_rejected(
+        self, owner_client: Client, workspace: Workspace
+    ) -> None:
+        """Test an empty recipient sends nothing."""
+        response = owner_client.post(
+            reverse("core:email_setup_instructions", args=["stripe"]), {}
+        )
+
+        assert response.status_code == 302
+        assert len(mail.outbox) == 0
+
+    def test_get_method_rejected(
+        self, owner_client: Client, workspace: Workspace
+    ) -> None:
+        """Test GET requests are redirected without sending."""
+        response = owner_client.get(
+            reverse("core:email_setup_instructions", args=["stripe"])
+        )
+
+        assert response.status_code == 302
+        assert len(mail.outbox) == 0
+
+    def test_non_admin_rejected(
+        self, member_client: Client, workspace: Workspace
+    ) -> None:
+        """Test regular members cannot send setup instructions."""
+        response = member_client.post(
+            reverse("core:email_setup_instructions", args=["stripe"]),
+            {"recipient_email": "cfo@example.com"},
+        )
+
+        assert response.status_code == 302
+        assert len(mail.outbox) == 0
+
+    def test_anonymous_rejected(self, db) -> None:
+        """Test unauthenticated users are redirected to login."""
+        response = Client().post(
+            reverse("core:email_setup_instructions", args=["stripe"]),
+            {"recipient_email": "cfo@example.com"},
+        )
+
+        assert response.status_code == 302
+        assert len(mail.outbox) == 0
+
+
+class TestSendSetupInstructionsEmail:
+    """Test the content of the generated instruction email."""
+
+    def test_stripe_email_contains_webhook_url_and_events(
+        self, workspace: Workspace
+    ) -> None:
+        """Test the Stripe email carries the URL and every event."""
+        result = send_setup_instructions_email(
+            "cfo@example.com",
+            workspace,
+            "Alice Admin",
+            PROVIDER_INSTRUCTIONS["stripe"],
+        )
+
+        assert result is True
+        message = mail.outbox[0]
+        expected_url = f"/webhook/customer/{workspace.uuid}/stripe/"
+        assert expected_url in message.body
+        for event in PROVIDER_INSTRUCTIONS["stripe"].webhook_events:
+            assert event in message.body
+        html_body = message.alternatives[0][0]
+        assert expected_url in html_body
+
+    def test_email_names_the_requester(self, workspace: Workspace) -> None:
+        """Test the colleague can see who asked for the setup."""
+        send_setup_instructions_email(
+            "cfo@example.com",
+            workspace,
+            "Alice Admin",
+            PROVIDER_INSTRUCTIONS["stripe"],
+        )
+
+        message = mail.outbox[0]
+        assert "Alice Admin" in message.body
+        assert "Alice Admin" in message.alternatives[0][0]
+
+    def test_email_never_contains_a_secret_value(self, workspace: Workspace) -> None:
+        """Test instructions ask for a secure channel, not email replies.
+
+        The email must instruct the colleague where to FIND the secret,
+        never carry one itself, and steer the handover to a secure
+        channel.
+        """
+        send_setup_instructions_email(
+            "cfo@example.com",
+            workspace,
+            "Alice Admin",
+            PROVIDER_INSTRUCTIONS["stripe"],
+        )
+
+        message = mail.outbox[0]
+        assert "secure channel" in message.body
+        assert "not by replying to this email" in message.body
+
+    def test_subject_names_provider_and_workspace(self, workspace: Workspace) -> None:
+        """Test the subject line is self-explanatory in an inbox."""
+        send_setup_instructions_email(
+            "cfo@example.com",
+            workspace,
+            "Alice Admin",
+            PROVIDER_INSTRUCTIONS["chargify"],
+        )
+
+        subject = mail.outbox[0].subject
+        assert "Chargify" in subject
+        assert workspace.name in subject

--- a/tests/core/test_email_instructions.py
+++ b/tests/core/test_email_instructions.py
@@ -157,11 +157,12 @@ class TestSendSetupInstructionsEmail:
         assert result is True
         message = mail.outbox[0]
         expected_url = f"/webhook/customer/{workspace.uuid}/stripe/"
+        html_body = message.alternatives[0][0]
         assert expected_url in message.body
+        assert expected_url in html_body
         for event in PROVIDER_INSTRUCTIONS["stripe"].webhook_events:
             assert event in message.body
-        html_body = message.alternatives[0][0]
-        assert expected_url in html_body
+            assert event in html_body
 
     def test_email_names_the_requester(self, workspace: Workspace) -> None:
         """Test the colleague can see who asked for the setup."""
@@ -191,8 +192,11 @@ class TestSendSetupInstructionsEmail:
         )
 
         message = mail.outbox[0]
+        html_body = message.alternatives[0][0]
         assert "secure channel" in message.body
         assert "not by replying to this email" in message.body
+        assert "secure channel" in html_body
+        assert "not by replying to this email" in html_body
 
     def test_subject_names_provider_and_workspace(self, workspace: Workspace) -> None:
         """Test the subject line is self-explanatory in an inbox."""


### PR DESCRIPTION
## Problem

The person setting up Notipus is often not the person with access to the company's Stripe (or Chargify/Maxio) account. Today the setup wizard assumes one person can do everything; in practice the admin has to copy-paste the steps into an email or Slack DM themselves.

## Changes

- **"Not the person with Stripe access?" card** on the Stripe and Chargify setup pages: enter a colleague's email, and Notipus sends them the full manual setup steps — dashboard navigation, events to select (Stripe), the workspace webhook URL, and where to find the signing secret.
- **Secrets stay out of email.** The email never carries a secret value; it explicitly instructs the colleague to hand the signing secret back to the requesting admin over a secure channel (password manager), *not by replying*, and names the requester so they know who to contact.
- New `email_setup_instructions` view (`integrate/<provider>/email-instructions/`): admin-only, POST-only, recipient validated with `validate_email`, unsupported providers rejected. Provider copy lives in a typed `PROVIDER_INSTRUCTIONS` registry (`SetupStep`/`ProviderInstructions` dataclasses) reusing `STRIPE_WEBHOOK_EVENTS` from the setup view, so email and wizard can't drift apart.
- New `core/emails/setup_instructions.html.j2` template modeled on the invitation email, plus a plain-text version; sending mirrors `send_invitation_email` (boolean result → messages framework success/warning).
- **Shopify deliberately unsupported**: its OAuth flow registers webhooks automatically, so there are no instructions to relay — a workspace invitation is the right tool there (noted in the module docstring).

## Testing

- 12 new tests in `tests/core/test_email_instructions.py`: view permissions (anonymous, non-admin, GET), recipient validation, provider gating, and email content (webhook URL + all Stripe events in both text and HTML bodies, requester named, secure-channel wording, subject line).
- Full suite: 1867 passed; ruff and `mypy app/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)