### PR TITLE
feat(dashboard): replace the getting-started banner with a live setup checklist

### DIFF
--- a/app/core/models.py
+++ b/app/core/models.py
@@ -391,7 +391,9 @@ class Integration(models.Model):
 
     # The subset of INTEGRATION_TYPES that send events into Notipus.
     # Keep in sync when adding a provider above — the dashboard setup
-    # checklist and integrations page both derive "source" state from it.
+    # checklist derives "source" state from it. (The integrations page
+    # overview keeps its own richer display list in
+    # IntegrationService.get_integration_overview.)
     SOURCE_INTEGRATION_TYPES: ClassVar[tuple[str, ...]] = (
         "stripe_customer",
         "shopify",

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -389,6 +389,15 @@ class Integration(models.Model):
         ("hunter_enrichment", "Hunter.io Email Enrichment"),
     )
 
+    # The subset of INTEGRATION_TYPES that send events into Notipus.
+    # Keep in sync when adding a provider above — the dashboard setup
+    # checklist and integrations page both derive "source" state from it.
+    SOURCE_INTEGRATION_TYPES: ClassVar[tuple[str, ...]] = (
+        "stripe_customer",
+        "shopify",
+        "chargify",
+    )
+
     workspace: Any = models.ForeignKey(
         Workspace, on_delete=models.CASCADE, related_name="integrations"
     )

--- a/app/core/services/dashboard.py
+++ b/app/core/services/dashboard.py
@@ -8,7 +8,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime
 from datetime import timezone as dt_timezone
-from typing import Any, ClassVar
+from typing import Any
 
 from core.models import Integration, Plan, UserProfile, Workspace, WorkspaceMember
 from django.contrib.auth.models import User
@@ -87,34 +87,29 @@ class DashboardService:
             workspace=workspace, is_active=True
         )
 
