### PR TITLE
chore(docker): migrate to Chainguard Python images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 # syntax=docker/dockerfile:1
-# Use the official Python image
-FROM python:3.14-slim
+# Build stage: Chainguard's -dev variant includes a shell and apk for build
+# tooling. Both stages must use the same tag so the venv built here runs on
+# the same interpreter version in the runtime stage.
+FROM cgr.dev/chainguard/python:latest-dev AS builder
+
+USER root
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 # Precompile dependencies to .pyc at build time so container boots skip
 # bytecode compilation (~1.1s saved per cold start)
 ENV UV_COMPILE_BYTECODE=1
-
-# Git SHA for Sentry release tracking (passed as build arg)
-ARG GIT_SHA=unknown
-ENV SENTRY_RELEASE=${GIT_SHA}
+# Build the venv against the image's interpreter so its symlinks resolve to
+# the same path in the runtime stage
+ENV UV_PYTHON=/usr/bin/python
 
 # Copy uv binary from official image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -20,9 +23,6 @@ COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/
 
 # Set the working directory
 WORKDIR /app
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y libpq-dev gcc redis-tools postgresql-client && rm -rf /var/lib/apt/lists/*
 
 # Copy dependency files
 COPY pyproject.toml uv.lock /app/
@@ -54,8 +54,27 @@ RUN uv run --no-dev python manage.py collectstatic --noinput
 # Precompile application code to bytecode (deps are handled by UV_COMPILE_BYTECODE)
 RUN /app/.venv/bin/python -m compileall -q -x '(\.venv|node_modules)' /app
 
+# Drop frontend build inputs so they don't ship in the runtime image
+RUN rm -rf /app/node_modules /app/src /app/package.json /app/bun.lock /app/postcss.config.js
+
+# Runtime stage: distroless (no shell, no package manager), runs as nonroot
+FROM cgr.dev/chainguard/python:latest
+
+ENV PYTHONUNBUFFERED=1
+
+# Git SHA for Sentry release tracking (passed as build arg)
+ARG GIT_SHA=unknown
+ENV SENTRY_RELEASE=${GIT_SHA}
+
+WORKDIR /app
+COPY --from=builder /app /app
+
 # Port that the application will use
 EXPOSE 8080
+
+# The base image's entrypoint is `python`; reset it so CMD (and
+# docker-compose `command:` overrides) execute as-is
+ENTRYPOINT []
 
 # Command to start the server
 # Invoke uvicorn from the venv directly: `uv run` re-validates the lockfile and

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # syntax=docker/dockerfile:1
+# Single source of truth for the Chainguard Python tag: the builder and
+# runtime stages must track the same release so the venv built in the
+# builder runs on the same interpreter version at runtime.
+ARG PYTHON_TAG=latest
+
 # Build stage: Chainguard's -dev variant includes a shell and apk for build
-# tooling. Both stages must use the same tag so the venv built here runs on
-# the same interpreter version in the runtime stage.
-FROM cgr.dev/chainguard/python:latest-dev AS builder
+# tooling.
+FROM cgr.dev/chainguard/python:${PYTHON_TAG}-dev AS builder
 
 USER root
 
@@ -58,7 +62,7 @@ RUN /app/.venv/bin/python -m compileall -q -x '(\.venv|node_modules)' /app
 RUN rm -rf /app/node_modules /app/src /app/package.json /app/bun.lock /app/postcss.config.js
 
 # Runtime stage: distroless (no shell, no package manager), runs as nonroot
-FROM cgr.dev/chainguard/python:latest
+FROM cgr.dev/chainguard/python:${PYTHON_TAG}
 
 ENV PYTHONUNBUFFERED=1
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,8 +2,8 @@
 # Usage: docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
 # This file provides development-specific overrides for the multi-container setup
 
-# Mount source directories individually so the image's /app/.venv (and built
-# static assets) stay visible — a blanket ./app:/app mount would hide them.
+# Mount source directories individually so the image's /app/.venv stays
+# visible — a blanket ./app:/app mount would hide it.
 x-dev-volumes: &dev-volumes
   - ./app/core:/app/core
   - ./app/django_notipus:/app/django_notipus

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,10 @@ x-dev-volumes: &dev-volumes
   - ./app/plugins:/app/plugins
   - ./app/webhooks:/app/webhooks
   - ./app/manage.py:/app/manage.py
+  # Live static assets (js/, img/, and bun-generated dist/). This hides the
+  # image's built dist/ — run `bun run dev` (or `bun run build`) on the host
+  # so CSS/fonts exist locally.
+  - ./app/static:/app/static
 
 services:
   # Override migration service for development

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,20 +2,27 @@
 # Usage: docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
 # This file provides development-specific overrides for the multi-container setup
 
+# Mount source directories individually so the image's /app/.venv (and built
+# static assets) stay visible — a blanket ./app:/app mount would hide them.
+x-dev-volumes: &dev-volumes
+  - ./app/core:/app/core
+  - ./app/django_notipus:/app/django_notipus
+  - ./app/plugins:/app/plugins
+  - ./app/webhooks:/app/webhooks
+  - ./app/manage.py:/app/manage.py
+
 services:
   # Override migration service for development
   migration:
-    volumes:
-      - ./app:/app  # Live code reloading for migration files
+    volumes: *dev-volumes
 
   # Override Django service for development
   django:
-    # Use development server instead of gunicorn for auto-reload
-    command: ["uv", "run", "python", "manage.py", "runserver", "0.0.0.0:8000"]
+    # Use Django's dev server for auto-reload; invoke the venv's python
+    # directly — the Chainguard runtime image has no uv (or shell)
+    command: ["/app/.venv/bin/python", "manage.py", "runserver", "0.0.0.0:8000"]
     environment:
       - DEBUG=True
-    # Enable live code reloading for development
-    volumes:
-      - ./app:/app
+    volumes: *dev-volumes
     ports:
       - "8000:8000"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "django>=5.2.16,<6.0.0",
     "requests>=2.34.2,<3.0.0",
     "uvicorn[standard]>=0.51.0",
-    "psycopg2>=2.9.12,<3.0.0",
     "stripe>=15.3.1,<16.0.0",
     "shopifyapi>=12.7.0,<13.0.0",
     "django-allauth>=65.18.0,<66.0.0",
@@ -20,6 +19,7 @@ dependencies = [
     "sentry-sdk[django]>=2.66.0",
     "disposable-email-domains>=0.0.227",
     "cryptography>=43.0.0",
+    "psycopg2-binary>=2.9.12,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -852,7 +852,7 @@ dependencies = [
     { name = "disposable-email-domains" },
     { name = "django" },
     { name = "django-allauth" },
-    { name = "psycopg2" },
+    { name = "psycopg2-binary" },
     { name = "redis" },
     { name = "requests" },
     { name = "sentry-sdk", extra = ["django"] },
@@ -888,7 +888,7 @@ requires-dist = [
     { name = "disposable-email-domains", specifier = ">=0.0.227" },
     { name = "django", specifier = ">=5.2.16,<6.0.0" },
     { name = "django-allauth", specifier = ">=65.18.0,<66.0.0" },
-    { name = "psycopg2", specifier = ">=2.9.12,<3.0.0" },
+    { name = "psycopg2-binary", specifier = ">=2.9.12,<3.0.0" },
     { name = "redis", specifier = ">=8.0.1,<9.0.0" },
     { name = "requests", specifier = ">=2.34.2,<3.0.0" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.66.0" },
@@ -988,14 +988,44 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2"
+name = "psycopg2-binary"
 version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/bc/f66df707ed1aec949fbf24e4460e4f4277a7ba23cdadb3965bb1f634ddb9/psycopg2-2.9.12.tar.gz", hash = "sha256:1dedb1c7a1d8552c4a6044c6b1c41a52e6a8e2d144af83eccac758076b1b7c15", size = 379683, upload-time = "2026-04-20T23:36:11.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/b2/7319dc488444b1dfe9ce89c4440df1d5425e2579e6ce9a63e2b70f648491/psycopg2-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:83d48e66e18c301d832e93c984a7bcbc0f4ac3bb79e2137e3bc335978c756dc0", size = 2757068, upload-time = "2026-04-20T23:33:20.664Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ab/03403779a251ca14a7f1b07a41c7aa735fd451f0aebe4c4f901a231167a4/psycopg2-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:3d23e684927d37b95cee9a943f6927b04ae2fdcd056fd0e2a30929ee89fee5a9", size = 2757176, upload-time = "2026-04-20T23:33:23.577Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4a/a3566f77501c21a6c2a1fc234dbe5dff74a86e3f150ef070e4ffb835e7f9/psycopg2-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:a73d5513bfe929c56555006c7a9cc7ae6e4276aa99dd2b1e2544eb8bb54f8b23", size = 2848588, upload-time = "2026-04-20T23:33:25.983Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Migrates the app image from `python:3.14-slim` to Chainguard's Wolfi-based Python images with a two-stage build:

- **Builder** (`cgr.dev/chainguard/python:latest-dev`): has a shell/apk; installs the venv with uv, builds Tailwind assets with bun, runs `collectstatic`, and precompiles bytecode. Deletes `node_modules`/frontend sources before handoff so they no longer ship in production.
- **Runtime** (`cgr.dev/chainguard/python:latest`): distroless — no shell, no package manager, runs as nonroot (uid 65532). Only `/app` is copied in. `ENTRYPOINT` is reset because the base image's entrypoint is `python`, which would otherwise prepend itself to `CMD` and compose `command:` overrides.

Supporting changes:

- **`psycopg2` → `psycopg2-binary`** (same version pin, same importable module, no code changes). The bundled libpq removes the need for `gcc`/`libpq-dev` at build time and `libpq` at runtime — the distroless image can't `apt install` anything. Nothing imports `psycopg2` directly; only Django's `django.db.backends.postgresql` backend uses it.
- **Dropped `redis-tools` and `postgresql-client`** from the app image — the compose healthchecks that use them run in the db/redis containers, not this one.
- **`docker-compose.dev.yml`**: the override ran `uv run ...` (uv no longer exists in the runtime image) and its blanket `./app:/app` mount hid `/app/.venv` (pre-existing bug). It now mounts source directories individually and invokes the venv python directly.

## Verification

- Image builds clean; final size 358MB
- Runtime confirmed: Python 3.14.6 as uid 65532, `psycopg2` imports, `manage.py check` passes, uvicorn boots via image CMD and serves
- Full test suite: 1885 passed

## Deployment notes

1. **Tag pinning**: Chainguard's free tier only offers `latest`/`latest-dev`, so the Python version floats with their releases. Pin by digest (or paid versioned tags) if reproducibility matters.
2. **Fly.io**: `fly.toml` lives in the `FLY_CONFIG` secret so it isn't in this diff. If it has a `release_command` using `uv run`, bare `python`, or shell syntax, it must switch to exec-style `/app/.venv/bin/python ...` — there is no shell or uv in the image now. `fly ssh console` into the app image also no longer provides a shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)