### PR TITLE
fix(slack): give trial-ending notifications context and identity

### DIFF
--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -842,6 +842,42 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
             "elements": [{"type": "mrkdwn", "text": " · ".join(links)}],
         }
 
+    def _customer_identity_line(
+        self, customer: CustomerInfo, icon_prefix: str
+    ) -> str | None:
+        """Build the identity element of the customer footer.
+
+        Prefers the email (with compact domain-type badges, e.g.
+        ":bust_in_silhouette: jane@stanford.edu · :mortar_board:
+        Education"), then the name. Last resort is company_name, which
+        carries get_display_name()'s fallback chain ending at the
+        provider customer id (e.g. "cus_...") - an ugly-but-proven
+        identifier still beats a notification that names nobody (Stripe
+        trial_will_end before any invoice has cached the email).
+
+        Args:
+            customer: CustomerInfo object.
+            icon_prefix: Person-icon prefix, or empty string when a
+                person section already shows it.
+
+        Returns:
+            Identity string, or None when nothing identifies the
+            customer.
+        """
+        if customer.email:
+            email_parts = [f"{icon_prefix}{safe_mrkdwn(customer.email)}"]
+            email_parts.extend(
+                EMAIL_TAG_BADGES[tag]
+                for tag in customer.email_tags
+                if tag in EMAIL_TAG_BADGES
+            )
+            return " · ".join(email_parts)
+        if customer.name:
+            return f"{icon_prefix}{safe_mrkdwn(customer.name)}"
+        if customer.company_name:
+            return f"{icon_prefix}{safe_mrkdwn(customer.company_name)}"
+        return None
+
     def _format_customer_footer(
         self, customer: CustomerInfo, include_icon: bool = True
     ) -> dict[str, Any] | None:
@@ -859,20 +895,9 @@ class SlackDestinationPlugin(BaseDestinationPlugin):
         elements: list[str] = []
         icon_prefix = ":bust_in_silhouette: " if include_icon else ""
 
-        # Email, with compact domain-type badges (e.g.
-        # ":bust_in_silhouette: jane@stanford.edu · :mortar_board: Education")
-        if customer.email:
-            email_parts = [f"{icon_prefix}{safe_mrkdwn(customer.email)}"]
-            email_parts.extend(
-                EMAIL_TAG_BADGES[tag]
-                for tag in customer.email_tags
-                if tag in EMAIL_TAG_BADGES
-            )
-            elements.append(" · ".join(email_parts))
-
-        # Name if no email
-        if not customer.email and customer.name:
-            elements.append(f"{icon_prefix}{safe_mrkdwn(customer.name)}")
+        identity = self._customer_identity_line(customer, icon_prefix)
+        if identity:
+            elements.append(identity)
 
         # Tenure (no emoji for cleaner look)
         if customer.tenure_display:

--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -523,6 +523,19 @@ class StripeSourcePlugin(BaseSourcePlugin):
             0 (no payment for trials).
         """
         data["_is_trial"] = True
+        self._stage_trial_fields(data)
+        return 0  # No payment for trials
+
+    def _stage_trial_fields(self, data: dict[str, Any]) -> None:
+        """Extract trial fields from a subscription payload into staging keys.
+
+        Shared by trial_started (via _flag_as_trial) and trial_ending,
+        whose payloads are both full subscription objects; the staged
+        keys feed _add_trial_metadata.
+
+        Args:
+            data: Event data dictionary (mutated with staged trial fields).
+        """
         data["_trial_end"] = data.get("trial_end")
         # Sum item amounts: top-level plan is null on multi-item subscriptions
         data["_plan_amount_cents"] = self._extract_subscription_amount(data)
@@ -532,8 +545,6 @@ class StripeSourcePlugin(BaseSourcePlugin):
         trial_end = data.get("trial_end")
         if trial_start and trial_end:
             data["_trial_days"] = (trial_end - trial_start) // 86400
-
-        return 0  # No payment for trials
 
     def _handle_subscription_updated(self, data: dict[str, Any]) -> int:
         """Handle subscription_updated event with change detection.
@@ -704,6 +715,16 @@ class StripeSourcePlugin(BaseSourcePlugin):
         if data.get("_is_trial"):
             self._add_trial_metadata(metadata, data)
 
