### PR TITLE
feat(billing): send the trial-ending email to workspace admins

### DIFF
--- a/app/core/services/usage_alerts.py
+++ b/app/core/services/usage_alerts.py
@@ -1,4 +1,4 @@
-"""Usage alert emails for monthly event limits.
+"""Billing alert emails to workspace owners and admins.
 
 Implements the notification side of soft limit enforcement: workspace
 owners and admins get a warning email when usage approaches the plan
@@ -6,9 +6,13 @@ limit, an "exceeded" email when usage crosses it (delivery continues
 inside the grace window), and a "paused" email when the hard cap is
 reached.
 
-Each alert fires exactly once per month without any persisted state:
-the usage counter increments atomically by one, so exactly one request
-observes each threshold value.
+Each usage alert fires exactly once per month without any persisted
+state: the usage counter increments atomically by one, so exactly one
+request observes each threshold value.
+
+Also home to the trial-ending alert, sent when Stripe fires
+customer.subscription.trial_will_end (~3 days before the workspace's
+own Notipus trial converts to a paid subscription).
 """
 
 import logging
@@ -248,6 +252,92 @@ Delivery only pauses if usage reaches {hard_at} events before your count
 resets on the first day of next month.
 
 You can upgrade any time here:
+{_billing_url()}
+
+- The Notipus Team
+"""
+    _send(subject, body, _admin_emails(workspace))
+
+
+def send_trial_ending_alert(
+    workspace: Any,
+    *,
+    ends_on: str | None = None,
+    price: str | None = None,
+    will_cancel: bool = False,
+) -> None:
+    """Email workspace admins that their Notipus trial is about to end.
+
+    Only proven payload fields appear in the copy: the end date and
+    converted price are omitted when Stripe did not supply them, never
+    guessed. Never raises — alert delivery must not break billing
+    webhook processing.
+
+    Args:
+        workspace: Workspace whose trial is ending.
+        ends_on: Human-readable trial end date (e.g. "February 8, 2026"),
+            or None when the payload carried no usable trial_end.
+        price: Formatted recurring price the trial converts to (e.g.
+            "$29.00/month"), or None when not determinable.
+        will_cancel: True when the subscription is set to cancel at the
+            end of the trial instead of converting.
+    """
+    try:
+        if will_cancel:
+            _send_trial_cancel_alert(workspace, ends_on)
+        else:
+            _send_trial_convert_alert(workspace, ends_on, price)
+    except Exception:
+        logger.exception(
+            "Failed to send trial ending alert for workspace %s",
+            getattr(workspace, "uuid", "unknown"),
+        )
+
+
+def _send_trial_convert_alert(
+    workspace: Any, ends_on: str | None, price: str | None
+) -> None:
+    """Email workspace admins that the trial converts to a paid plan."""
+    when = f"on {ends_on}" if ends_on else "soon"
+    continues = "your subscription continues automatically"
+    if price:
+        continues = f"{continues} at {price}"
+    subject = f"[Notipus] {workspace.name}: your trial ends {ends_on or 'soon'}"
+    body = f"""Hi,
+
+The {workspace.subscription_plan} plan trial for your workspace
+"{workspace.name}" ends {when}. After that, {continues} — no action
+needed to keep your notifications flowing.
+
+If you'd like to change or cancel your plan, you can do that any time here:
+{_billing_url()}
+
+- The Notipus Team
+"""
+    _send(subject, body, _admin_emails(workspace))
+
+
+def _send_trial_cancel_alert(workspace: Any, ends_on: str | None) -> None:
+    """Email workspace admins that delivery stops when the trial ends.
+
+    Sent when the subscription has cancel_at_period_end set, so the
+    trial will not convert — the concrete consequence is that Notipus
+    stops delivering notifications for the workspace.
+    """
+    when = f"on {ends_on}" if ends_on else "soon"
+    subject = (
+        f"[Notipus] {workspace.name}: your trial ends {ends_on or 'soon'} "
+        f"and delivery will stop"
+    )
+    body = f"""Hi,
+
+The {workspace.subscription_plan} plan trial for your workspace
+"{workspace.name}" ends {when}, and your subscription is set to cancel
+at that point. When it does, Notipus stops delivering notifications for
+this workspace.
+
+To keep your notifications flowing, reactivate your subscription before
+the trial ends:
 {_billing_url()}
 
 - The Notipus Team

--- a/app/core/services/usage_alerts.py
+++ b/app/core/services/usage_alerts.py
@@ -1,4 +1,4 @@
-"""Billing alert emails to workspace owners and admins.
+"""Usage-limit and trial-ending alert emails for workspace admins.
 
 Implements the notification side of soft limit enforcement: workspace
 owners and admins get a warning email when usage approaches the plan

--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -21,6 +21,10 @@ from plugins.sources.base import (
     mask_sensitive_headers,
 )
 from webhooks.utils.currency import from_minor_units
+from webhooks.utils.subscriptions import (
+    subscription_recurring_amount_cents,
+    sum_item_amounts,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -229,57 +233,6 @@ class StripeSourcePlugin(BaseSourcePlugin):
             # Don't fail webhook processing if we can't get idempotency key
             return None
 
-    def _extract_item_amount(self, item: dict[str, Any]) -> int | None:
-        """Extract the per-unit amount in cents from a subscription item.
-
-        Supports both the old API shape (``item.plan.amount``) and the
-        newer prices API shape (``item.price.unit_amount``).
-
-        Args:
-            item: A single subscription item dict from items.data[].
-
-        Returns:
-            Per-unit amount in cents, or None if not determinable.
-        """
-        plan = item.get("plan")
-        if isinstance(plan, dict) and plan.get("amount") is not None:
-            return int(plan["amount"])
-
-        price = item.get("price")
-        if isinstance(price, dict) and price.get("unit_amount") is not None:
-            return int(price["unit_amount"])
-
-        return None
-
-    def _sum_item_amounts(self, items_data: Any) -> int | None:
-        """Sum ``amount * quantity`` across subscription items.
-
-        Args:
-            items_data: The items.data[] list from a subscription payload
-                (or from _previous_attributes.items).
-
-        Returns:
-            Total amount in cents, or None if no item amount is determinable.
-        """
-        if not isinstance(items_data, list):
-            return None
-
-        total = 0
-        found = False
-        for item in items_data:
-            if not isinstance(item, dict):
-                continue
-            unit_amount = self._extract_item_amount(item)
-            if unit_amount is None:
-                continue
-            quantity = item.get("quantity")
-            if not isinstance(quantity, int) or quantity < 1:
-                quantity = 1
-            total += unit_amount * quantity
-            found = True
-
-        return total if found else None
-
     def _extract_subscription_amount(self, sub_data: dict[str, Any]) -> int:
         """Extract the total recurring amount in cents for a subscription.
 
