### PR TITLE
fix: extract social handles from Hunter.io nested objects

### DIFF
--- a/app/core/services/email_enrichment.py
+++ b/app/core/services/email_enrichment.py
@@ -247,14 +247,16 @@ class EmailEnrichmentService:
         logger.debug(f"{action} person record for {email}")
         return person
 
-    def _fit_to_column(self, field_name: str, value: str) -> str:
+    def _fit_to_column(self, field_name: str, value: Any) -> str:
         """Fit an enrichment value into its Person column.
 
         Hunter.io occasionally returns values longer than our columns,
         which would abort the whole insert with a DataError. Display-text
         fields are truncated to the column width; link/identifier fields
         are dropped instead, since a clipped URL or handle would point at
-        the wrong place.
+        the wrong place. Non-string values (e.g. a nested object that
+        slipped through normalization) are dropped outright: their repr
+        is garbage data, and storing it would show guessed values.
 
         Args:
             field_name: Name of the Person model field.
@@ -263,6 +265,13 @@ class EmailEnrichmentService:
         Returns:
             A value guaranteed to fit the column.
         """
+        if not isinstance(value, str):
+            logger.warning(
+                f"Dropping non-string {field_name} from Hunter.io "
+                f"({type(value).__name__})"
+            )
+            return ""
+
         max_length = Person._meta.get_field(field_name).max_length
         if not max_length or len(value) <= max_length:
             return value

--- a/app/plugins/enrichment/hunter.py
+++ b/app/plugins/enrichment/hunter.py
@@ -238,13 +238,33 @@ class HunterPlugin(BaseEmailEnrichmentPlugin):
             "seniority": employment.get("seniority") or data.get("seniority") or "",
             "company_domain": employment.get("domain") or "",
             "linkedin_url": self._build_linkedin_url(data.get("linkedin")),
-            "twitter_handle": data.get("twitter") or "",
-            "github_handle": data.get("github") or "",
+            "twitter_handle": self._extract_handle(data.get("twitter")),
+            "github_handle": self._extract_handle(data.get("github")),
             "location": self._build_location_string(data),
             "_raw": data,
         }
 
         return result