+        # trial_will_end payloads are full subscription objects too, but
+        # they must not go through _flag_as_trial: its _is_trial flag
+        # would rename the event to trial_started in parse_webhook.
+        # Stage and attach the same trial metadata so the notification
+        # can say when the trial ends and what price it converts to,
+        # instead of a bare "Trial ending soon" with no context.
+        if event_type == "trial_ending":
+            self._stage_trial_fields(data)
+            self._add_trial_metadata(metadata, data)
+
         # Add change direction for subscription updates (upgrade/downgrade)
         if data.get("_change_direction"):
             metadata["change_direction"] = data["_change_direction"]
@@ -714,6 +735,7 @@ class StripeSourcePlugin(BaseSourcePlugin):
             "subscription_updated",
             "subscription_deleted",
             "trial_started",
+            "trial_ending",
         }
         if event_type in subscription_events:
             self._add_subscription_metadata(metadata, event_type, data)

--- a/app/webhooks/services/insight_detector.py
+++ b/app/webhooks/services/insight_detector.py
@@ -31,7 +31,9 @@ Per-provider signal sources (update this list when adding a detector):
   Stripe = none (anniversary silent);
   Chargify and Shopify = customer.created_at.
 * trial metadata:
-  Stripe = parser-derived;
+  Stripe = parser-derived (subscription_created with status "trialing"
+  and trial_will_end both carry the full subscription object, so
+  trial_end and the post-trial plan price are proven fields);
   Chargify = parser-derived (signup_success with state "trialing");
   Shopify = n/a.
 * failure attempt count:
@@ -156,6 +158,7 @@ class InsightDetector:
     ICONS = {
         "first_payment": "new",
         "trial_started": "rocket",
+        "trial_ending": "clock",
         "trial_converted": "celebration",
         "ltv_milestone": "celebration",
         "anniversary": "celebration",
@@ -191,6 +194,7 @@ class InsightDetector:
         detectors = [
             self._detect_initial_payment_failure,
             self._detect_trial_started,
+            self._detect_trial_ending,
             self._detect_trial_converted,
             self._detect_first_payment,
             self._detect_ltv_milestone,
@@ -352,6 +356,50 @@ class InsightDetector:
             icon=self.ICONS["trial_started"],
             text="New trial - Welcome aboard!",
         )
+
+    def _detect_trial_ending(
+        self, event_data: dict[str, Any], customer_data: dict[str, Any]
+    ) -> InsightInfo | None:
+        """Surface when the trial ends and the price it converts to.
+
+        Stripe's customer.subscription.trial_will_end payload is a full
+        subscription object, so trial_end and the plan price are proven
+        fields; the insight degrades to whichever parts are present and
+        stays silent when both are missing rather than guessing.
+
+        Args:
+            event_data: Event data dictionary.
+            customer_data: Customer data dictionary (unused but required
+                for interface).
+
+        Returns:
+            InsightInfo for the ending trial or None.
+        """
+        _ = customer_data  # unused
+        if event_data.get("type", "") != "trial_ending":
+            return None
+
+        metadata = event_data.get("metadata") or {}
+        end_date = self._format_short_date(metadata.get("trial_end"))
+
+        money = None
+        # "is not None" so a $0 post-trial plan (free tier) still renders
+        plan_amount = metadata.get("plan_amount")
+        if plan_amount is not None:
+            currency = event_data.get("currency") or "USD"
+            suffix = interval_suffix(metadata.get("billing_period"))
+            money = f"{format_money(_to_float(plan_amount), currency)}{suffix}"
+
+        if end_date and money:
+            text = f"Trial ends {end_date}, then {money}"
+        elif end_date:
+            text = f"Trial ends {end_date}"
+        elif money:
+            text = f"Converts to {money} at trial end"
+        else:
+            return None
+
+        return InsightInfo(icon=self.ICONS["trial_ending"], text=text)
 
     def _detect_initial_payment_failure(
         self, event_data: dict[str, Any], customer_data: dict[str, Any]

--- a/tests/test_insight_detector.py
+++ b/tests/test_insight_detector.py
@@ -695,6 +695,131 @@ class TestTrialConvertedDetection:
         assert result is None
 
 
+class TestTrialEndingDetection:
+    """Test the trial_ending insight (end date and post-trial price).
+
+    Stripe's trial_will_end payload is a full subscription object, so
+    trial_end and the plan price are proven fields the parser stages
+    into metadata; the insight must degrade gracefully when they are
+    missing rather than guessing.
+    """
+
+    def test_full_insight_with_date_and_price(self, detector: InsightDetector) -> None:
+        """Test end date plus post-trial price renders the full insight."""
+        event = {
+            "type": "trial_ending",
+            "customer_id": "cus_123",
+            "amount": 0,
+            "currency": "USD",
+            "metadata": {
+                "is_trial": True,
+                "trial_end": 1770537317,  # Feb 8, 2026 UTC
+                "plan_amount": 26.60,
+                "billing_period": "monthly",
+            },
+        }
+
+        result = detector.detect(event, {})
+
+        assert result is not None
+        assert result.text == "Trial ends Feb 8, then $26.60/mo"
+        assert result.icon == "clock"
+
+    def test_date_only_when_plan_amount_missing(
+        self, detector: InsightDetector
+    ) -> None:
+        """Test a missing plan amount degrades to the end date alone."""
+        event = {
+            "type": "trial_ending",
+            "customer_id": "cus_123",
+            "amount": 0,
+            "metadata": {"is_trial": True, "trial_end": 1770537317},
+        }
+
+        result = detector._detect_trial_ending(event, {})
+
+        assert result is not None
+        assert result.text == "Trial ends Feb 8"
+
+    def test_price_only_when_trial_end_missing(self, detector: InsightDetector) -> None:
+        """Test a missing end date degrades to the conversion price alone."""
+        event = {
+            "type": "trial_ending",
+            "customer_id": "cus_123",
+            "amount": 0,
+            "currency": "USD",
+            "metadata": {
+                "is_trial": True,
+                "plan_amount": 26.60,
+                "billing_period": "monthly",
+            },
+        }
+
+        result = detector._detect_trial_ending(event, {})
+
+        assert result is not None
+        assert result.text == "Converts to $26.60/mo at trial end"
+
+    def test_zero_plan_amount_still_renders(self, detector: InsightDetector) -> None:
+        """Test a $0 post-trial plan (free tier) is not treated as missing."""
+        event = {
+            "type": "trial_ending",
+            "customer_id": "cus_123",
+            "amount": 0,
+            "currency": "USD",
+            "metadata": {
+                "is_trial": True,
+                "trial_end": 1770537317,
+                "plan_amount": 0.0,
+                "billing_period": "monthly",
+            },
+        }
+
+        result = detector._detect_trial_ending(event, {})
+
+        assert result is not None
+        assert result.text == "Trial ends Feb 8, then $0.00/mo"
+
+    def test_silent_when_both_signals_missing(self, detector: InsightDetector) -> None:
+        """Test the detector stays silent with neither date nor price."""
+        event = {
+            "type": "trial_ending",
+            "customer_id": "cus_123",
+            "amount": 0,
+            "metadata": {"is_trial": True},
+        }
+
+        result = detector._detect_trial_ending(event, {})
+
+        assert result is None
+
+    def test_ignores_other_event_types(self, detector: InsightDetector) -> None:
+        """Test non-trial-ending events never trigger the insight."""
+        event = {
+            "type": "trial_started",
+            "customer_id": "cus_123",
+            "amount": 0,
+            "metadata": {"trial_end": 1770537317, "plan_amount": 26.60},
+        }
+
+        result = detector._detect_trial_ending(event, {})
+
+        assert result is None
+
+    def test_none_metadata_does_not_crash(self, detector: InsightDetector) -> None:
+        """Test that an explicit metadata=None is handled gracefully."""
+        event = {
+            "type": "trial_ending",
+            "customer_id": "cus_123",
+            "amount": 0,
+            "metadata": None,
+        }
+
+        result = detector._detect_trial_ending(event, {})
+
+        assert result is None
+
+
 class TestInitialPaymentFailureDetection:
     """Test surfacing of a payment_failure folded into an aggregated event."""
 

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -813,6 +813,42 @@ class TestSlackDestinationPluginCustomerFooter:
 
         assert "Since Mar 2024" in text
 
+    def test_customer_footer_falls_back_to_customer_id(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test the footer falls back to company_name identity.
+
+        When the payload carried neither email nor name (e.g. Stripe
+        trial_will_end before any invoice cached the address),
+        company_name holds get_display_name()'s fallback chain ending at
+        the provider customer id - the footer must show it so the
+        message still says who it is about.
+        """
+        basic_notification.customer = CustomerInfo(
+            email="",
+            name=None,
+            company_name="cus_TestCustomer123",
+        )
+        result = formatter.format(basic_notification)
+
+        context_blocks = [b for b in get_blocks(result) if b["type"] == "context"]
+        footer_text = str(context_blocks[-1].get("elements", [{}])[0].get("text", ""))
+
+        assert "cus_TestCustomer123" in footer_text
+        assert ":bust_in_silhouette:" in footer_text
+
+    def test_customer_footer_id_fallback_not_used_with_email(
+        self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
+    ) -> None:
+        """Test the identity fallback stays silent when an email exists."""
+        result = formatter.format(basic_notification)
+
+        context_blocks = [b for b in get_blocks(result) if b["type"] == "context"]
+        footer_text = str(context_blocks[-1].get("elements", [{}])[0].get("text", ""))
+
+        assert "alice@acme.com" in footer_text
+        assert "Acme Inc" not in footer_text
+
     def test_customer_footer_icon_suppressed_with_person(
         self, formatter: SlackDestinationPlugin, basic_notification: RichNotification
     ) -> None:

--- a/tests/test_stripe_realistic_scenarios.py
+++ b/tests/test_stripe_realistic_scenarios.py
@@ -428,6 +428,159 @@ class TestTrialSignupIntegration:
 
 
 @pytest.mark.django_db
+class TestTrialEndingIntegration:
+    """Integration test: trial_will_end webhook flow.
+
+    trial_will_end fires ~3 days before a trial ends and its payload is
+    a full subscription object, but it carries no customer email. The
+    notification must still say when the trial ends, what it converts
+    to, and who it is about (customer id fallback) - not a bare
+    "Trial ending soon" with an empty body.
+    """
+
+    @pytest.fixture
+    def stripe_plugin(self) -> StripeSourcePlugin:
+        """Create a Stripe plugin instance."""
+        return StripeSourcePlugin()
+
+    @pytest.fixture
+    def event_processor(self) -> EventProcessor:
+        """Create an event processor instance."""
+        return EventProcessor()
+
+    @pytest.fixture
+    def trial_will_end_payload(self) -> dict[str, Any]:
+        """Realistic customer.subscription.trial_will_end webhook payload."""
+        return {
+            "id": "evt_3ABC123DEF456GHI789",
+            "object": "event",
+            "api_version": "2025-12-15.clover",
+            "created": 1770278117,
+            "type": "customer.subscription.trial_will_end",
+            "data": {
+                "object": {
+                    "id": "sub_1ABC123DEF456GHI",
+                    "object": "subscription",
+                    "customer": "cus_TestCustomer123",
+                    "status": "trialing",
+                    "currency": "usd",
+                    "created": 1769327717,
+                    "current_period_start": 1769327717,
+                    "current_period_end": 1770537317,
+                    "trial_start": 1769327717,
+                    "trial_end": 1770537317,
+                    "cancel_at_period_end": False,
+                    "canceled_at": None,
+                    "plan": {
+                        "id": "price_1ABC123",
+                        "object": "plan",
+                        "amount": 2660,
+                        "currency": "usd",
+                        "interval": "month",
+                        "product": "prod_TestProduct",
+                    },
+                },
+            },
+        }
+
+    def test_trial_ending_event_carries_trial_metadata(
+        self,
+        stripe_plugin: StripeSourcePlugin,
+        trial_will_end_payload: dict[str, Any],
+    ) -> None:
+        """Test trial_will_end parses with trial end date and plan price."""
+        mock_event = Mock()
+        mock_event.type = trial_will_end_payload["type"]
+        mock_event.data.object = trial_will_end_payload["data"]["object"]
+        mock_event.data.previous_attributes = None
+
+        event_type, data = stripe_plugin._extract_stripe_event_info(mock_event)
+        assert event_type == "trial_ending"
+
+        amount = stripe_plugin._handle_stripe_billing(event_type, data)
+        assert amount == Decimal("0.00")
+        # trial_ending must NOT set _is_trial: parse_webhook renames
+        # _is_trial events to trial_started.
+        assert data.get("_is_trial") is None
+
+        event_data = stripe_plugin._build_stripe_event_data(
+            event_type=event_type,
+            customer_id=data["customer"],
+            data=data,
+            amount=amount,
+        )
+
+        assert event_data["type"] == "trial_ending"
+        metadata = event_data["metadata"]
+        assert metadata["is_trial"] is True
+        assert metadata["trial_end"] == 1770537317
+        assert metadata["trial_days"] == 14
+        assert metadata["plan_amount"] == 26.60
+        assert metadata["billing_period"] == "monthly"
+        assert metadata["subscription_id"] == "sub_1ABC123DEF456GHI"
+
+    def test_trial_ending_notification_names_customer_without_email(
+        self,
+        stripe_plugin: StripeSourcePlugin,
+        event_processor: EventProcessor,
+        trial_will_end_payload: dict[str, Any],
+    ) -> None:
+        """Test the notification carries insight and identity, not a bare title.
+
+        Simulates the email cache miss (no invoice cached the address):
+        the message must still show the trial end date, the post-trial
+        price, and the customer id as last-resort identity.
+        """
+        import json
+
+        mock_event = Mock()
+        mock_event.type = trial_will_end_payload["type"]
+        mock_event.data.object = trial_will_end_payload["data"]["object"]
+        mock_event.data.previous_attributes = None
+
+        event_type, data = stripe_plugin._extract_stripe_event_info(mock_event)
+        amount = stripe_plugin._handle_stripe_billing(event_type, data)
+        event_data = stripe_plugin._build_stripe_event_data(
+            event_type, data["customer"], data, amount
+        )
+
+        # Email cache miss: only the customer id identifies the customer
+        customer_data = {
+            "email": "",
+            "first_name": "",
+            "last_name": "",
+            "company_name": "",
+            "customer_id": "cus_TestCustomer123",
+        }
+
+        notification = event_processor.build_rich_notification(
+            event_data, customer_data
+        )
+        assert isinstance(notification, RichNotification)
+        assert notification.headline == "Trial ending soon"
+        assert notification.insight is not None
+        assert notification.insight.text == "Trial ends Feb 8, then $26.60/mo"
+
+        slack_message = event_processor.process_event_rich(
+            event_data, customer_data, target="slack"
+        )
+        rendered = json.dumps(slack_message)
+        # Identity fallback: the customer id must appear in a context
+        # (identity) block, not merely inside the action button URL
+        blocks = slack_message["attachments"][0]["blocks"]
+        context_texts = [
+            element["text"]
+            for block in blocks
+            if block["type"] == "context"
+            for element in block["elements"]
+            if element.get("type") == "mrkdwn"
+        ]
+        assert any("cus_TestCustomer123" in text for text in context_texts)
+        # The insight line made it into the rendered message
+        assert "Trial ends Feb 8, then $26.60/mo" in rendered
+
+
+@pytest.mark.django_db
 class TestTrialConversionIntegration:
     """Integration test: Trial conversion to paid subscription.
 


### PR DESCRIPTION
## Problem

Trial-ending notifications rendered as a bare message with nothing in the body:

> :warning: **Trial ending soon**
> Stripe • Trial

No trial end date, no post-trial price, and — whenever the encrypted email cache missed — no customer identity at all. Yet the `customer.subscription.trial_will_end` payload is a full subscription object carrying all of that as proven fields; the parser was dropping every one of them.

## Changes

- **Stripe parser** (`app/plugins/sources/stripe.py`): `trial_ending` events now get the same staged trial fields as `trial_started` (`trial_end`, `trial_days`, post-trial `plan_amount`) plus subscription metadata (plan name, billing period, subscription id). The staging helper is shared (`_stage_trial_fields`), and `_is_trial` is deliberately not set — that flag renames events to `trial_started` in `parse_webhook`. Setting `is_trial` metadata also suppresses the meaningless $0 payment grid, consistent with trial_started.
- **Insight detector** (`app/webhooks/services/insight_detector.py`): new `_detect_trial_ending` renders "Trial ends Feb 8, then $26.60/mo", degrading to just the date or just the price when only one is present, and staying silent when both are missing (per the signal-availability contract — no guessed data). Signal matrix docstring updated.
- **Slack formatter** (`app/plugins/destinations/slack.py`): the customer footer now falls back to `CustomerInfo.company_name`, which carries `get_display_name()`'s fallback chain ending at the provider customer id (`cus_...`) — so an email-less notification still says who it is about. The fallback never fires when an email or name exists. Identity-line construction extracted to `_customer_identity_line` (ruff C901).

## Result

> :warning: **Trial ending soon**
> :clock: **Trial ends Feb 8, then $26.60/mo**
> Stripe • Trial
> :bust_in_silhouette: cus_TestCustomer123
> [View in Stripe]

(with the email shown instead of the customer id whenever the cache has it)

## Testing

- New integration tests: `trial_will_end` parse → metadata → notification → Slack blocks, including the email-cache-miss identity fallback
- New insight detector tests covering all degradation branches
- New formatter tests: id fallback fires without email/name, stays silent with them
- Full suite: 1896 passed; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)