@@ -294,17 +247,8 @@ class StripeSourcePlugin(BaseSourcePlugin):
         Returns:
             Total amount in cents, or 0 if not determinable.
         """
-        items = sub_data.get("items")
-        if isinstance(items, dict):
-            items_total = self._sum_item_amounts(items.get("data"))
-            if items_total is not None:
-                return items_total
-
-        plan = sub_data.get("plan")
-        if isinstance(plan, dict) and plan.get("amount") is not None:
-            return int(plan["amount"])
-
-        return 0
+        amount = subscription_recurring_amount_cents(sub_data)
+        return amount if amount is not None else 0
 
     def _get_previous_plan_amount(self, data: dict[str, Any]) -> int | None:
         """Extract previous plan amount from subscription update data.
@@ -330,7 +274,10 @@ class StripeSourcePlugin(BaseSourcePlugin):
         # Check items for multi-item subscriptions
         prev_items = prev_attrs.get("items", {})
         if isinstance(prev_items, dict):
-            return self._sum_item_amounts(prev_items.get("data"))
+            # cast: mypy cannot resolve cross-package imports in this
+            # layout (see the disabled django plugin note in pyproject),
+            # so the util's int | None return arrives as Any.
+            return cast("int | None", sum_item_amounts(prev_items.get("data")))
 
         return None
 

--- a/app/webhooks/services/billing.py
+++ b/app/webhooks/services/billing.py
@@ -898,7 +898,9 @@ class BillingService:
             ws,
             ends_on=BillingService._format_timestamp_date(trial_end),
             price=BillingService._recurring_price_label(subscription),
-            will_cancel=bool(subscription.get("cancel_at_period_end")),
+            # "is True": a malformed truthy value (e.g. the string
+            # "false") must not send the "delivery will stop" variant.
+            will_cancel=subscription.get("cancel_at_period_end") is True,
         )
         # TODO: Trigger Slack notification if configured
 

--- a/app/webhooks/services/billing.py
+++ b/app/webhooks/services/billing.py
@@ -28,6 +28,7 @@ from core.services.usage_alerts import send_trial_ending_alert
 from django.db.models import Q
 from webhooks.utils.currency import format_money, from_minor_units
 from webhooks.utils.subscriptions import (
+    subscription_currency,
     subscription_recurring_amount_cents,
     subscription_recurring_interval,
 )
@@ -930,14 +931,18 @@ class BillingService:
 
         Returns:
             A label like "$29.00/month", or None when the payload does
-            not prove an amount — a zero result is also treated as
-            unknown because the extractor cannot distinguish a genuine
-            $0 plan from missing data.
+            not prove both an amount and a currency — a zero amount is
+            also treated as unknown because the extractor cannot
+            distinguish a genuine $0 plan from missing data, and
+            without a currency the minor-unit exponent and symbol
+            would be guesses.
         """
         cents = subscription_recurring_amount_cents(subscription)
         if not cents:
             return None
-        currency = str(subscription.get("currency") or "USD")
+        currency = subscription_currency(subscription)
+        if not currency:
+            return None
         money = format_money(from_minor_units(cents, currency), currency)
         interval = subscription_recurring_interval(subscription)
         return f"{money}/{interval}" if interval else money

--- a/app/webhooks/services/billing.py
+++ b/app/webhooks/services/billing.py
@@ -24,7 +24,13 @@ import stripe
 from core import analytics
 from core.models import Workspace
 from core.services.stripe import StripeAPI
+from core.services.usage_alerts import send_trial_ending_alert
 from django.db.models import Q
+from webhooks.utils.currency import format_money, from_minor_units
+from webhooks.utils.subscriptions import (
+    subscription_recurring_amount_cents,
+    subscription_recurring_interval,
+)
 
 from .redis_client import get_raw_redis_client
 
@@ -863,8 +869,11 @@ class BillingService:
     def handle_trial_ending(subscription: dict[str, Any]) -> None:
         """Handle trial ending notification (3 days before trial ends).
 
