### PR TITLE
chore: silence the django.security.DisallowedHost logger

### DIFF
--- a/app/django_notipus/settings.py
+++ b/app/django_notipus/settings.py
@@ -661,6 +661,13 @@ LOGGING = {
             "level": "ERROR",  # Always silence static file duplicate warnings
             "propagate": False,
         },
+        # Scanners probing unallowed hostnames (e.g. *.fly.dev) trigger a
+        # DisallowedHost log per hit; the 400 response is the correct and
+        # sufficient outcome, so drop the log noise entirely.
+        "django.security.DisallowedHost": {
+            "handlers": [],
+            "propagate": False,
+        },
     },
     # Set root logger level based on DEBUG
     "root": {

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -26,3 +26,14 @@ def test_named_loggers_with_handlers_do_not_propagate() -> None:
                 f"Logger {name!r} attaches handlers and propagates to the "
                 "root logger, so every record it emits is printed twice"
             )
+
+
+def test_disallowed_host_logger_is_silenced() -> None:
+    """DisallowedHost records must be dropped entirely.
+
+    Scanners probing unallowed hostnames (e.g. *.fly.dev) would otherwise
+    log a full traceback per hit; the 400 response is outcome enough.
+    """
+    config = LOGGING["loggers"]["django.security.DisallowedHost"]
+    assert config["handlers"] == []
+    assert config["propagate"] is False


### PR DESCRIPTION
## Summary
Requests with unallowed Host headers (mostly scanners enumerating `*.fly.dev`, e.g. the 16:20 UTC `notipus.fly.dev` hit in today's Fly logs) log a full `DisallowedHost` traceback each time. Per discussion, the decision is to keep `ALLOWED_HOSTS` narrow (notipus.com only) and drop the log noise: the 400 response Django returns is the correct and sufficient outcome.

## Change
- Add a `django.security.DisallowedHost` logger with no handlers and `propagate: False` to the production `LOGGING` config.
- Regression test asserting the logger stays silenced.

## Testing
- `tests/test_logging_config.py`: 3 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)