-        has_slack = integrations.filter(integration_type="slack_notifications").exists()
-        sources = integrations.filter(
-            integration_type__in=self.SOURCE_INTEGRATION_TYPES
+        # One query for every flag: unique_together on (workspace,
+        # integration_type) makes this lossless.
+        verified_by_type: dict[str, Any] = dict(
+            integrations.values_list("integration_type", "webhook_verified_at")
         )
+        has_slack = "slack_notifications" in verified_by_type
+        connected_sources = [
+            t for t in Integration.SOURCE_INTEGRATION_TYPES if t in verified_by_type
+        ]
         return {
             "integrations": integrations,
             "has_slack": has_slack,
-            "has_shopify": integrations.filter(integration_type="shopify").exists(),
-            "has_chargify": integrations.filter(integration_type="chargify").exists(),
-            "has_stripe": integrations.filter(
-                integration_type="stripe_customer"
-            ).exists(),
+            "has_shopify": "shopify" in verified_by_type,
+            "has_chargify": "chargify" in verified_by_type,
+            "has_stripe": "stripe_customer" in verified_by_type,
             "setup_progress": self._build_setup_progress(
                 has_slack=has_slack,
-                has_source=sources.exists(),
-                has_first_event=sources.filter(
-                    webhook_verified_at__isnull=False
-                ).exists(),
+                has_source=bool(connected_sources),
+                has_first_event=any(
+                    verified_by_type[t] is not None for t in connected_sources
+                ),
             ),
         }
-
-    # Integration types that send events into Notipus; the Slack
-    # destination and enrichment integrations are not sources.
-    SOURCE_INTEGRATION_TYPES: ClassVar[tuple[str, ...]] = (
-        "stripe_customer",
-        "shopify",
-        "chargify",
-    )
 
     @staticmethod
     def _build_setup_progress(

--- a/app/core/services/dashboard.py
+++ b/app/core/services/dashboard.py
@@ -88,25 +88,27 @@ class DashboardService:
         )
 
         # One query for every flag: unique_together on (workspace,
-        # integration_type) makes this lossless.
-        verified_by_type: dict[str, Any] = dict(
+        # integration_type) makes this lossless. Values are the raw
+        # webhook_verified_at timestamps — None means connected but not
+        # yet verified.
+        verified_at_by_type: dict[str, Any] = dict(
             integrations.values_list("integration_type", "webhook_verified_at")
         )
-        has_slack = "slack_notifications" in verified_by_type
+        has_slack = "slack_notifications" in verified_at_by_type
         connected_sources = [
-            t for t in Integration.SOURCE_INTEGRATION_TYPES if t in verified_by_type
+            t for t in Integration.SOURCE_INTEGRATION_TYPES if t in verified_at_by_type
         ]
         return {
             "integrations": integrations,
             "has_slack": has_slack,
-            "has_shopify": "shopify" in verified_by_type,
-            "has_chargify": "chargify" in verified_by_type,
-            "has_stripe": "stripe_customer" in verified_by_type,
+            "has_shopify": "shopify" in verified_at_by_type,
+            "has_chargify": "chargify" in verified_at_by_type,
+            "has_stripe": "stripe_customer" in verified_at_by_type,
             "setup_progress": self._build_setup_progress(
                 has_slack=has_slack,
                 has_source=bool(connected_sources),
                 has_first_event=any(
-                    verified_by_type[t] is not None for t in connected_sources
+                    verified_at_by_type[t] is not None for t in connected_sources
                 ),
             ),
         }

--- a/app/core/services/dashboard.py
+++ b/app/core/services/dashboard.py
@@ -8,7 +8,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime
 from datetime import timezone as dt_timezone
-from typing import Any
+from typing import Any, ClassVar
 
 from core.models import Integration, Plan, UserProfile, Workspace, WorkspaceMember
 from django.contrib.auth.models import User
@@ -87,16 +87,80 @@ class DashboardService:
             workspace=workspace, is_active=True
         )
 
+        has_slack = integrations.filter(integration_type="slack_notifications").exists()
+        sources = integrations.filter(
+            integration_type__in=self.SOURCE_INTEGRATION_TYPES
+        )
         return {
             "integrations": integrations,
-            "has_slack": integrations.filter(
-                integration_type="slack_notifications"
-            ).exists(),
+            "has_slack": has_slack,
             "has_shopify": integrations.filter(integration_type="shopify").exists(),
             "has_chargify": integrations.filter(integration_type="chargify").exists(),
             "has_stripe": integrations.filter(
                 integration_type="stripe_customer"
             ).exists(),
+            "setup_progress": self._build_setup_progress(
+                has_slack=has_slack,
+                has_source=sources.exists(),
+                has_first_event=sources.filter(
+                    webhook_verified_at__isnull=False
+                ).exists(),
+            ),
+        }
+
+    # Integration types that send events into Notipus; the Slack
+    # destination and enrichment integrations are not sources.
+    SOURCE_INTEGRATION_TYPES: ClassVar[tuple[str, ...]] = (
+        "stripe_customer",
+        "shopify",
+        "chargify",
+    )
+
+    @staticmethod
+    def _build_setup_progress(
+        *, has_slack: bool, has_source: bool, has_first_event: bool
+    ) -> dict[str, Any]:
+        """Build the dashboard setup checklist state.
+
+        The checklist never renders at zero, honestly: reaching the
+        dashboard requires an account, a plan, and a workspace, so
+        those three steps are genuinely complete and counted — no
+        fabricated head start.
+
+        Args:
+            has_slack: Whether a Slack destination is connected.
+            has_source: Whether any event source is connected.
+            has_first_event: Whether any source has received a
+                verified webhook.
+
+        Returns:
+            Dict with the step list (key, label, done), done_count,
+            total, percent, and complete.
+        """
+        steps = [
+            {"key": "account", "label": "Create your account", "done": True},
+            {"key": "plan", "label": "Choose your plan", "done": True},
+            {"key": "workspace", "label": "Create your workspace", "done": True},
+            {"key": "slack", "label": "Connect Slack", "done": has_slack},
+            {
+                "key": "source",
+                "label": "Connect an event source",
+                "done": has_source,
+            },
+            {
+                "key": "first_event",
+                "label": "Receive your first event",
+                "done": has_first_event,
+            },
+        ]
+        done_count = sum(1 for step in steps if step["done"])
+        total = len(steps)
+        return {
+            "steps": steps,
+            "done_count": done_count,
+            "total": total,
+            "percent": round(done_count * 100 / total),
+            "complete": done_count == total,
         }
 
     def _get_recent_activity(self, workspace: Workspace) -> list[dict[str, Any]]:

--- a/app/core/templates/core/dashboard.html.j2
+++ b/app/core/templates/core/dashboard.html.j2
@@ -26,7 +26,7 @@
                 <div class="bg-gradient-to-r from-primary-50 to-blue-50 border border-primary-200 rounded-xl p-6 mb-8">
                     <div class="flex items-center justify-between flex-wrap gap-3">
                         <h3 class="text-lg font-semibold text-primary-900 flex items-center gap-2">
-                            Finish your setup <i class="ti ti-rocket text-primary-600"></i>
+                            Finish your setup <i class="ti ti-rocket text-primary-600" aria-hidden="true"></i>
                         </h3>
                         <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800 border border-primary-200">
                             {{ setup_progress.done_count }} of {{ setup_progress.total }} steps done
@@ -47,10 +47,12 @@
                         {% for step in setup_progress.steps %}
                             <li class="flex items-start gap-3 text-sm">
                                 {% if step.done %}
-                                    <i class="ti ti-circle-check text-green-600 text-lg leading-5"></i>
+                                    <i class="ti ti-circle-check text-green-600 text-lg leading-5"
+                                       aria-hidden="true"></i>
                                     <span class="text-primary-800">{{ step.label }}</span>
                                 {% else %}
-                                    <i class="ti ti-circle text-primary-300 text-lg leading-5"></i>
+                                    <i class="ti ti-circle text-primary-300 text-lg leading-5"
+                                       aria-hidden="true"></i>
                                     {% if step.key == 'slack' %}
                                         <a href="{% url 'core:integrate_slack' %}"
                                            class="font-medium text-primary-700 hover:text-primary-900 hover:underline">{{ step.label }}</a>

--- a/app/core/templates/core/dashboard.html.j2
+++ b/app/core/templates/core/dashboard.html.j2
@@ -21,50 +21,52 @@
 
         <!-- Main content -->
         <div class="max-w-7xl mx-auto py-8 sm:px-6 lg:px-8">
-            <!-- Getting Started -->
-            {% if not has_slack and not has_shopify and not has_chargify %}
+            <!-- Getting Started: setup checklist driven by real integration state -->
+            {% if setup_progress and not setup_progress.complete %}
                 <div class="bg-gradient-to-r from-primary-50 to-blue-50 border border-primary-200 rounded-xl p-6 mb-8">
-                    <div class="flex">
-                        <div class="flex-shrink-0">
-                            <div class="h-12 w-12 bg-primary-100 rounded-xl flex items-center justify-center">
-                                <svg class="h-6 w-6 text-primary-600"
-                                     fill="currentColor"
-                                     viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd">
-                                    </path>
-                                </svg>
-                            </div>
-                        </div>
-                        <div class="ml-5">
-                            <div class="flex items-center">
-                                <h3 class="text-lg font-semibold text-primary-900 flex items-center gap-2">
-                                    Welcome to Notipus! <i class="ti ti-rocket text-primary-600"></i>
-                                </h3>
-                                <span class="ml-3 inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800 border border-primary-200">
-                                    Getting Started
-                                </span>
-                            </div>
-                            <div class="mt-2 text-sm text-primary-700">
-                                <p>Let's get you set up with your first integration. Connect a service to start receiving webhook notifications:</p>
-                            </div>
-                            <div class="mt-4 flex flex-wrap gap-3">
-                                <a href="{% url 'core:integrate_slack' %}"
-                                   class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 transition-all duration-200">
-                                    <i class="ti ti-brand-slack mr-2"></i>
-                                    Connect Slack
-                                </a>
-                                <a href="{% url 'core:integrate_shopify' %}"
-                                   class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 transition-all duration-200">
-                                    <i class="ti ti-shopping-cart mr-2"></i>
-                                    Connect Shopify
-                                </a>
-                                <a href="{% url 'core:integrations' %}"
-                                   class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-all duration-200">
-                                    View All Integrations
-                                </a>
-                            </div>
+                    <div class="flex items-center justify-between flex-wrap gap-3">
+                        <h3 class="text-lg font-semibold text-primary-900 flex items-center gap-2">
+                            Finish your setup <i class="ti ti-rocket text-primary-600"></i>
+                        </h3>
+                        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-100 text-primary-800 border border-primary-200">
+                            {{ setup_progress.done_count }} of {{ setup_progress.total }} steps done
+                        </span>
+                    </div>
+                    <div class="mt-4"
+                         role="progressbar"
+                         aria-valuenow="{{ setup_progress.percent }}"
+                         aria-valuemin="0"
+                         aria-valuemax="100"
+                         aria-label="Setup progress">
+                        <div class="w-full bg-primary-100 rounded-full h-2">
+                            <div class="bg-primary-600 h-2 rounded-full transition-all duration-500"
+                                 style="width: {{ setup_progress.percent }}%"></div>
                         </div>
                     </div>
+                    <ul class="mt-4 space-y-2">
+                        {% for step in setup_progress.steps %}
+                            <li class="flex items-start gap-3 text-sm">
+                                {% if step.done %}
+                                    <i class="ti ti-circle-check text-green-600 text-lg leading-5"></i>
+                                    <span class="text-primary-800">{{ step.label }}</span>
+                                {% else %}
+                                    <i class="ti ti-circle text-primary-300 text-lg leading-5"></i>
+                                    {% if step.key == 'slack' %}
+                                        <a href="{% url 'core:integrate_slack' %}"
+                                           class="font-medium text-primary-700 hover:text-primary-900 hover:underline">{{ step.label }}</a>
+                                        <span class="text-primary-500">— where your notifications land</span>
+                                    {% elif step.key == 'source' %}
+                                        <a href="{% url 'core:integrations' %}"
+                                           class="font-medium text-primary-700 hover:text-primary-900 hover:underline">{{ step.label }}</a>
+                                        <span class="text-primary-500">— Stripe, Shopify, or Chargify</span>
+                                    {% else %}
+                                        <span class="font-medium text-primary-700">{{ step.label }}</span>
+                                        <span class="text-primary-500">— completes automatically when your first event arrives</span>
+                                    {% endif %}
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
                 </div>
             {% endif %}
 

--- a/tests/core/tests_services.py
+++ b/tests/core/tests_services.py
@@ -691,6 +691,102 @@ class DashboardServiceTest(TestCase):
         self.assertFalse(result["has_chargify"])
         self.assertFalse(result["has_stripe"])
 
+    def test_setup_progress_starts_at_half_for_bare_workspace(self) -> None:
+        """A workspace with no integrations shows 3 of 6 steps done.
+
+        Account, plan, and workspace are genuinely complete by the time
+        the dashboard renders — the checklist counts them instead of
+        starting at zero, and never counts anything else unearned.
+        """
+        from core.services.dashboard import DashboardService
+
+        service = DashboardService()
+        progress = service._get_integration_data(self.workspace)["setup_progress"]
+
+        self.assertEqual(progress["done_count"], 3)
+        self.assertEqual(progress["total"], 6)
+        self.assertEqual(progress["percent"], 50)
+        self.assertFalse(progress["complete"])
+        done_keys = {s["key"] for s in progress["steps"] if s["done"]}
+        self.assertEqual(done_keys, {"account", "plan", "workspace"})
+
+    def test_setup_progress_counts_slack_and_source(self) -> None:
+        """Connecting Slack and a source completes those steps only.
+
+        The first-event step stays open until a webhook is verified.
+        """
+        from core.services.dashboard import DashboardService
+
+        Integration.objects.create(
+            workspace=self.workspace,
+            integration_type="slack_notifications",
+            is_active=True,
+        )
+        Integration.objects.create(
+            workspace=self.workspace,
+            integration_type="stripe_customer",
+            is_active=True,
+        )
+
+        service = DashboardService()
+        progress = service._get_integration_data(self.workspace)["setup_progress"]
+
+        self.assertEqual(progress["done_count"], 5)
+        self.assertFalse(progress["complete"])
+        open_keys = {s["key"] for s in progress["steps"] if not s["done"]}
+        self.assertEqual(open_keys, {"first_event"})
+
+    def test_setup_progress_completes_on_first_verified_webhook(self) -> None:
+        """A verified webhook on a source integration completes setup."""
+        from core.services.dashboard import DashboardService
+        from django.utils import timezone
+
+        Integration.objects.create(
+            workspace=self.workspace,
+            integration_type="slack_notifications",
+            is_active=True,
+        )
+        Integration.objects.create(
+            workspace=self.workspace,
+            integration_type="chargify",
+            is_active=True,
+            webhook_verified_at=timezone.now(),
+        )
+
+        service = DashboardService()
+        progress = service._get_integration_data(self.workspace)["setup_progress"]
+
+        self.assertEqual(progress["done_count"], 6)
+        self.assertEqual(progress["percent"], 100)
+        self.assertTrue(progress["complete"])
+
+    def test_setup_progress_ignores_non_source_integrations(self) -> None:
+        """Enrichment and inactive integrations earn no source credit.
+
+        Hunter.io is not an event source, and an inactive source must
+        not count as connected.
+        """
+        from core.services.dashboard import DashboardService
+        from django.utils import timezone
+
+        Integration.objects.create(
+            workspace=self.workspace,
+            integration_type="hunter_enrichment",
+            is_active=True,
+        )
+        Integration.objects.create(
+            workspace=self.workspace,
+            integration_type="shopify",
+            is_active=False,
+            webhook_verified_at=timezone.now(),
+        )
+
+        service = DashboardService()
+        progress = service._get_integration_data(self.workspace)["setup_progress"]
+
+        open_keys = {s["key"] for s in progress["steps"] if not s["done"]}
+        self.assertEqual(open_keys, {"slack", "source", "first_event"})
+
     def test_get_trial_info_active_trial(self) -> None:
         """Test trial info for active trial."""
         from core.services.dashboard import DashboardService


### PR DESCRIPTION
## Summary

UX psychology item #2 (goal gradient): the dashboard's getting-started banner was static decoration with a state bug — it keyed off Slack/Shopify/Chargify only, so a Stripe-only workspace still saw "connect your first integration". This PR replaces it with a **setup checklist driven by real integration state**.

## The checklist

| Step | Signal |
|---|---|
| Create your account | always done (you're logged in) |
| Choose your plan | always done (required before workspace) |
| Create your workspace | always done (required before dashboard) |
| Connect Slack | active `slack_notifications` Integration |
| Connect an event source | active `stripe_customer`/`shopify`/`chargify` Integration |
| Receive your first event | any source Integration with `webhook_verified_at` set — the same signal the integrations page renders as "Receiving events" |

**Honest goal gradient**: the bar starts at 3 of 6 (50%) because those steps are *genuinely* complete by the time the dashboard renders — no fabricated head start. Pending steps link to their setup pages; the last step explains it completes automatically. The banner disappears entirely once setup is complete.

## Design review

Reviewed with the frontend-design skill and screenshot-verified via Playwright at 1440px and 390px in all three states (3/6, 5/6, complete). Fixes found during review: a non-rendering `ti-circle-check-filled` glyph (switched to the codebase-standard `ti-circle-check`), a stacked double-welcome heading (banner now says "Finish your setup"), system-side copy reworded to the user's vocabulary, and icons pinned to the first line on wrapped mobile rows. `role=progressbar` with aria values; djlint clean.

## Testing

- 4 new `DashboardService` tests: 3/6 for a bare workspace, 5/6 with Slack+source, complete on verified webhook, and no credit for enrichment/inactive integrations
- Full suite: **1964 passed**; ruff, mypy, djlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)