-        This event is fired when a subscription's trial is about to end.
-        Can be used to send reminder notifications to customers.
+        Emails workspace owners and admins that the trial is about to
+        end, saying when it ends and what it converts to when those
+        fields are present in the payload. When the subscription is set
+        to cancel at trial end, the email says delivery will stop
+        instead.
 
         Args:
             subscription: Subscription data from Stripe webhook.
@@ -875,18 +884,63 @@ class BillingService:
 
         trial_end = subscription.get("trial_end")
 
-        # Find workspace and log the event
         ws = Workspace.objects.filter(stripe_customer_id=customer_id).first()
-
-        if ws:
-            logger.info(
-                f"Trial ending soon for workspace {ws.name} "
-                f"(customer: {customer_id}), trial_end: {trial_end}"
-            )
-            # TODO: Send notification email to workspace admins
-            # TODO: Trigger Slack notification if configured
-        else:
+        if not ws:
             logger.warning(f"Trial ending for unknown customer {customer_id}")
+            return
+
+        logger.info(
+            f"Trial ending soon for workspace {ws.name} "
+            f"(customer: {customer_id}), trial_end: {trial_end}"
+        )
+        send_trial_ending_alert(
+            ws,
+            ends_on=BillingService._format_timestamp_date(trial_end),
+            price=BillingService._recurring_price_label(subscription),
+            will_cancel=bool(subscription.get("cancel_at_period_end")),
+        )
+        # TODO: Trigger Slack notification if configured
+
+    @staticmethod
+    def _format_timestamp_date(ts: Any) -> str | None:
+        """Format a unix timestamp as a human-readable UTC date.
+
+        Args:
+            ts: Unix timestamp from a Stripe payload, or anything else.
+
+        Returns:
+            A date like "February 8, 2026", or None when the value is
+            not a usable timestamp — the caller omits the date rather
+            than showing a guessed one.
+        """
+        if isinstance(ts, bool) or not isinstance(ts, (int, float)):
+            return None
+        try:
+            dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+        return f"{dt:%B} {dt.day}, {dt.year}"
+
+    @staticmethod
+    def _recurring_price_label(subscription: dict[str, Any]) -> str | None:
+        """Format the recurring price a subscription bills at.
+
+        Args:
+            subscription: Subscription payload dictionary.
+
+        Returns:
+            A label like "$29.00/month", or None when the payload does
+            not prove an amount — a zero result is also treated as
+            unknown because the extractor cannot distinguish a genuine
+            $0 plan from missing data.
+        """
+        cents = subscription_recurring_amount_cents(subscription)
+        if not cents:
+            return None
+        currency = str(subscription.get("currency") or "USD")
+        money = format_money(from_minor_units(cents, currency), currency)
+        interval = subscription_recurring_interval(subscription)
+        return f"{money}/{interval}" if interval else money
 
     @staticmethod
     def handle_invoice_paid(invoice: dict[str, Any]) -> None:

--- a/app/webhooks/services/billing.py
+++ b/app/webhooks/services/billing.py
@@ -933,14 +933,13 @@ class BillingService:
 
         Returns:
             A label like "$29.00/month", or None when the payload does
