### PR TITLE
fix(slack): stop rendering the placeholder $0.00 on trial notifications

### DIFF
--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -502,10 +502,12 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
 
         if is_ecommerce:
             return self._format_ecommerce_details(payment)
-        return self._format_subscription_details(payment, n.headline)
+        return self._format_subscription_details(
+            payment, n.headline, is_trial=n.type in TRIAL_NOTIFICATION_TYPES
+        )
 
     def _format_subscription_details(
-        self, payment: PaymentInfo, headline: str
+        self, payment: PaymentInfo, headline: str, is_trial: bool = False
     ) -> dict[str, Any] | None:
         """Format SaaS subscription payment details as a two-column grid.
 
@@ -515,10 +517,18 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         (e.g. "New subscription!") get the full amount-with-ARR field so
         the money is never lost.
 
+        Trials are the exception: no payment has occurred, and the 0 the
+        parser reports is Stripe's placeholder invoice, not a price - so
+        an "Amount $0.00" field would be showing data we don't have. The
+        post-trial plan price is surfaced by the trial insight instead.
+        A trial that does carry a real amount (e.g. trial_converted's
+        first charge) still shows it.
+
         Args:
             payment: PaymentInfo object.
             headline: The notification headline, used to detect whether
                 the amount is already visible.
+            is_trial: Whether the notification is a trial event.
 
         Returns:
             Slack section block dict with a ``fields`` grid, or None
@@ -531,7 +541,9 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
 
         amount_display: str = format_money(payment.amount, payment.currency)
         arr = payment.get_arr()
-        if amount_display not in headline:
+        if is_trial and not payment.amount:
+            pass  # placeholder $0, not a payment - show no amount at all
+        elif amount_display not in headline:
             # Sanitized because format_money falls back to the raw
             # payload currency code for unknown currencies.
             fields.append(f"*Amount*\n{safe_mrkdwn(payment.format_amount_with_arr())}")

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -1511,3 +1511,88 @@ class TestSlackDestinationPluginMetadata:
             provider_display="Segment",
         )
         assert usage_notification.is_payment_event is False
+
+
+class TestTrialAmountSuppression:
+    """Trial events must not render Stripe's placeholder $0 as an amount."""
+
+    def _trial_notification(
+        self, notification_type: NotificationType, amount: float
+    ) -> RichNotification:
+        """Build a trial notification with the given amount.
+
+        Args:
+            notification_type: The trial notification type to use.
+            amount: The parsed payment amount.
+
+        Returns:
+            RichNotification resembling a Stripe trial event.
+        """
+        return RichNotification(
+            type=notification_type,
+            severity=NotificationSeverity.WARNING,
+            headline="Trial ending soon",
+            headline_icon="warning",
+            provider="stripe",
+            provider_display="Stripe",
+            payment=PaymentInfo(
+                amount=amount,
+                currency="USD",
+                interval="monthly",
+                plan_name="Pro",
+                subscription_id="sub_trial123",
+            ),
+        )
+
+    def _all_field_text(self, result: dict[str, Any]) -> str:
+        """Concatenate every block field and text in the formatted output."""
+        chunks: list[str] = []
+        for block in get_blocks(result):
+            for f in block.get("fields", []):
+                chunks.append(f["text"])
+            text = block.get("text")
+            if isinstance(text, dict):
+                chunks.append(text["text"])
+        return "\n".join(chunks)
+
+    def test_trial_ending_zero_amount_not_shown(
+        self, formatter: SlackDestinationPlugin
+    ) -> None:
+        """A trial's placeholder $0.00 must not appear anywhere."""
+        n = self._trial_notification(NotificationType.TRIAL_ENDING, 0.0)
+        text = self._all_field_text(formatter.format(n))
+        assert "$0.00" not in text
+        assert "*Amount*" not in text
+
+    def test_trial_started_zero_amount_not_shown(
+        self, formatter: SlackDestinationPlugin
+    ) -> None:
+        """trial_started with the placeholder $0 hides the amount too."""
+        n = self._trial_notification(NotificationType.TRIAL_STARTED, 0.0)
+        text = self._all_field_text(formatter.format(n))
+        assert "$0.00" not in text
+
+    def test_trial_zero_amount_keeps_plan_and_subscription(
+        self, formatter: SlackDestinationPlugin
+    ) -> None:
+        """Suppressing the amount must not drop the other detail fields."""
+        n = self._trial_notification(NotificationType.TRIAL_ENDING, 0.0)
+        text = self._all_field_text(formatter.format(n))
+        assert "Pro" in text
+        assert "sub_trial123" in text
+
+    def test_trial_with_real_amount_still_shows_it(
+        self, formatter: SlackDestinationPlugin
+    ) -> None:
+        """A trial event carrying a real charge keeps its amount."""
+        n = self._trial_notification(NotificationType.TRIAL_CONVERTED, 49.0)
+        text = self._all_field_text(formatter.format(n))
+        assert "$49.00" in text
+
+    def test_free_plan_outside_trial_still_shows_zero(
+        self, formatter: SlackDestinationPlugin
+    ) -> None:
+        """A genuine $0 plan on a non-trial event is real data and stays."""
+        n = self._trial_notification(NotificationType.SUBSCRIPTION_CREATED, 0.0)
+        text = self._all_field_text(formatter.format(n))
+        assert "$0.00" in text


### PR DESCRIPTION
## Summary
Reported by Viktor: Slack still shows `Trial ending soon / Stripe • Trial / Amount $0.00`. Trial events parse to amount 0 by design (no payment has occurred — `stripe.py` returns 0 for `trial_ending` and trialing `subscription_created`), but `_format_subscription_details` rendered that placeholder as a literal **Amount $0.00**, violating the "never show guessed data" rule.

## Fix
- `_format_subscription_details` gains an `is_trial` flag (driven by the existing `TRIAL_NOTIFICATION_TYPES` set) and omits the Amount/ARR field when a trial's amount is 0.
- Plan and Subscription fields still render; the post-trial price is already covered by the trial insight ("N-day trial, then $X/mo").
- Deliberately narrow: `trial_converted` with a real first charge keeps its amount, and a genuine $0 plan on a non-trial event still shows $0.00 (that's real data).

## Testing
- 5 new tests in `tests/test_slack_formatter.py` covering suppression, field preservation, real-charge trials, and free non-trial plans.
- Full suite: 1885 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)