### PR TITLE
feat(onboarding): build before you commit - auto-provision free workspaces

### DIFF
--- a/app/core/services/dashboard.py
+++ b/app/core/services/dashboard.py
@@ -120,9 +120,10 @@ class DashboardService:
         """Build the dashboard setup checklist state.
 
         The checklist never renders at zero, honestly: reaching the
-        dashboard requires an account, a plan, and a workspace, so
-        those three steps are genuinely complete and counted — no
-        fabricated head start.
+        dashboard requires an account and a workspace, so those two
+        steps are genuinely complete and counted — no fabricated head
+        start. Plan choice is not a step: workspaces start on the free
+        plan and upgrading is a later decision, not setup.
 
         Args:
             has_slack: Whether a Slack destination is connected.
@@ -136,7 +137,6 @@ class DashboardService:
         """
         steps = [
             {"key": "account", "label": "Create your account", "done": True},
-            {"key": "plan", "label": "Choose your plan", "done": True},
             {"key": "workspace", "label": "Create your workspace", "done": True},
             {"key": "slack", "label": "Connect Slack", "done": has_slack},
             {

--- a/app/core/templates/core/integrations.html.j2
+++ b/app/core/templates/core/integrations.html.j2
@@ -26,22 +26,7 @@
                 </div>
             </div>
 
-            <!-- Messages -->
-            {% if messages %}
-                {% for message in messages %}
-                    <div class="mb-6 p-4 rounded-xl {% if message.tags == 'error' %}bg-red-50 border border-red-200{% else %}bg-green-50 border border-green-200{% endif %}">
-                        <div class="flex items-center gap-3">
-                            {% if message.tags == 'error' %}
-                                <i class="ti ti-alert-circle text-red-500 text-lg"></i>
-                            {% else %}
-                                <i class="ti ti-circle-check text-green-500 text-lg"></i>
-                            {% endif %}
-                            <p class="text-sm {% if message.tags == 'error' %}text-red-700{% else %}text-green-700{% endif %}">{{ message }}</p>
-                        </div>
-                    </div>
-                {% endfor %}
-            {% endif %}
-
+            <!-- Flash messages render once, in base.html.j2 -->
             <!-- Integration Sections Grid -->
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
 

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -29,14 +29,22 @@ _get_user_workspace = get_workspace_for_user
 
 @login_required
 def select_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
-    """Plan selection page.
+    """Plan selection page for users who do not have a workspace yet.
+
+    New signups get a free workspace auto-provisioned by the dashboard,
+    so plan decisions for existing workspaces belong to the upgrade
+    page — anyone who lands here with a workspace is redirected there.
 
     Args:
         request: The HTTP request object.
 
     Returns:
-        Plan selection page or redirect on successful selection.
+        Plan selection page, redirect on successful selection, or
+        redirect to the upgrade page for workspace owners.
     """
+    if _get_user_workspace(request.user):
+        return redirect("core:upgrade_plan")
+
     if request.method == "POST":
         selected_plan = request.POST.get("plan")
         # Validate against available plans

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -17,7 +17,7 @@ from webhooks.services.rate_limiter import rate_limiter
 
 from .. import analytics
 from ..models import Plan
-from ..permissions import get_workspace_for_user
+from ..permissions import get_workspace_for_user, get_workspace_member
 from .integrations.base import require_admin_role
 
 logger = logging.getLogger(__name__)
@@ -33,16 +33,21 @@ def select_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
 
     New signups get a free workspace auto-provisioned by the dashboard,
     so plan decisions for existing workspaces belong to the upgrade
-    page — anyone who lands here with a workspace is redirected there.
+    page — owners and admins who land here are redirected there, and
+    plain members go to the dashboard (upgrade_plan would bounce them
+    anyway).
 
     Args:
         request: The HTTP request object.
 
     Returns:
-        Plan selection page, redirect on successful selection, or
-        redirect to the upgrade page for workspace owners.
+        Plan selection page, redirect on successful selection, or a
+        role-appropriate redirect for users with a workspace.
     """
     if _get_user_workspace(request.user):
+        member = get_workspace_member(request.user)
+        if member and member.role not in ("owner", "admin"):
+            return redirect("core:dashboard")
         return redirect("core:upgrade_plan")
 
     if request.method == "POST":

--- a/app/core/views/dashboard.py
+++ b/app/core/views/dashboard.py
@@ -27,7 +27,8 @@ def dashboard(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
         request: The HTTP request object.
 
     Returns:
-        Dashboard page or redirect to workspace creation.
+        Dashboard page, or a redirect to the integrations hub right
+        after the user's free workspace is auto-provisioned.
     """
     from core.services.dashboard import DashboardService
 
@@ -35,12 +36,16 @@ def dashboard(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
     dashboard_data = dashboard_service.get_dashboard_data(request.user)
 
     if not dashboard_data:
-        # User doesn't have a workspace yet
-        # First, ensure they've selected a plan
-        if "selected_plan" not in request.session:
-            return redirect("core:select_plan")
-        # Then redirect to workspace creation
-        return redirect("core:create_workspace")
+        # First visit: provision a free workspace instead of forcing a
+        # plan decision before the user has built anything. Plan choice
+        # moves to the upgrade page, once there is something to lose.
+        workspace = _provision_free_workspace(request)
+        messages.success(
+            request,
+            f"Your workspace '{workspace.name}' is ready. "
+            f"Connect your first integration to start receiving notifications.",
+        )
+        return redirect("core:integrations")
 
     # Flatten the data for template compatibility
     workspace = dashboard_data["workspace"]
@@ -116,9 +121,84 @@ def _create_stripe_checkout_for_plan(
         return None
 
 
+def _create_workspace_records(
+    user: Any, *, name: str, shop_domain: str | None, plan: str
+) -> Workspace:
+    """Create a workspace with its owner membership and user profile.
+
+    Args:
+        user: The user who becomes the workspace owner.
+        name: Workspace display name.
+        shop_domain: Optional shop domain; empty values are stored as
+            None so the unique constraint allows multiple workspaces
+            without domains (PostgreSQL allows multiple NULLs but not
+            multiple empty strings).
+        plan: Internal plan name; paid plans start in trial status.
+
+    Returns:
+        The created Workspace.
+    """
+    workspace = Workspace.objects.create(
+        name=name,
+        shop_domain=shop_domain or None,
+        subscription_plan=plan,
+        subscription_status="trial" if plan != "free" else "active",
+    )
+    WorkspaceMember.objects.create(user=user, workspace=workspace, role="owner")
+
+    # Also create/update user profile for backward compatibility
+    # (slack_user_id). get_or_create handles users who already have a
+    # profile from SSO.
+    user_profile, created = UserProfile.objects.get_or_create(
+        user=user,
+        defaults={"workspace": workspace, "slack_user_id": None},
+    )
+    if not created:
+        user_profile.workspace = workspace
+        user_profile.save()
+
+    return workspace
+
+
+def _provision_free_workspace(request: HttpRequest) -> Workspace:
+    """Create the user's default free workspace without a form.
+
+    Users build before they commit: they land in the product on the
+    free plan with a workspace named after their Slack team (captured
+    at OAuth) or their username, and pick a paid plan later from the
+    upgrade page.
+
+    Args:
+        request: The HTTP request object for the workspace-less user.
+
+    Returns:
+        The provisioned Workspace.
+    """
+    # get_username() exists on the AbstractBaseUser union; the view is
+    # login_required so this is never an AnonymousUser.
+    name = (
+        request.session.get(SLACK_TEAM_NAME_SESSION_KEY)
+        or f"{request.user.get_username()}'s Workspace"
+    )
+    workspace = _create_workspace_records(
+        request.user, name=name, shop_domain=None, plan="free"
+    )
+    request.session.pop(SLACK_TEAM_NAME_SESSION_KEY, None)
+    request.session.pop("selected_plan", None)
+    analytics.track_event(
+        request, "workspace_created", {"plan": "free", "method": "auto"}
+    )
+    logger.info(f"Auto-provisioned free workspace '{name}' for user {request.user.pk}")
+    return workspace
+
+
 @login_required
 def create_workspace(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
     """Workspace creation page.
+
+    Kept as the manual path (custom name, shop domain, or a paid plan
+    already staged in the session); new signups normally get a free
+    workspace auto-provisioned by the dashboard instead.
 
     Args:
         request: The HTTP request object.
@@ -132,34 +212,12 @@ def create_workspace(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
         selected_plan = request.session.get("selected_plan", "free")
 
         if name:
-            # Create workspace with selected plan
-            # Use None for empty shop_domain to allow multiple orgs without domains
-            # (PostgreSQL unique constraint allows multiple NULLs but not empty strings)
-            workspace = Workspace.objects.create(
+            workspace = _create_workspace_records(
+                request.user,
                 name=name,
-                shop_domain=shop_domain or None,
-                subscription_plan=selected_plan,
-                # If paid plan with trial, set status to trial
-                subscription_status="trial" if selected_plan != "free" else "active",
+                shop_domain=shop_domain,
+                plan=selected_plan,
             )
-
-            # Create workspace member with owner role
-            WorkspaceMember.objects.create(
-                user=request.user,
-                workspace=workspace,
-                role="owner",
-            )
-
-            # Also create/update user profile for backward compatibility (slack_user_id)
-            # Use get_or_create to handle users who already have a profile from SSO
-            user_profile, created = UserProfile.objects.get_or_create(
-                user=request.user,
-                defaults={"workspace": workspace, "slack_user_id": None},
-            )
-            if not created:
-                # Update existing profile's workspace
-                user_profile.workspace = workspace
-                user_profile.save()
 
             # Clear the selected plan from session
             if "selected_plan" in request.session:

--- a/app/core/views/dashboard.py
+++ b/app/core/views/dashboard.py
@@ -4,10 +4,12 @@ This module handles the main dashboard and workspace settings.
 """
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect, render
 
@@ -168,11 +170,15 @@ def _provision_free_workspace(request: HttpRequest) -> Workspace:
     at OAuth) or their username, and pick a paid plan later from the
     upgrade page.
 
+    Safe under concurrent first visits: the user row is locked while
+    provisioning, so a racing request waits and then adopts the
+    winner's workspace instead of creating a duplicate.
+
     Args:
         request: The HTTP request object for the workspace-less user.
 
     Returns:
-        The provisioned Workspace.
+        The provisioned (or concurrently created) Workspace.
     """
     # get_username() exists on the AbstractBaseUser union; the view is
     # login_required so this is never an AnonymousUser.
@@ -180,9 +186,22 @@ def _provision_free_workspace(request: HttpRequest) -> Workspace:
         request.session.get(SLACK_TEAM_NAME_SESSION_KEY)
         or f"{request.user.get_username()}'s Workspace"
     )
-    workspace = _create_workspace_records(
-        request.user, name=name, shop_domain=None, plan="free"
-    )
+
+    with transaction.atomic():
+        get_user_model().objects.select_for_update().get(pk=request.user.pk)
+        existing = (
+            WorkspaceMember.objects.filter(user=request.user, is_active=True)
+            .select_related("workspace")
+            .first()
+        )
+        if existing:
+            # cast: without the django mypy plugin, FK attribute access
+            # types as Any.
+            return cast(Workspace, existing.workspace)
+        workspace = _create_workspace_records(
+            request.user, name=name, shop_domain=None, plan="free"
+        )
+
     request.session.pop(SLACK_TEAM_NAME_SESSION_KEY, None)
     request.session.pop("selected_plan", None)
     analytics.track_event(

--- a/tests/core/tests_onboarding_provisioning.py
+++ b/tests/core/tests_onboarding_provisioning.py
@@ -1,0 +1,117 @@
+"""Tests for build-before-plan onboarding: auto-provisioned workspaces.
+
+New signups no longer pick a plan before entering the product. The
+dashboard provisions a free workspace on first visit (named after the
+Slack team captured at OAuth, else the username) and sends the user to
+the integrations hub; plan decisions move to the upgrade page.
+"""
+
+import pytest
+from core.constants import SLACK_TEAM_NAME_SESSION_KEY
+from core.models import Workspace, WorkspaceMember
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.fixture
+def user(db: None) -> User:
+    """Create a user without any workspace."""
+    return User.objects.create_user(
+        username="newbie", email="newbie@example.com", password="x"
+    )
+
+
+@pytest.fixture
+def logged_in_client(client: Client, user: User) -> Client:
+    """Return a test client with the workspace-less user logged in."""
+    client.force_login(user)
+    return client
+
+
+class TestDashboardAutoProvisioning:
+    """First dashboard visit provisions a free workspace, no form."""
+
+    def test_first_visit_provisions_free_workspace(
+        self, logged_in_client: Client, user: User
+    ) -> None:
+        """A workspace-less user gets a free workspace and lands on
+        the integrations hub instead of the plan-selection funnel."""
+        response = logged_in_client.get(reverse("core:dashboard"))
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:integrations")
+        workspace = Workspace.objects.get()
+        assert workspace.subscription_plan == "free"
+        assert workspace.subscription_status == "active"
+        member = WorkspaceMember.objects.get(user=user)
+        assert member.workspace == workspace
+        assert member.role == "owner"
+
+    def test_workspace_named_after_slack_team(self, logged_in_client: Client) -> None:
+        """The Slack team name captured at OAuth names the workspace
+        and is cleared from the session once used."""
+        session = logged_in_client.session
+        session[SLACK_TEAM_NAME_SESSION_KEY] = "Acme Inc"
+        session.save()
+
+        logged_in_client.get(reverse("core:dashboard"))
+
+        assert Workspace.objects.get().name == "Acme Inc"
+        assert SLACK_TEAM_NAME_SESSION_KEY not in logged_in_client.session
+
+    def test_workspace_name_falls_back_to_username(
+        self, logged_in_client: Client
+    ) -> None:
+        """Without a Slack team name, the username names the workspace."""
+        logged_in_client.get(reverse("core:dashboard"))
+
+        assert Workspace.objects.get().name == "newbie's Workspace"
+
+    def test_second_visit_does_not_duplicate(self, logged_in_client: Client) -> None:
+        """A user with a workspace renders the dashboard normally."""
+        logged_in_client.get(reverse("core:dashboard"))
+        response = logged_in_client.get(reverse("core:dashboard"))
+
+        assert response.status_code == 200
+        assert Workspace.objects.count() == 1
+
+    def test_stale_selected_plan_session_key_is_cleared(
+        self, logged_in_client: Client
+    ) -> None:
+        """A leftover selected_plan key cannot leak into provisioning:
+        the workspace is free and the key is removed."""
+        session = logged_in_client.session
+        session["selected_plan"] = "pro"
+        session.save()
+
+        logged_in_client.get(reverse("core:dashboard"))
+
+        assert Workspace.objects.get().subscription_plan == "free"
+        assert "selected_plan" not in logged_in_client.session
+
+
+class TestSelectPlanRedirect:
+    """Plan selection belongs to the upgrade page once a workspace exists."""
+
+    def test_workspace_owner_is_redirected_to_upgrade(
+        self, logged_in_client: Client, user: User
+    ) -> None:
+        """A user with a workspace never sees the pre-signup plan page."""
+        workspace = Workspace.objects.create(
+            name="Acme", subscription_plan="free", subscription_status="active"
+        )
+        WorkspaceMember.objects.create(user=user, workspace=workspace, role="owner")
+
+        response = logged_in_client.get(reverse("core:select_plan"))
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:upgrade_plan")
+
+    def test_workspace_less_user_still_sees_plans(
+        self, logged_in_client: Client
+    ) -> None:
+        """Without a workspace the page renders (manual funnel intact)."""
+        response = logged_in_client.get(reverse("core:select_plan"))
+
+        assert response.status_code == 200

--- a/tests/core/tests_onboarding_provisioning.py
+++ b/tests/core/tests_onboarding_provisioning.py
@@ -90,6 +90,30 @@ class TestDashboardAutoProvisioning:
         assert Workspace.objects.get().subscription_plan == "free"
         assert "selected_plan" not in logged_in_client.session
 
+    def test_racing_provision_adopts_existing_workspace(
+        self, logged_in_client: Client, user: User
+    ) -> None:
+        """Provisioning behind an existing membership returns it.
+
+        Simulates the loser of a concurrent first-visit race: the
+        membership already exists by the time provisioning runs, so no
+        duplicate workspace is created.
+        """
+        from core.views.dashboard import _provision_free_workspace
+        from django.test import RequestFactory
+
+        workspace = Workspace.objects.create(
+            name="Winner", subscription_plan="free", subscription_status="active"
+        )
+        WorkspaceMember.objects.create(user=user, workspace=workspace, role="owner")
+
+        request = RequestFactory().get(reverse("core:dashboard"))
+        request.user = user
+        request.session = logged_in_client.session
+
+        assert _provision_free_workspace(request) == workspace
+        assert Workspace.objects.count() == 1
+
 
 class TestSelectPlanRedirect:
     """Plan selection belongs to the upgrade page once a workspace exists."""
@@ -107,6 +131,21 @@ class TestSelectPlanRedirect:
 
         assert response.status_code == 302
         assert response.url == reverse("core:upgrade_plan")
+
+    def test_plain_member_is_redirected_to_dashboard(
+        self, logged_in_client: Client, user: User
+    ) -> None:
+        """Non-admin members go to the dashboard, not the upgrade page
+        (which would bounce them for lacking billing permissions)."""
+        workspace = Workspace.objects.create(
+            name="Acme", subscription_plan="free", subscription_status="active"
+        )
+        WorkspaceMember.objects.create(user=user, workspace=workspace, role="user")
+
+        response = logged_in_client.get(reverse("core:select_plan"))
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:dashboard")
 
     def test_workspace_less_user_still_sees_plans(
         self, logged_in_client: Client

--- a/tests/core/tests_services.py
+++ b/tests/core/tests_services.py
@@ -691,24 +691,26 @@ class DashboardServiceTest(TestCase):
         self.assertFalse(result["has_chargify"])
         self.assertFalse(result["has_stripe"])
 
-    def test_setup_progress_starts_at_half_for_bare_workspace(self) -> None:
-        """A workspace with no integrations shows 3 of 6 steps done.
+    def test_setup_progress_starts_partially_done_for_bare_workspace(self) -> None:
+        """A workspace with no integrations shows 2 of 5 steps done.
 
-        Account, plan, and workspace are genuinely complete by the time
-        the dashboard renders — the checklist counts them instead of
+        Account and workspace are genuinely complete by the time the
+        dashboard renders — the checklist counts them instead of
         starting at zero, and never counts anything else unearned.
+        Plan choice is not a setup step: workspaces start on the free
+        plan and upgrading is a later decision.
         """
         from core.services.dashboard import DashboardService
 
         service = DashboardService()
         progress = service._get_integration_data(self.workspace)["setup_progress"]
 
-        self.assertEqual(progress["done_count"], 3)
-        self.assertEqual(progress["total"], 6)
-        self.assertEqual(progress["percent"], 50)
+        self.assertEqual(progress["done_count"], 2)
+        self.assertEqual(progress["total"], 5)
+        self.assertEqual(progress["percent"], 40)
         self.assertFalse(progress["complete"])
         done_keys = {s["key"] for s in progress["steps"] if s["done"]}
-        self.assertEqual(done_keys, {"account", "plan", "workspace"})
+        self.assertEqual(done_keys, {"account", "workspace"})
 
     def test_setup_progress_counts_slack_and_source(self) -> None:
         """Connecting Slack and a source completes those steps only.
@@ -731,7 +733,7 @@ class DashboardServiceTest(TestCase):
         service = DashboardService()
         progress = service._get_integration_data(self.workspace)["setup_progress"]
 
-        self.assertEqual(progress["done_count"], 5)
+        self.assertEqual(progress["done_count"], 4)
         self.assertFalse(progress["complete"])
         open_keys = {s["key"] for s in progress["steps"] if not s["done"]}
         self.assertEqual(open_keys, {"first_event"})
@@ -756,7 +758,7 @@ class DashboardServiceTest(TestCase):
         service = DashboardService()
         progress = service._get_integration_data(self.workspace)["setup_progress"]
 
-        self.assertEqual(progress["done_count"], 6)
+        self.assertEqual(progress["done_count"], 5)
         self.assertEqual(progress["percent"], 100)
         self.assertTrue(progress["complete"])
 

--- a/tests/core/tests_templates.py
+++ b/tests/core/tests_templates.py
@@ -220,9 +220,21 @@ class BillingTemplateTests(TestCase):
         response = self.client.get(reverse("core:billing_dashboard"))
         assert response.status_code == 200
 
-    def test_select_plan_renders(self) -> None:
-        """Test select plan page renders."""
+    def test_select_plan_redirects_workspace_owner_to_upgrade(self) -> None:
+        """Users with a workspace change plans on the upgrade page."""
         self.client.force_login(self.user)
+        response = self.client.get(reverse("core:select_plan"))
+        assert response.status_code == 302
+        assert response.url == reverse("core:upgrade_plan")
+
+    def test_select_plan_renders_for_workspace_less_user(self) -> None:
+        """The plan page still renders for a user without a workspace."""
+        lone_user = User.objects.create_user(
+            username="planless",
+            email="planless@example.com",
+            password="testpass123",
+        )
+        self.client.force_login(lone_user)
         response = self.client.get(reverse("core:select_plan"))
         assert response.status_code == 200
 


### PR DESCRIPTION
## Summary

UX psychology item #3 (IKEA effect / endowment), full inversion as planned: new signups no longer face a pricing decision before they've seen the product.

**Old flow:** signup → select plan → confirm plan → create workspace form → dashboard
**New flow:** signup → dashboard auto-provisions a free workspace → integrations hub ("Your workspace 'Acme Inc' is ready. Connect your first integration…")

Plan choice moves to the upgrade page, made when there's something to lose (a connected Slack, subscribed webhooks, a stream of notifications) — and the soft-limit alert emails + usage banners already prompt it at the right moments.

## Changes

- **Dashboard**: workspace-less users get a free workspace provisioned inline — named after the Slack team captured at OAuth (`SLACK_TEAM_NAME_SESSION_KEY`), else `{username}'s Workspace` — then land on the integrations hub with a success flash.
- **select_plan**: redirects users who already have a workspace to `upgrade_plan`. After this change the page has no inbound links; it remains functional for workspace-less users (the manual funnel).
- **create_workspace**: kept as the manual path (custom name, shop domain, paid plan staged in session). Its record creation (Workspace + owner WorkspaceMember + UserProfile backfill) is extracted into `_create_workspace_records`, shared with auto-provisioning.
- **Setup checklist**: drops "Choose your plan" (no longer a setup step — free is the valid default, upgrading is a later decision) and starts at an honest 2 of 5.
- **Bug fix**: flash messages double-rendered on the integrations page (both base template and page template rendered `messages`) — pre-existing, surfaced by the new landing flash; page-level block removed.

## Funnel note (deliberate)

Paid-trial starts are no longer forced at signup; `workspace_created` analytics now carry `method: auto` so conversion can be compared before/after. The GA4 `select_plan`/`begin_checkout` events still fire on their respective paths.

## Testing

- New `tests_onboarding_provisioning.py`: provisioning (plan/status/owner role), Slack-team naming + session cleanup, username fallback, no duplicate on second visit, stale `selected_plan` cleared, select_plan redirect for owners, plans page intact for workspace-less users
- Updated checklist tests (2/5 → 4/5 → 5/5) and select_plan template tests
- Full suite: **1976 passed**; ruff, mypy, djlint clean; screenshot-verified landing + checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)