-            not prove both an amount and a currency — a zero amount is
-            also treated as unknown because the extractor cannot
-            distinguish a genuine $0 plan from missing data, and
-            without a currency the minor-unit exponent and symbol
-            would be guesses.
+            not prove both an amount and a currency — without a
+            currency the minor-unit exponent and symbol would be
+            guesses. A proven zero renders as "$0.00" like the Slack
+            trial insights do.
         """
         cents = subscription_recurring_amount_cents(subscription)
-        if not cents:
+        if cents is None:
             return None
         currency = subscription_currency(subscription)
         if not currency:

--- a/app/webhooks/utils/subscriptions.py
+++ b/app/webhooks/utils/subscriptions.py
@@ -1,0 +1,127 @@
+"""Amount and interval extraction for Stripe subscription payloads.
+
+Shared by the Stripe source plugin (notification metadata) and
+BillingService (trial-ending emails). Extraction never guesses: every
+function returns None when the payload does not prove the value.
+"""
+
+from typing import Any
+
+
+def extract_item_amount(item: dict[str, Any]) -> int | None:
+    """Extract the per-unit amount in cents from a subscription item.
+
+    Supports both the old API shape (``item.plan.amount``) and the
+    newer prices API shape (``item.price.unit_amount``).
+
+    Args:
+        item: A single subscription item dict from items.data[].
+
+    Returns:
+        Per-unit amount in cents, or None if not determinable.
+    """
+    plan = item.get("plan")
+    if isinstance(plan, dict) and plan.get("amount") is not None:
+        return int(plan["amount"])
+
+    price = item.get("price")
+    if isinstance(price, dict) and price.get("unit_amount") is not None:
+        return int(price["unit_amount"])
+
+    return None
+
+
+def sum_item_amounts(items_data: Any) -> int | None:
+    """Sum ``amount * quantity`` across subscription items.
+
+    Args:
+        items_data: The items.data[] list from a subscription payload
+            (or from _previous_attributes.items).
+
+    Returns:
+        Total amount in cents, or None if no item amount is determinable.
+    """
+    if not isinstance(items_data, list):
+        return None
+
+    total = 0
+    found = False
+    for item in items_data:
+        if not isinstance(item, dict):
+            continue
+        unit_amount = extract_item_amount(item)
+        if unit_amount is None:
+            continue
+        quantity = item.get("quantity")
+        if not isinstance(quantity, int) or quantity < 1:
+            quantity = 1
+        total += unit_amount * quantity
+        found = True
+
+    return total if found else None
+
+
+def subscription_recurring_amount_cents(sub_data: dict[str, Any]) -> int | None:
+    """Extract the total recurring amount in cents for a subscription.
+
+    Modern multi-item subscriptions have a null top-level ``plan``, so
+    the item amounts (``items[].plan.amount * quantity`` or
+    ``items[].price.unit_amount * quantity``) are summed first, with
+    the top-level plan as a legacy single-item fallback.
+
+    Args:
+        sub_data: Subscription payload dictionary.
+
+    Returns:
+        Total amount in cents, or None if not determinable.
+    """
+    items = sub_data.get("items")
+    if isinstance(items, dict):
+        items_total = sum_item_amounts(items.get("data"))
+        if items_total is not None:
+            return items_total
+
+    plan = sub_data.get("plan")
+    if isinstance(plan, dict) and plan.get("amount") is not None:
+        return int(plan["amount"])
+
+    return None
+
+
+def subscription_recurring_interval(sub_data: dict[str, Any]) -> str | None:
+    """Extract the billing interval ("month", "year", ...) for a subscription.
+
+    Reads the legacy top-level ``plan.interval`` first, then falls back
+    to the first item's ``price.recurring.interval`` or
+    ``plan.interval`` for prices-API payloads.
+
+    Args:
+        sub_data: Subscription payload dictionary.
+
+    Returns:
+        Billing interval string, or None if not determinable.
+    """
+    plan = sub_data.get("plan")
+    if isinstance(plan, dict) and plan.get("interval"):
+        return str(plan["interval"])
+
+    items = sub_data.get("items")
+    if not isinstance(items, dict):
+        return None
+    items_data = items.get("data")
+    if not isinstance(items_data, list):
+        return None
+
+    for item in items_data:
+        if not isinstance(item, dict):
+            continue
+        price = item.get("price")
+        if isinstance(price, dict):
+            recurring = price.get("recurring")
+            if isinstance(recurring, dict) and recurring.get("interval"):
+                return str(recurring["interval"])
+        item_plan = item.get("plan")
+        if isinstance(item_plan, dict) and item_plan.get("interval"):
+            return str(item_plan["interval"])
+
+    return None

--- a/app/webhooks/utils/subscriptions.py
+++ b/app/webhooks/utils/subscriptions.py
@@ -88,6 +88,51 @@ def subscription_recurring_amount_cents(sub_data: dict[str, Any]) -> int | None:
     return None
 
 
+def _currency_field(obj: Any) -> str | None:
+    """Return a dict's non-empty ``currency`` string, else None."""
+    if isinstance(obj, dict):
+        currency = obj.get("currency")
+        if isinstance(currency, str) and currency:
+            return currency
+    return None
+
+
+def subscription_currency(sub_data: dict[str, Any]) -> str | None:
+    """Extract the ISO currency code for a subscription.
+
+    Reads the top-level ``currency`` first, then the legacy top-level
+    ``plan.currency``, then the first item's ``price.currency`` or
+    ``plan.currency``.
+
+    Args:
+        sub_data: Subscription payload dictionary.
+
+    Returns:
+        Currency code string, or None if the payload does not carry one.
+    """
+    currency = _currency_field(sub_data) or _currency_field(sub_data.get("plan"))
+    if currency:
+        return currency
+
+    items = sub_data.get("items")
+    if not isinstance(items, dict):
+        return None
+    items_data = items.get("data")
+    if not isinstance(items_data, list):
+        return None
+
+    for item in items_data:
+        if not isinstance(item, dict):
+            continue
+        currency = _currency_field(item.get("price")) or _currency_field(
+            item.get("plan")
+        )
+        if currency:
+            return currency
+
+    return None
+
+
 def subscription_recurring_interval(sub_data: dict[str, Any]) -> str | None:
     """Extract the billing interval ("month", "year", ...) for a subscription.
 

--- a/app/webhooks/utils/subscriptions.py
+++ b/app/webhooks/utils/subscriptions.py
@@ -8,6 +8,20 @@ function returns None when the payload does not prove the value.
 from typing import Any
 
 
+def _amount_cents(value: Any) -> int | None:
+    """Coerce a payload amount to integer cents, or None when non-numeric.
+
+    Malformed amounts must degrade to "not determinable" rather than
+    raise out of webhook processing.
+    """
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def extract_item_amount(item: dict[str, Any]) -> int | None:
     """Extract the per-unit amount in cents from a subscription item.
 
