### PR TITLE
fix(slack): map clock icon to a real Slack emoji

### DIFF
--- a/app/plugins/destinations/slack.py
+++ b/app/plugins/destinations/slack.py
@@ -71,7 +71,8 @@ SLACK_ICONS: dict[str, str] = {
     "rocket": "rocket",
     "check": "white_check_mark",
     "calendar": "calendar",
-    "clock": "clock",
+    # Slack has no bare :clock: emoji, only numbered faces and :alarm_clock:
+    "clock": "alarm_clock",
     "email": "email",
     "phone": "phone",
     "globe": "globe_with_meridians",


### PR DESCRIPTION
## Summary
The trial-ending notification rendered the literal text `:clock:` in Slack because `SLACK_ICONS` mapped the semantic `clock` icon to the shortcode `clock` — Slack only has numbered clock faces (`:clock1:`–`:clock12:`) and `:alarm_clock:`, not a bare `:clock:`.

Seen in production:
> :warning: Trial ending soon **:clock:** Trial ends Jul 26, then $53.20/mo

## Change
- Map `clock` → `alarm_clock` (⏰) in `app/plugins/destinations/slack.py`

## Testing
- `uv run pytest -k "slack or insight"` — 341 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)