### PR TITLE
fix: stop double-emitting every log record in production

### DIFF
--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -637,22 +637,29 @@ LOGGING = {
             "class": "logging.StreamHandler",
         },
     },
+    # propagate=False everywhere: the root logger also has the console
+    # handler, so propagation would emit every record twice (seen in prod
+    # as duplicated, interleaved tracebacks in the Fly logs).
     "loggers": {
         "webhooks": {
             "handlers": ["console"],
             "level": "DEBUG" if DEBUG else "INFO",
+            "propagate": False,
         },
         "core": {
             "handlers": ["console"],
             "level": "DEBUG" if DEBUG else "INFO",
+            "propagate": False,
         },
         "django": {
             "handlers": ["console"],
             "level": "DEBUG" if DEBUG else "WARNING",
+            "propagate": False,
         },
         "django.contrib.staticfiles": {
             "handlers": ["console"],
             "level": "ERROR",  # Always silence static file duplicate warnings
+            "propagate": False,
         },
     },
     # Set root logger level based on DEBUG

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,28 @@
+"""Tests for the production logging configuration.
+
+The root logger has the console handler attached, so any named logger
+that both attaches the console handler and propagates to root emits
+every record twice (seen in prod as duplicated, interleaved tracebacks
+in the Fly logs).
+"""
+
+from django_notipus.settings import LOGGING
+
+
+def test_root_logger_has_console_handler() -> None:
+    """Root keeps a console handler so unnamed loggers still emit."""
+    assert "console" in LOGGING["root"]["handlers"]
+
+
+def test_named_loggers_with_handlers_do_not_propagate() -> None:
+    """Loggers with their own handler must not also propagate to root.
+
+    Propagation plus a root handler means double emission: the record is
+    handled once by the named logger's handler and again by root's.
+    """
+    for name, config in LOGGING["loggers"].items():
+        if config.get("handlers"):
+            assert config.get("propagate") is False, (
+                f"Logger {name!r} attaches handlers and propagates to the "
+                "root logger, so every record it emits is printed twice"
+            )


### PR DESCRIPTION
## Summary
Every `core.*` and `webhooks.*` log record is currently printed **twice** in production. The named loggers in `LOGGING` each attach the `console` handler and also propagate (the default) to the root logger, which has the same handler — so each record is handled twice. In the Fly logs the two copies of multi-line tracebacks arrive interleaved, which is why prod tracebacks look scrambled and duplicated.

## Fix
Set `propagate: False` on every named logger that attaches its own handler (`webhooks`, `core`, `django`, `django.contrib.staticfiles`). Root keeps its console handler so unnamed loggers still emit once.

## Testing
- New `tests/test_logging_config.py` asserts no configured logger both attaches handlers and propagates to root.
- Full suite: 1877 passed. Tests use their own `LOGGING` in `test_settings`, so `caplog`-based tests are unaffected.
- ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)