+
+    def _extract_handle(self, value: Any) -> str:
+        """Extract a scalar social handle from a Hunter.io response value.
+
+        Hunter.io returns social fields as nested objects
+        (e.g. ``{"handle": "johndoe", "followers": 42, ...}``), with
+        ``handle`` set to null when unknown. Older/mocked shapes use a
+        plain string. Anything else is unusable for a handle column.
+
+        Args:
+            value: The raw ``twitter``/``github`` value from the response.
+
+        Returns:
+            The handle string, or empty string if not present.
+        """
+        if isinstance(value, dict):
+            value = value.get("handle")
+        if isinstance(value, str):
+            return value
+        return ""
 
     def _build_linkedin_url(self, linkedin_handle: str | None) -> str:
         """Build full LinkedIn URL from handle.

--- a/tests/test_email_enrichment.py
+++ b/tests/test_email_enrichment.py
@@ -159,6 +159,43 @@ class TestHunterPluginNormalization:
         assert result["position"] == ""
         assert result["seniority"] == ""
 
+    def test_normalize_nested_social_objects(self, hunter_plugin: HunterPlugin) -> None:
+        """Test that nested twitter/github objects yield the handle string.
+
+        The live Hunter.io People API returns social fields as nested
+        objects, not plain strings (seen in prod: the dict repr overflowed
+        the varchar(100) handle columns and aborted every Person insert).
+        """
+        data = {
+            "twitter": {"handle": "johndoe", "followers": 42, "id": 1},
+            "github": {"handle": "jdoe", "followers": None},
+        }
+        result = hunter_plugin._normalize_response(data, "john@example.com")
+
+        assert result["twitter_handle"] == "johndoe"
+        assert result["github_handle"] == "jdoe"
+
+    def test_normalize_nested_social_objects_with_null_handles(
+        self, hunter_plugin: HunterPlugin
+    ) -> None:
+        """Test that all-null nested social objects normalize to empty strings."""
+        data = {
+            "twitter": {"handle": None, "id": None, "bio": None},
+            "github": {"handle": None, "id": None},
+        }
+        result = hunter_plugin._normalize_response(data, "info@fcthun.ch")
+
+        assert result["twitter_handle"] == ""
+        assert result["github_handle"] == ""
+
+    def test_extract_handle_rejects_non_string_scalars(
+        self, hunter_plugin: HunterPlugin
+    ) -> None:
+        """Test that non-string, non-dict social values are dropped."""
+        assert hunter_plugin._extract_handle(12345) == ""
+        assert hunter_plugin._extract_handle(["johndoe"]) == ""
+        assert hunter_plugin._extract_handle(None) == ""
+
     def test_build_linkedin_url_from_handle(self, hunter_plugin: HunterPlugin) -> None:
         """Test building LinkedIn URL from handle."""
         url = hunter_plugin._build_linkedin_url("johndoe")

--- a/tests/test_email_enrichment_field_limits.py
+++ b/tests/test_email_enrichment_field_limits.py
@@ -96,6 +96,29 @@ class TestEnrichmentFieldLimits:
         assert person.github_handle == ""
         assert person.company_domain == ""
 
+    def test_non_string_values_are_dropped_not_fatal(
+        self, enrichment_service: EmailEnrichmentService, workspace: Workspace
+    ) -> None:
+        """A non-string value is dropped instead of aborting the insert.
+
+        Seen in prod: nested twitter/github objects slipped through
+        normalization, and their dict repr overflowed the varchar(100)
+        handle columns, so no Person was ever cached.
+        """
+        api_data = {
+            "first_name": "John",
+            "twitter_handle": {"handle": None, "id": None, "bio": None},
+            "github_handle": {"handle": None, "followers": None},
+            "_raw": {},
+        }
+
+        person = _enrich(enrichment_service, workspace, api_data)
+
+        assert person is not None
+        assert person.first_name == "John"
+        assert person.twitter_handle == ""
+        assert person.github_handle == ""
+
     def test_values_within_limits_are_stored_unchanged(
         self, enrichment_service: EmailEnrichmentService, workspace: Workspace
     ) -> None:


### PR DESCRIPTION
## Problem

Prod error at 2026-07-23 12:20 UTC during `trial_started` processing:

```
django.db.utils.DataError: value too long for type character varying(100)
```

The Postgres log shows the failing INSERT into `core_person`: `twitter_handle` and `github_handle` contained **stringified dicts** like `{'handle': None, 'id': None, 'bio': None, ...}`.

The live Hunter.io People API returns social fields as nested objects (`"twitter": {"handle": ...}`), but `_normalize_response` did `data.get("twitter") or ""`, passing the whole dict through. The fit-to-column guard from #141 uses `len(value)`, which for a dict counts keys (10 ≤ 100), so the ~150-char repr reached Postgres and aborted the insert.

**Impact:** Hunter returns these nested objects on every response, so *every* Person insert failed — `core_person` is empty in prod. Enrichment caching never worked, so every webhook re-queried the Hunter API (burning tenant quota), and person data never appeared in notifications.

## Fix

- `hunter.py`: extract the `handle` string from nested twitter/github objects via a new `_extract_handle`, mirroring what `_build_linkedin_url` already does for linkedin. Non-string scalars are dropped.
- `email_enrichment.py`: defense in depth — `_fit_to_column` now drops any non-string value outright instead of letting it abort the insert (a repr is garbage data; storing it would show guessed values).

## Testing

- New normalization tests with the real nested API shape (including the all-null shape from the prod payload) and non-string scalars.
- New field-limits test proving a nested object slipping through normalization no longer aborts the insert.
- Full suite: 1935 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3k1yqkAbEm2A5nFvE4p4m