@@ -21,12 +35,16 @@ def extract_item_amount(item: dict[str, Any]) -> int | None:
         Per-unit amount in cents, or None if not determinable.
     """
     plan = item.get("plan")
-    if isinstance(plan, dict) and plan.get("amount") is not None:
-        return int(plan["amount"])
+    if isinstance(plan, dict):
+        amount = _amount_cents(plan.get("amount"))
+        if amount is not None:
+            return amount
 
     price = item.get("price")
-    if isinstance(price, dict) and price.get("unit_amount") is not None:
-        return int(price["unit_amount"])
+    if isinstance(price, dict):
+        amount = _amount_cents(price.get("unit_amount"))
+        if amount is not None:
+            return amount
 
     return None
 
@@ -82,8 +100,8 @@ def subscription_recurring_amount_cents(sub_data: dict[str, Any]) -> int | None:
             return items_total
 
     plan = sub_data.get("plan")
-    if isinstance(plan, dict) and plan.get("amount") is not None:
-        return int(plan["amount"])
+    if isinstance(plan, dict):
+        return _amount_cents(plan.get("amount"))
 
     return None
 

--- a/app/webhooks/utils/subscriptions.py
+++ b/app/webhooks/utils/subscriptions.py
@@ -106,13 +106,18 @@ def subscription_recurring_amount_cents(sub_data: dict[str, Any]) -> int | None:
     return None
 
 
+def _string_field(obj: Any, key: str) -> str | None:
+    """Return a dict's non-empty string value for ``key``, else None."""
+    if isinstance(obj, dict):
+        value = obj.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
 def _currency_field(obj: Any) -> str | None:
     """Return a dict's non-empty ``currency`` string, else None."""
-    if isinstance(obj, dict):
-        currency = obj.get("currency")
-        if isinstance(currency, str) and currency:
-            return currency
-    return None
+    return _string_field(obj, "currency")
 
 
 def subscription_currency(sub_data: dict[str, Any]) -> str | None:
@@ -162,11 +167,13 @@ def subscription_recurring_interval(sub_data: dict[str, Any]) -> str | None:
         sub_data: Subscription payload dictionary.
 
     Returns:
-        Billing interval string, or None if not determinable.
+        Billing interval string, or None if not determinable — a
+        malformed non-string interval is not determinable rather than
+        something to stringify into the price label.
     """
-    plan = sub_data.get("plan")
-    if isinstance(plan, dict) and plan.get("interval"):
-        return str(plan["interval"])
+    interval = _string_field(sub_data.get("plan"), "interval")
+    if interval:
+        return interval
 
     items = sub_data.get("items")
     if not isinstance(items, dict):
@@ -180,11 +187,11 @@ def subscription_recurring_interval(sub_data: dict[str, Any]) -> str | None:
             continue
         price = item.get("price")
         if isinstance(price, dict):
-            recurring = price.get("recurring")
-            if isinstance(recurring, dict) and recurring.get("interval"):
-                return str(recurring["interval"])
-        item_plan = item.get("plan")
-        if isinstance(item_plan, dict) and item_plan.get("interval"):
-            return str(item_plan["interval"])
+            interval = _string_field(price.get("recurring"), "interval")
+            if interval:
+                return interval
+        interval = _string_field(item.get("plan"), "interval")
+        if interval:
+            return interval
 
     return None

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -832,6 +832,23 @@ class TestBillingServiceWebhooks:
                 will_cancel=False,
             )
 
+    def test_handle_trial_ending_truthy_non_boolean_cancel_flag(self) -> None:
+        """Only an explicit True means canceling; "false" must not."""
+        subscription_data: dict[str, Any] = {
+            "customer": "cus_test123",
+            "trial_end": 1704067200,
+            "cancel_at_period_end": "false",
+        }
+
+        with (
+            patch("core.models.Workspace.objects.filter") as mock_filter,
+            patch("webhooks.services.billing.send_trial_ending_alert") as mock_alert,
+        ):
+            mock_ws = MagicMock(name="Test Workspace")
+            mock_filter.return_value.first.return_value = mock_ws
+            BillingService.handle_trial_ending(subscription_data)
+            assert mock_alert.call_args.kwargs["will_cancel"] is False
+
     def test_handle_trial_ending_unknown_customer_sends_nothing(self) -> None:
         """No workspace for the customer means no alert email."""
         subscription_data: dict[str, Any] = {

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -911,6 +911,14 @@ class TestBillingServiceWebhooks:
         """A payload without any amount yields no price claim."""
         assert BillingService._recurring_price_label({"plan": None}) is None
 
+    def test_recurring_price_label_renders_proven_zero(self) -> None:
+        """An explicit 0 amount is a proven $0 plan, not missing data."""
+        subscription_data: dict[str, Any] = {
+            "plan": {"amount": 0, "interval": "month", "currency": "usd"},
+        }
+        label = BillingService._recurring_price_label(subscription_data)
+        assert label == "$0.00/month"
+
     def test_recurring_price_label_unknown_currency_is_none(self) -> None:
         """An amount without a currency anywhere yields no price claim.
 

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -809,17 +809,96 @@ class TestBillingServiceWebhooks:
         BillingService.handle_checkout_completed(session_data)
 
     def test_handle_trial_ending(self) -> None:
-        """Test trial ending handler."""
+        """The handler emails admins with the proven end date and price."""
         subscription_data: dict[str, Any] = {
             "customer": "cus_test123",
             "trial_end": 1704067200,
+            "currency": "usd",
+            "cancel_at_period_end": False,
+            "plan": {"amount": 2900, "interval": "month"},
         }
 
-        with patch("core.models.Workspace.objects.filter") as mock_filter:
+        with (
+            patch("core.models.Workspace.objects.filter") as mock_filter,
+            patch("webhooks.services.billing.send_trial_ending_alert") as mock_alert,
+        ):
             mock_ws = MagicMock(name="Test Workspace")
             mock_filter.return_value.first.return_value = mock_ws
-            # Should not raise
             BillingService.handle_trial_ending(subscription_data)
+            mock_alert.assert_called_once_with(
+                mock_ws,
+                ends_on="January 1, 2024",
+                price="$29.00/month",
+                will_cancel=False,
+            )
+
+    def test_handle_trial_ending_unknown_customer_sends_nothing(self) -> None:
+        """No workspace for the customer means no alert email."""
+        subscription_data: dict[str, Any] = {
+            "customer": "cus_unknown",
+            "trial_end": 1704067200,
+        }
+
+        with (
+            patch("core.models.Workspace.objects.filter") as mock_filter,
+            patch("webhooks.services.billing.send_trial_ending_alert") as mock_alert,
+        ):
+            mock_filter.return_value.first.return_value = None
+            BillingService.handle_trial_ending(subscription_data)
+            mock_alert.assert_not_called()
+
+    def test_handle_trial_ending_omits_unproven_fields(self) -> None:
+        """Missing trial_end and plan degrade to None, never guesses."""
+        subscription_data: dict[str, Any] = {
+            "customer": "cus_test123",
+            "trial_end": None,
+            "cancel_at_period_end": True,
+        }
+
+        with (
+            patch("core.models.Workspace.objects.filter") as mock_filter,
+            patch("webhooks.services.billing.send_trial_ending_alert") as mock_alert,
+        ):
+            mock_ws = MagicMock(name="Test Workspace")
+            mock_filter.return_value.first.return_value = mock_ws
+            BillingService.handle_trial_ending(subscription_data)
+            mock_alert.assert_called_once_with(
+                mock_ws,
+                ends_on=None,
+                price=None,
+                will_cancel=True,
+            )
+
+    def test_recurring_price_label_sums_multi_item_subscription(self) -> None:
+        """Prices-API payloads sum item amounts and read their interval."""
+        subscription_data: dict[str, Any] = {
+            "currency": "usd",
+            "plan": None,
+            "items": {
+                "data": [
+                    {
+                        "price": {
+                            "unit_amount": 1500,
+                            "recurring": {"interval": "year"},
+                        },
+                        "quantity": 2,
+                    },
+                ]
+            },
+        }
+        label = BillingService._recurring_price_label(subscription_data)
+        assert label == "$30.00/year"
+
+    def test_recurring_price_label_unknown_amount_is_none(self) -> None:
+        """A payload without any amount yields no price claim."""
+        assert BillingService._recurring_price_label({"plan": None}) is None
+
+    def test_format_timestamp_date_rejects_non_timestamps(self) -> None:
+        """Only real numeric timestamps produce a date."""
+        assert BillingService._format_timestamp_date(1704067200) == "January 1, 2024"
+        assert BillingService._format_timestamp_date(None) is None
+        assert BillingService._format_timestamp_date("soon") is None
+        assert BillingService._format_timestamp_date(True) is None
 
     def test_handle_invoice_paid_ignores_one_off_invoice(self) -> None:
         """A paid invoice with no subscription never touches the workspace."""

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -870,15 +870,16 @@ class TestBillingServiceWebhooks:
             )
 
     def test_recurring_price_label_sums_multi_item_subscription(self) -> None:
-        """Prices-API payloads sum item amounts and read their interval."""
+        """Prices-API payloads sum item amounts and read the item's
+        currency and interval when the top level carries neither."""
         subscription_data: dict[str, Any] = {
-            "currency": "usd",
             "plan": None,
             "items": {
                 "data": [
                     {
                         "price": {
                             "unit_amount": 1500,
+                            "currency": "usd",
                             "recurring": {"interval": "year"},
                         },
                         "quantity": 2,
@@ -892,6 +893,17 @@ class TestBillingServiceWebhooks:
     def test_recurring_price_label_unknown_amount_is_none(self) -> None:
         """A payload without any amount yields no price claim."""
         assert BillingService._recurring_price_label({"plan": None}) is None
+
+    def test_recurring_price_label_unknown_currency_is_none(self) -> None:
+        """An amount without a currency anywhere yields no price claim.
+
+        Defaulting to USD would guess both the symbol and the
+        minor-unit exponent (a JPY amount is not divided by 100).
+        """
+        subscription_data: dict[str, Any] = {
+            "plan": {"amount": 2900, "interval": "month"},
+        }
+        assert BillingService._recurring_price_label(subscription_data) is None
 
     def test_format_timestamp_date_rejects_non_timestamps(self) -> None:
         """Only real numeric timestamps produce a date."""

--- a/tests/test_subscription_utils.py
+++ b/tests/test_subscription_utils.py
@@ -114,3 +114,15 @@ class TestCurrencyAndInterval:
     def test_no_interval_anywhere_is_none(self) -> None:
         """No interval in any shape returns None."""
         assert subscription_recurring_interval({"plan": {"amount": 1}}) is None
+
+    def test_malformed_interval_is_none(self) -> None:
+        """A non-string interval must not be stringified into a label."""
+        assert subscription_recurring_interval({"plan": {"interval": 123}}) is None
+        sub: dict[str, Any] = {
+            "items": {"data": [{"price": {"recurring": {"interval": ["month"]}}}]}
+        }
+        assert subscription_recurring_interval(sub) is None
+
+    def test_malformed_currency_is_none(self) -> None:
+        """A non-string currency must not be stringified into a label."""
+        assert subscription_currency({"currency": 840}) is None

--- a/tests/test_subscription_utils.py
+++ b/tests/test_subscription_utils.py
@@ -1,0 +1,116 @@
+"""Tests for the shared Stripe subscription payload extraction utils.
+
+Pins the module contract: every extractor returns None when the payload
+does not prove the value — including malformed amounts, which must
+degrade rather than raise out of webhook processing.
+"""
+
+from typing import Any
+
+from webhooks.utils.subscriptions import (
+    extract_item_amount,
+    subscription_currency,
+    subscription_recurring_amount_cents,
+    subscription_recurring_interval,
+    sum_item_amounts,
+)
+
+
+class TestAmountExtraction:
+    """Amounts come from proven payload fields or not at all."""
+
+    def test_item_amount_prefers_legacy_plan_shape(self) -> None:
+        """item.plan.amount wins over item.price.unit_amount."""
+        item: dict[str, Any] = {
+            "plan": {"amount": 2900},
+            "price": {"unit_amount": 100},
+        }
+        assert extract_item_amount(item) == 2900
+
+    def test_item_amount_reads_prices_api_shape(self) -> None:
+        """item.price.unit_amount is used when plan carries no amount."""
+        item: dict[str, Any] = {"price": {"unit_amount": 1500}}
+        assert extract_item_amount(item) == 1500
+
+    def test_malformed_item_amount_falls_through_not_raises(self) -> None:
+        """A non-numeric plan amount degrades to the price shape."""
+        item: dict[str, Any] = {
+            "plan": {"amount": "not-a-number"},
+            "price": {"unit_amount": 1500},
+        }
+        assert extract_item_amount(item) == 1500
+
+    def test_malformed_amounts_everywhere_yield_none(self) -> None:
+        """Non-numeric amounts in every shape return None, never raise."""
+        item: dict[str, Any] = {
+            "plan": {"amount": "abc"},
+            "price": {"unit_amount": [2900]},
+        }
+        assert extract_item_amount(item) is None
+
+    def test_boolean_amount_is_not_a_number(self) -> None:
+        """True must not be silently read as 1 cent."""
+        assert extract_item_amount({"plan": {"amount": True}}) is None
+
+    def test_subscription_amount_malformed_plan_yields_none(self) -> None:
+        """A malformed top-level plan amount returns None, never raises."""
+        sub: dict[str, Any] = {"plan": {"amount": "abc"}}
+        assert subscription_recurring_amount_cents(sub) is None
+
+    def test_subscription_amount_sums_items_with_quantity(self) -> None:
+        """Item amounts multiply by quantity and sum across items."""
+        sub: dict[str, Any] = {
+            "items": {
+                "data": [
+                    {"price": {"unit_amount": 1000}, "quantity": 2},
+                    {"plan": {"amount": 500}},
+                ]
+            }
+        }
+        assert subscription_recurring_amount_cents(sub) == 2500
+
+    def test_sum_skips_malformed_items(self) -> None:
+        """Malformed items are skipped; the sum uses the provable ones."""
+        items: list[Any] = [
+            {"price": {"unit_amount": "abc"}},
+            {"price": {"unit_amount": 1000}},
+            "not-a-dict",
+        ]
+        assert sum_item_amounts(items) == 1000
+
+
+class TestCurrencyAndInterval:
+    """Currency and interval come from known payload shapes only."""
+
+    def test_currency_prefers_top_level(self) -> None:
+        """The subscription's own currency field wins."""
+        sub: dict[str, Any] = {
+            "currency": "eur",
+            "plan": {"currency": "usd"},
+        }
+        assert subscription_currency(sub) == "eur"
+
+    def test_currency_from_item_price(self) -> None:
+        """Prices-API payloads carry currency on the item price."""
+        sub: dict[str, Any] = {"items": {"data": [{"price": {"currency": "jpy"}}]}}
+        assert subscription_currency(sub) == "jpy"
+
+    def test_no_currency_anywhere_is_none(self) -> None:
+        """No currency in any shape returns None — never a guess."""
+        assert subscription_currency({"plan": {"amount": 2900}}) is None
+
+    def test_interval_from_legacy_plan(self) -> None:
+        """The legacy top-level plan interval is read first."""
+        sub: dict[str, Any] = {"plan": {"interval": "month"}}
+        assert subscription_recurring_interval(sub) == "month"
+
+    def test_interval_from_item_price_recurring(self) -> None:
+        """Prices-API payloads carry interval under price.recurring."""
+        sub: dict[str, Any] = {
+            "items": {"data": [{"price": {"recurring": {"interval": "year"}}}]}
+        }
+        assert subscription_recurring_interval(sub) == "year"
+
+    def test_no_interval_anywhere_is_none(self) -> None:
+        """No interval in any shape returns None."""
+        assert subscription_recurring_interval({"plan": {"amount": 1}}) is None

--- a/tests/test_usage_alerts.py
+++ b/tests/test_usage_alerts.py
@@ -15,6 +15,7 @@ from core.models import Plan, Workspace, WorkspaceMember
 from core.services.usage_alerts import (
     hard_limit,
     maybe_send_usage_alerts,
+    send_trial_ending_alert,
     warning_count,
 )
 from django.contrib.auth.models import User
@@ -253,6 +254,74 @@ class TestUsageAlertEmails:
             subscription_status="active",
         )
         maybe_send_usage_alerts(lonely, new_usage=16, limit=20)
+
+        assert mail.outbox == []
+
+
+class TestTrialEndingAlert:
+    """Trial-ending emails state the proven end date, price, and outcome."""
+
+    def test_converting_trial_names_date_and_price(self, workspace: Workspace) -> None:
+        """A converting trial says when it ends and what it costs after."""
+        send_trial_ending_alert(
+            workspace,
+            ends_on="February 8, 2026",
+            price="$29.00/month",
+            will_cancel=False,
+        )
+
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        assert "trial ends February 8, 2026" in message.subject
+        assert sorted(message.to) == ["admin@example.com", "owner@example.com"]
+        assert "continues automatically at $29.00/month" in message.body
+        assert "no action" in message.body.lower()
+
+    def test_cancelling_trial_says_delivery_stops(self, workspace: Workspace) -> None:
+        """A trial set to cancel names the concrete loss: delivery stops."""
+        send_trial_ending_alert(
+            workspace,
+            ends_on="February 8, 2026",
+            price="$29.00/month",
+            will_cancel=True,
+        )
+
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        assert "delivery will stop" in message.subject
+        assert "stops delivering notifications" in message.body
+        assert "reactivate" in message.body.lower()
+
+    def test_missing_fields_degrade_to_soon_without_price(
+        self, workspace: Workspace
+    ) -> None:
+        """Unproven date and price are omitted, never guessed."""
+        send_trial_ending_alert(workspace, ends_on=None, price=None)
+
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        assert "trial ends soon" in message.subject
+        assert "$" not in message.body
+        assert "ends soon" in message.body
+        assert "continues automatically —" in message.body
+
+    def test_send_failure_does_not_raise(self, workspace: Workspace) -> None:
+        """A broken mail backend must never break billing webhooks."""
+        with patch(
+            "core.services.usage_alerts.send_mail",
+            side_effect=Exception("smtp down"),
+        ):
+            send_trial_ending_alert(workspace, ends_on="February 8, 2026")
+
+    def test_recipient_lookup_failure_does_not_raise(
+        self, workspace: Workspace
+    ) -> None:
+        """Even a failing recipient query is swallowed and logged."""
+        with patch(
+            "core.services.usage_alerts._admin_emails",
+            side_effect=Exception("db down"),
+        ):
+            send_trial_ending_alert(workspace, ends_on="February 8, 2026")
 
         assert mail.outbox == []
 


### PR DESCRIPTION
## Summary

`BillingService.handle_trial_ending` was a logging stub with a `# TODO: Send notification email` — Stripe fires `customer.subscription.trial_will_end` ~3 days before a workspace's trial converts, and nothing was sent. This PR ships the email.

## What it does

Workspace **owners and admins** now get a plain-text email (same style and plumbing as the soft-limit usage alerts):

- **Converting trial**: "The pro plan trial for your workspace ends on February 8, 2026. After that, your subscription continues automatically at $99.00/month — no action needed to keep your notifications flowing." + billing link to change/cancel.
- **Trial set to cancel** (`cancel_at_period_end`): "…your subscription is set to cancel at that point. When it does, Notipus stops delivering notifications for this workspace." + reactivation link.

## Design constraints

- **Only payload-proven fields appear in the copy**: end date and price are omitted when Stripe didn't supply them ("ends soon", no price claim) — never guessed.
- **Never raises**: recipient lookup and send failures are logged; mail problems cannot break billing webhook processing.
- The Slack-notification TODO stays; this PR is email only.

## Refactor

Subscription amount/interval extraction moved from the Stripe plugin's private methods into shared `webhooks/utils/subscriptions.py` (dependency-light, plugin-safe package) so `BillingService` and the plugin use one implementation. `_extract_subscription_amount` remains as a thin delegate for API stability.

## Testing

- New `TestTrialEndingAlert` class covering both variants, degraded fields, and failure swallowing
- Expanded `handle_trial_ending` handler tests (dispatch args, unknown customer, unproven fields)
- Full suite: **1941 passed**; mypy and ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)