### PR TITLE
feat(billing): annual billing in-app — yearly checkout, toggle, honest FAQ

### DIFF
--- a/app/core/services/stripe.py
+++ b/app/core/services/stripe.py
@@ -457,6 +457,47 @@ class StripeAPI:
             logger.error(f"Unexpected error retrieving checkout session: {e!s}")
             return None
 
+    def expire_open_checkout_sessions(self, customer_id: str) -> int:
+        """Expire all open Checkout Sessions for a customer.
+
+        Called before creating a new checkout session so a customer can
+        never hold two live sessions at once — completing a stale
+        session after paying a newer one would create a second
+        subscription (double-billing). Best-effort: failures are logged
+        and must not block the new checkout.
+
+        Args:
+            customer_id: The Stripe customer ID.
+
+        Returns:
+            Number of sessions expired.
+        """
+        expired = 0
+        try:
+            sessions = stripe.checkout.Session.list(
+                customer=customer_id, status="open", limit=10, api_key=self.api_key
+            )
+            for session in _safe_getattr(sessions, "data", None) or []:
+                session_id = _safe_getattr(session, "id")
+                if not session_id:
+                    continue
+                try:
+                    stripe.checkout.Session.expire(session_id, api_key=self.api_key)
+                    expired += 1
+                except stripe.StripeError as e:
+                    logger.warning(
+                        f"Could not expire checkout session {session_id}: {e!s}"
+                    )
+        except stripe.StripeError as e:
+            logger.warning(
+                f"Could not list open checkout sessions for {customer_id}: {e!s}"
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error expiring checkout sessions: {e!s}")
+        if expired:
+            logger.info(f"Expired {expired} open checkout session(s) for {customer_id}")
+        return expired
+
     def create_portal_session(
         self,
         customer_id: str,

--- a/app/core/services/stripe.py
+++ b/app/core/services/stripe.py
@@ -475,9 +475,11 @@ class StripeAPI:
         expired = 0
         try:
             sessions = stripe.checkout.Session.list(
-                customer=customer_id, status="open", limit=10, api_key=self.api_key
+                customer=customer_id, status="open", limit=100, api_key=self.api_key
             )
-            for session in _safe_getattr(sessions, "data", None) or []:
+            # auto_paging_iter follows has_more so no open session can
+            # hide beyond the first page.
+            for session in sessions.auto_paging_iter():
                 session_id = _safe_getattr(session, "id")
                 if not session_id:
                     continue

--- a/app/core/services/stripe.py
+++ b/app/core/services/stripe.py
@@ -457,6 +457,29 @@ class StripeAPI:
             logger.error(f"Unexpected error retrieving checkout session: {e!s}")
             return None
 
+    def get_price(self, price_id: str) -> dict[str, Any] | None:
+        """Retrieve a Stripe price by id.
+
+        Args:
+            price_id: The Stripe price ID.
+
+        Returns:
+            Dict with id, unit_amount, and currency, or None on failure.
+        """
+        try:
+            price = stripe.Price.retrieve(price_id, api_key=self.api_key)
+            return {
+                "id": price.id,
+                "unit_amount": _safe_getattr(price, "unit_amount"),
+                "currency": _safe_getattr(price, "currency"),
+            }
+        except stripe.StripeError as e:
+            logger.warning(f"Stripe error retrieving price {price_id}: {e!s}")
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error retrieving price {price_id}: {e!s}")
+            return None
+
     def expire_open_checkout_sessions(self, customer_id: str) -> int:
         """Expire all open Checkout Sessions for a customer.
 

--- a/app/core/templates/core/select_plan.html.j2
+++ b/app/core/templates/core/select_plan.html.j2
@@ -32,13 +32,13 @@
                                 <span class="text-4xl font-extrabold text-gray-900">{{ plan.price }}</span>
                                 {% if '$' in plan.price %}<span class="text-base font-medium text-gray-500">/month</span>{% endif %}
                             </p>
+                            {% if plan.price_yearly %}
+                                <p class="mt-1 text-sm text-gray-500">or {{ plan.price_yearly }}/year — 2 months free</p>
+                            {% endif %}
 
                             <form method="post" class="mt-8">
                                 {% csrf_token %}
                                 <input type="hidden" name="plan" value="{{ plan.name }}">
-                                <input type="hidden"
-                                       name="workspace_name"
-                                       value="{{ user.username }}'s Workspace">
                                 <button type="submit"
                                         class="{% if plan.name == 'pro' %}bg-primary-500 hover:bg-primary-600 text-white border-transparent{% else %}bg-white text-primary-500 border-primary-500 hover:bg-primary-50{% endif %} block w-full border rounded-md py-2 text-sm font-semibold text-center">
                                     {% if plan.name == 'free' %}
@@ -93,7 +93,7 @@
                         <div class="bg-white rounded-lg shadow p-6">
                             <h4 class="text-lg font-medium text-gray-900 mb-2">Do you offer annual billing?</h4>
                             <p class="text-gray-600">
-                                Yes! Save 20% when you pay annually. Annual billing options are available for all paid plans.
+                                Yes! Pay annually and get 2 months free (about 17% off). Annual billing is available for all paid plans.
                             </p>
                         </div>
                     </div>

--- a/app/core/templates/core/select_plan.html.j2
+++ b/app/core/templates/core/select_plan.html.j2
@@ -32,11 +32,6 @@
                                 <span class="text-4xl font-extrabold text-gray-900">{{ plan.price }}</span>
                                 {% if '$' in plan.price %}<span class="text-base font-medium text-gray-500">/month</span>{% endif %}
                             </p>
-                            {% if plan.price_yearly %}
-                                <p class="mt-1 text-sm text-gray-500">
-                                    or {{ plan.price_yearly }}/year{% if plan.yearly_savings %} — save {{ plan.yearly_savings }}{% endif %}
-                                </p>
-                            {% endif %}
 
                             <form method="post" class="mt-8">
                                 {% csrf_token %}
@@ -95,7 +90,7 @@
                         <div class="bg-white rounded-lg shadow p-6">
                             <h4 class="text-lg font-medium text-gray-900 mb-2">Do you offer annual billing?</h4>
                             <p class="text-gray-600">
-                                Yes! Pay annually and get 2 months free (about 17% off). Annual billing is available for all paid plans.
+                                Yes! Once your workspace is set up, you can switch to annual billing from the Billing page — each plan's yearly price and exact savings are shown there.
                             </p>
                         </div>
                     </div>

--- a/app/core/templates/core/select_plan.html.j2
+++ b/app/core/templates/core/select_plan.html.j2
@@ -33,7 +33,9 @@
                                 {% if '$' in plan.price %}<span class="text-base font-medium text-gray-500">/month</span>{% endif %}
                             </p>
                             {% if plan.price_yearly %}
-                                <p class="mt-1 text-sm text-gray-500">or {{ plan.price_yearly }}/year — 2 months free</p>
+                                <p class="mt-1 text-sm text-gray-500">
+                                    or {{ plan.price_yearly }}/year{% if plan.yearly_savings %} — save {{ plan.yearly_savings }}{% endif %}
+                                </p>
                             {% endif %}
 
                             <form method="post" class="mt-8">

--- a/app/core/templates/core/upgrade_plan.html.j2
+++ b/app/core/templates/core/upgrade_plan.html.j2
@@ -46,6 +46,28 @@
                 </div>
             </div>
 
+            <!-- Billing interval toggle: yearly first, so the lower
+                 per-month price anchors (matches the marketing site) -->
+            <div class="flex justify-center mb-8">
+                <div class="inline-flex items-center bg-white rounded-full border border-gray-200 shadow-sm p-1"
+                     role="group"
+                     aria-label="Billing interval">
+                    <button type="button"
+                            id="interval-toggle-yearly"
+                            class="interval-toggle px-4 py-2 rounded-full text-sm font-semibold transition-all duration-200"
+                            data-interval="yearly"
+                            aria-pressed="true">
+                        Yearly
+                        <span class="ml-1 text-xs font-medium">2 months free</span>
+                    </button>
+                    <button type="button"
+                            id="interval-toggle-monthly"
+                            class="interval-toggle px-4 py-2 rounded-full text-sm font-semibold transition-all duration-200"
+                            data-interval="monthly"
+                            aria-pressed="false">Monthly</button>
+                </div>
+            </div>
+
             <!-- Plan Comparison Cards -->
             <div class="grid grid-cols-1 {% if plans|length == 2 %}md:grid-cols-2 max-w-4xl mx-auto{% else %}md:grid-cols-2 lg:grid-cols-3{% endif %} gap-6 lg:gap-8 mb-8">
                 {% for plan in plans %}
@@ -96,10 +118,28 @@
 
                                 <h3 class="text-xl lg:text-2xl font-bold text-gray-900 mb-2">{{ plan.name }}</h3>
 
-                                <div class="flex items-baseline justify-center mb-2">
-                                    <span class="text-4xl lg:text-5xl font-extrabold {% if plan.recommended %}text-primary-600{% else %}text-gray-900{% endif %}">${{ plan.price }}</span>
-                                    <span class="ml-2 text-base lg:text-lg font-medium text-gray-500">/{{ plan.interval }}</span>
-                                </div>
+                                {% if plan.price_yearly %}
+                                    <div class="price-yearly" data-interval-block="yearly">
+                                        <div class="flex items-baseline justify-center mb-1">
+                                            <span class="text-4xl lg:text-5xl font-extrabold {% if plan.recommended %}text-primary-600{% else %}text-gray-900{% endif %}">${{ plan.price_yearly_per_month }}</span>
+                                            <span class="ml-2 text-base lg:text-lg font-medium text-gray-500">/month</span>
+                                        </div>
+                                        <p class="text-sm text-gray-500 mb-2">
+                                            ${{ plan.price_yearly }} billed annually{% if plan.yearly_savings %} · Save ${{ plan.yearly_savings }}{% endif %}
+                                        </p>
+                                    </div>
+                                    <div class="price-monthly hidden mb-2" data-interval-block="monthly">
+                                        <div class="flex items-baseline justify-center">
+                                            <span class="text-4xl lg:text-5xl font-extrabold {% if plan.recommended %}text-primary-600{% else %}text-gray-900{% endif %}">${{ plan.price }}</span>
+                                            <span class="ml-2 text-base lg:text-lg font-medium text-gray-500">/{{ plan.interval }}</span>
+                                        </div>
+                                    </div>
+                                {% else %}
+                                    <div class="flex items-baseline justify-center mb-2">
+                                        <span class="text-4xl lg:text-5xl font-extrabold {% if plan.recommended %}text-primary-600{% else %}text-gray-900{% endif %}">${{ plan.price }}</span>
+                                        <span class="ml-2 text-base lg:text-lg font-medium text-gray-500">/{{ plan.interval }}</span>
+                                    </div>
+                                {% endif %}
 
                                 {% if plan.recommended %}
                                     <p class="text-sm text-primary-600 font-semibold bg-primary-50 px-3 py-1 rounded-full inline-block">
@@ -154,8 +194,9 @@
                                         </div>
                                     </div>
                                 {% else %}
-                                    <a href="{% url 'core:checkout' plan_name=plan.id %}"
-                                       class="group/btn w-full inline-flex items-center justify-center py-4 px-6 rounded-xl text-sm font-bold tracking-wide transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 {% if plan.recommended %}bg-gradient-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white border-2 border-primary-600{% else %}bg-white text-primary-600 border-2 border-primary-600 hover:bg-primary-50 hover:border-primary-700{% endif %}">
+                                    <a href="{% url 'core:checkout' plan_name=plan.id %}{% if plan.price_yearly %}?interval=yearly{% endif %}"
+                                       {% if plan.price_yearly %}data-checkout-base="{% url 'core:checkout' plan_name=plan.id %}"{% endif %}
+                                       class="checkout-link group/btn w-full inline-flex items-center justify-center py-4 px-6 rounded-xl text-sm font-bold tracking-wide transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 {% if plan.recommended %}bg-gradient-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white border-2 border-primary-600{% else %}bg-white text-primary-600 border-2 border-primary-600 hover:bg-primary-50 hover:border-primary-700{% endif %}">
                                         {% if plan.recommended %}
                                             <svg class="mr-2 h-5 w-5 group-hover/btn:scale-110 transition-transform"
                                                  fill="none"
@@ -269,4 +310,38 @@
             </div>
         </div>
     </div>
+    <script>
+        (function() {
+            const ACTIVE = ["bg-primary-600", "text-white", "shadow"];
+            const INACTIVE = ["text-gray-600"];
+            const toggles = document.querySelectorAll(".interval-toggle");
+            if (!toggles.length) return;
+
+            function setInterval_(interval) {
+                toggles.forEach(function(btn) {
+                    const on = btn.dataset.interval === interval;
+                    btn.setAttribute("aria-pressed", on ? "true" : "false");
+                    ACTIVE.forEach(function(c) {
+                        btn.classList.toggle(c, on);
+                    });
+                    INACTIVE.forEach(function(c) {
+                        btn.classList.toggle(c, !on);
+                    });
+                });
+                document.querySelectorAll("[data-interval-block]").forEach(function(block) {
+                    block.classList.toggle("hidden", block.dataset.intervalBlock !== interval);
+                });
+                document.querySelectorAll(".checkout-link[data-checkout-base]").forEach(function(link) {
+                    link.href = link.dataset.checkoutBase + "?interval=" + interval;
+                });
+            }
+
+            toggles.forEach(function(btn) {
+                btn.addEventListener("click", function() {
+                    setInterval_(btn.dataset.interval);
+                });
+            });
+            setInterval_("yearly");
+        })();
+    </script>
 {% endblock content %}

--- a/app/core/templates/core/upgrade_plan.html.j2
+++ b/app/core/templates/core/upgrade_plan.html.j2
@@ -59,10 +59,7 @@
                                 data-interval="yearly"
                                 role="radio"
                                 aria-checked="true"
-                                tabindex="0">
-                            Yearly
-                            <span class="ml-1 text-xs font-medium">2 months free</span>
-                        </button>
+                                tabindex="0">Yearly</button>
                         <button type="button"
                                 id="interval-toggle-monthly"
                                 class="interval-toggle px-4 py-2 rounded-full text-sm font-semibold transition-all duration-200"
@@ -134,18 +131,14 @@
                                             ${{ plan.price_yearly }} billed annually{% if plan.yearly_savings %} · Save ${{ plan.yearly_savings }}{% endif %}
                                         </p>
                                     </div>
-                                    <div class="price-monthly hidden mb-2" data-interval-block="monthly">
-                                        <div class="flex items-baseline justify-center">
-                                            <span class="text-4xl lg:text-5xl font-extrabold {% if plan.recommended %}text-primary-600{% else %}text-gray-900{% endif %}">${{ plan.price }}</span>
-                                            <span class="ml-2 text-base lg:text-lg font-medium text-gray-500">/{{ plan.interval }}</span>
-                                        </div>
-                                    </div>
-                                {% else %}
-                                    <div class="flex items-baseline justify-center mb-2">
+                                {% endif %}
+                                <div class="{% if plan.price_yearly %}price-monthly hidden{% endif %} mb-2"
+                                     {% if plan.price_yearly %}data-interval-block="monthly"{% endif %}>
+                                    <div class="flex items-baseline justify-center">
                                         <span class="text-4xl lg:text-5xl font-extrabold {% if plan.recommended %}text-primary-600{% else %}text-gray-900{% endif %}">${{ plan.price }}</span>
                                         <span class="ml-2 text-base lg:text-lg font-medium text-gray-500">/{{ plan.interval }}</span>
                                     </div>
-                                {% endif %}
+                                </div>
 
                                 {% if plan.recommended %}
                                     <p class="text-sm text-primary-600 font-semibold bg-primary-50 px-3 py-1 rounded-full inline-block">

--- a/app/core/templates/core/upgrade_plan.html.j2
+++ b/app/core/templates/core/upgrade_plan.html.j2
@@ -46,27 +46,33 @@
                 </div>
             </div>
 
-            <!-- Billing interval toggle: yearly first, so the lower
-                 per-month price anchors (matches the marketing site) -->
-            <div class="flex justify-center mb-8">
-                <div class="inline-flex items-center bg-white rounded-full border border-gray-200 shadow-sm p-1"
-                     role="group"
-                     aria-label="Billing interval">
-                    <button type="button"
-                            id="interval-toggle-yearly"
-                            class="interval-toggle px-4 py-2 rounded-full text-sm font-semibold transition-all duration-200"
-                            data-interval="yearly"
-                            aria-pressed="true">
-                        Yearly
-                        <span class="ml-1 text-xs font-medium">2 months free</span>
-                    </button>
-                    <button type="button"
-                            id="interval-toggle-monthly"
-                            class="interval-toggle px-4 py-2 rounded-full text-sm font-semibold transition-all duration-200"
-                            data-interval="monthly"
-                            aria-pressed="false">Monthly</button>
+            {% if has_yearly_plans %}
+                <!-- Billing interval toggle: yearly first, so the lower
+                     per-month price anchors (matches the marketing site) -->
+                <div class="flex justify-center mb-8">
+                    <div class="inline-flex items-center bg-white rounded-full border border-gray-200 shadow-sm p-1"
+                         role="radiogroup"
+                         aria-label="Billing interval">
+                        <button type="button"
+                                id="interval-toggle-yearly"
+                                class="interval-toggle px-4 py-2 rounded-full text-sm font-semibold transition-all duration-200"
+                                data-interval="yearly"
+                                role="radio"
+                                aria-checked="true"
+                                tabindex="0">
+                            Yearly
+                            <span class="ml-1 text-xs font-medium">2 months free</span>
+                        </button>
+                        <button type="button"
+                                id="interval-toggle-monthly"
+                                class="interval-toggle px-4 py-2 rounded-full text-sm font-semibold transition-all duration-200"
+                                data-interval="monthly"
+                                role="radio"
+                                aria-checked="false"
+                                tabindex="-1">Monthly</button>
+                    </div>
                 </div>
-            </div>
+            {% endif %}
 
             <!-- Plan Comparison Cards -->
             <div class="grid grid-cols-1 {% if plans|length == 2 %}md:grid-cols-2 max-w-4xl mx-auto{% else %}md:grid-cols-2 lg:grid-cols-3{% endif %} gap-6 lg:gap-8 mb-8">
@@ -314,19 +320,21 @@
         (function() {
             const ACTIVE = ["bg-primary-600", "text-white", "shadow"];
             const INACTIVE = ["text-gray-600"];
-            const toggles = document.querySelectorAll(".interval-toggle");
-            if (!toggles.length) return;
+            const radios = Array.from(document.querySelectorAll(".interval-toggle"));
+            if (!radios.length) return;
 
-            function setInterval_(interval) {
-                toggles.forEach(function(btn) {
+            function select(interval, focus) {
+                radios.forEach(function(btn) {
                     const on = btn.dataset.interval === interval;
-                    btn.setAttribute("aria-pressed", on ? "true" : "false");
+                    btn.setAttribute("aria-checked", on ? "true" : "false");
+                    btn.tabIndex = on ? 0 : -1;
                     ACTIVE.forEach(function(c) {
                         btn.classList.toggle(c, on);
                     });
                     INACTIVE.forEach(function(c) {
                         btn.classList.toggle(c, !on);
                     });
+                    if (on && focus) btn.focus();
                 });
                 document.querySelectorAll("[data-interval-block]").forEach(function(block) {
                     block.classList.toggle("hidden", block.dataset.intervalBlock !== interval);
@@ -336,12 +344,19 @@
                 });
             }
 
-            toggles.forEach(function(btn) {
+            radios.forEach(function(btn, index) {
                 btn.addEventListener("click", function() {
-                    setInterval_(btn.dataset.interval);
+                    select(btn.dataset.interval, false);
+                });
+                btn.addEventListener("keydown", function(event) {
+                    if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)) return;
+                    event.preventDefault();
+                    const step = (event.key === "ArrowRight" || event.key === "ArrowDown") ? 1 : -1;
+                    const next = radios[(index + step + radios.length) % radios.length];
+                    select(next.dataset.interval, true);
                 });
             });
-            setInterval_("yearly");
+            select("yearly", false);
         })();
     </script>
 {% endblock content %}

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -436,6 +436,56 @@ def _resolve_checkout_price(
     return price_id, plan.price_monthly
 
 
+def _checkout_session_metadata(
+    workspace: Any, plan_name: str, interval: str, checkout_amount: Decimal | None
+) -> dict[str, str]:
+    """Build the checkout session metadata.
+
+    checkout_success reads interval and amount back from it to report
+    the value actually purchased instead of assuming monthly or
+    re-deriving from Plan rows that may have drifted. Stripe metadata
+    values are strings; the amount is omitted when unknown so the
+    reader falls back rather than parsing a placeholder.
+
+    Args:
+        workspace: The purchasing workspace.
+        plan_name: Internal plan name.
+        interval: Validated billing interval.
+        checkout_amount: Major-unit amount the session will charge, if
+            known.
+
+    Returns:
+        Metadata dict for create_checkout_session.
+    """
+    metadata = {
+        "workspace_id": str(workspace.pk),
+        "plan_name": plan_name,
+        "interval": interval,
+    }
+    if checkout_amount is not None:
+        metadata["amount"] = str(checkout_amount)
+    return metadata
+
+
+def _parse_metadata_amount(raw: Any) -> float | None:
+    """Parse a checkout-session metadata amount, or None when unusable.
+
+    Args:
+        raw: The metadata "amount" string stored at checkout time (all
+            Stripe metadata values are strings), or None/garbage.
+
+    Returns:
+        The amount as a float, or None so the caller falls back to the
+        Plan row rather than reporting a corrupted value.
+    """
+    if raw is None:
+        return None
+    try:
+        return float(Decimal(str(raw)))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
 def _missing_price_redirect(
     request: HttpRequest, plan_name: str, interval: str
 ) -> HttpResponseRedirect:
@@ -559,6 +609,10 @@ def checkout(
         if not price_id:
             return _missing_price_redirect(request, plan_name, interval)
 
+        session_metadata = _checkout_session_metadata(
+            workspace, plan_name, interval, checkout_amount
+        )
+
         # Create Stripe Checkout Session.
         # Idempotency key collapses duplicate checkout-initiation requests
         # (double-click, browser back, retry) to one session within Stripe's
@@ -566,13 +620,7 @@ def checkout(
         checkout_session = stripe_api.create_checkout_session(
             customer_id=customer["id"],
             price_id=price_id,
-            metadata={
-                "workspace_id": str(workspace.pk),
-                "plan_name": plan_name,
-                # checkout_success reads this back to report the value
-                # actually purchased instead of assuming monthly.
-                "interval": interval,
-            },
+            metadata=session_metadata,
             # No time-based component: any date bucket (local or UTC)
             # has a midnight edge where retries minutes apart fall on
             # different sides and stop deduping. Stripe's idempotency
@@ -685,6 +733,7 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
 
     plan_name = None
     purchased_interval = None
+    purchased_amount = None
 
     if session_id:
         # Retrieve plan name from Stripe Checkout Session metadata,
@@ -704,6 +753,9 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
                 session_metadata = checkout_session.get("metadata", {})
                 plan_name = session_metadata.get("plan_name")
                 purchased_interval = session_metadata.get("interval")
+                purchased_amount = _parse_metadata_amount(
+                    session_metadata.get("amount")
+                )
         except Exception as e:
             logger.warning(f"Error retrieving Stripe session: {e}")
 
@@ -719,11 +771,13 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
     if not request.session.get(purchase_tracked_key):
         request.session[purchase_tracked_key] = True
         plan = Plan.objects.filter(name=plan_name, is_active=True).first()
-        # Report the interval that was actually purchased — a $990/year
-        # checkout must not be counted as $99. price_yearly is nullable,
-        # so an unknown yearly amount reports 0 rather than a guess.
-        purchase_value = 0.0
-        if plan:
+        # Report what was actually purchased — a $990/year checkout must
+        # not be counted as $99. The amount resolved at checkout time
+        # (stored in session metadata) wins; the Plan row is the
+        # fallback, and an unknown yearly amount reports 0 rather than
+        # a guess (price_yearly is nullable).
+        purchase_value = purchased_amount
+        if purchase_value is None and plan:
             if purchased_interval == "yearly":
                 purchase_value = float(plan.price_yearly or 0)
             else:
@@ -735,7 +789,7 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
                 "plan": plan_name,
                 "transaction_id": session_id,
                 "currency": "USD",
-                "value": purchase_value,
+                "value": purchase_value if purchase_value is not None else 0.0,
                 "interval": purchased_interval or "monthly",
                 "items": [{"item_id": plan_name}],
             },

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -6,7 +6,7 @@ and checkout flows.
 
 import logging
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -67,22 +67,11 @@ def select_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
         price_display = (
             "Free" if plan.price_monthly == 0 else f"${plan.price_monthly:.0f}"
         )
-        # price_yearly is nullable — guard before comparing, and show the
-        # computed dollar savings instead of asserting a discount ratio.
-        price_yearly = None
-        yearly_savings = None
-        if plan.price_monthly > 0 and plan.price_yearly and plan.price_yearly > 0:
-            price_yearly = f"${plan.price_yearly:.0f}"
-            savings = plan.price_monthly * 12 - plan.price_yearly
-            if savings > 0:
-                yearly_savings = f"${savings:.0f}"
         plans.append(
             {
                 "name": plan.name,
                 "display_name": plan.display_name,
                 "price": price_display,
-                "price_yearly": price_yearly,
-                "yearly_savings": yearly_savings,
                 "features": plan.features,
                 "description": plan.description,
             }
@@ -196,30 +185,42 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
 def _annotate_yearly_pricing(plans: list[dict[str, Any]]) -> None:
     """Attach yearly pricing display fields to plan card dicts.
 
-    Values come from the local Plan table (the canonical yearly prices)
-    so the annotation works for both the Stripe and database card
-    sources. Cards for plans without a positive yearly price are left
-    untouched — the template keeps them monthly-only rather than
-    advertising a billing option that cannot be charged.
+    A card is only annotated when its Plan row proves the option is
+    billable: a positive price_yearly AND a stored yearly Stripe price
+    id (checkout refuses without one, so advertising would dead-end
+    the default Yearly toggle). Savings are computed against the
+    monthly price the card actually displays, so the numbers shown
+    together can never contradict each other even if the local Plan
+    row drifts from Stripe.
 
     Args:
         plans: Plan card dicts carrying an "id" of the internal plan
-            name; mutated in place with price_yearly,
-            price_yearly_per_month, and yearly_savings strings.
+            name and a displayed "price"; mutated in place with
+            price_yearly, price_yearly_per_month, and yearly_savings
+            strings.
     """
     rows = {
         row.name: row
         for row in Plan.objects.filter(is_active=True).only(
-            "name", "price_monthly", "price_yearly"
+            "name", "price_monthly", "price_yearly", "stripe_price_id_yearly"
         )
     }
     for plan in plans:
         row = rows.get(str(plan.get("id", "")))
-        if row is None or not row.price_yearly or row.price_yearly <= 0:
+        if (
+            row is None
+            or not row.price_yearly
+            or row.price_yearly <= 0
+            or not row.stripe_price_id_yearly
+        ):
             continue
         plan["price_yearly"] = f"{row.price_yearly:.0f}"
         plan["price_yearly_per_month"] = f"{row.price_yearly / 12:.2f}"
-        savings = row.price_monthly * 12 - row.price_yearly
+        try:
+            displayed_monthly = Decimal(str(plan.get("price", 0)))
+        except (InvalidOperation, TypeError, ValueError):
+            continue
+        savings = displayed_monthly * 12 - row.price_yearly
         if savings > 0:
             plan["yearly_savings"] = f"{savings:.0f}"
 
@@ -395,10 +396,10 @@ def _duplicate_subscription_guard(
     return None
 
 
-def _resolve_checkout_price_id(
+def _resolve_checkout_price(
     stripe_api: Any, plan: Plan, plan_name: str, interval: str
-) -> str | None:
-    """Resolve the Stripe price id for a plan and billing interval.
+) -> tuple[str | None, Decimal | None]:
+    """Resolve the Stripe price id and amount for a plan and interval.
 
     Prefers the Stripe lookup key, then falls back to the Plan row's
     stored price id, then (monthly only) to the environment mapping.
@@ -410,21 +411,72 @@ def _resolve_checkout_price_id(
         interval: "monthly" or "yearly" (already validated).
 
     Returns:
-        A Stripe price id, or None when the interval has no configured
-        price — the caller must error rather than bill a different
-        interval than the user picked.
+        (price_id, amount) tuple. price_id is None when the interval
+        has no configured price — the caller must error rather than
+        bill a different interval than the user picked. amount is the
+        major-unit price the id will actually charge when known
+        (from the Stripe price object, else the Plan row), or None.
     """
     from django.conf import settings as django_settings
 
     price = stripe_api.get_price_by_lookup_key(f"{plan_name}_{interval}")
     if price:
-        return cast(str, price["id"])
+        price_id: str | None = price["id"]
+        amount = _price_amount_major(price)
+        if amount is None:
+            amount = plan.price_yearly if interval == "yearly" else plan.price_monthly
+        return price_id, amount
+
     if interval == "yearly":
-        return cast(str, plan.stripe_price_id_yearly) or None
-    return cast(
-        "str | None",
-        plan.stripe_price_id_monthly or django_settings.STRIPE_PLANS.get(plan_name),
+        price_id = plan.stripe_price_id_yearly or None
+        return price_id, plan.price_yearly
+    price_id = plan.stripe_price_id_monthly or django_settings.STRIPE_PLANS.get(
+        plan_name
     )
+    return price_id, plan.price_monthly
+
+
+def _missing_price_redirect(
+    request: HttpRequest, plan_name: str, interval: str
+) -> HttpResponseRedirect:
+    """Log and redirect when a plan has no Stripe price for an interval.
+
+    Args:
+        request: The HTTP request object.
+        plan_name: Internal plan name that failed to resolve.
+        interval: The billing interval the user picked.
+
+    Returns:
+        Redirect to the upgrade page with an interval-appropriate error.
+    """
+    logger.error(f"No Stripe {interval} price configured for plan: {plan_name}")
+    if interval == "yearly":
+        messages.error(
+            request,
+            "Annual billing isn't set up for this plan yet. "
+            "Please choose monthly billing, or contact support.",
+        )
+    else:
+        messages.error(request, "Plan configuration error. Please contact support.")
+    return redirect("core:upgrade_plan")
+
+
+def _price_amount_major(price: dict[str, Any]) -> Decimal | None:
+    """Return a Stripe price object's amount in major units, or None."""
+    from webhooks.utils.currency import from_minor_units
+
+    unit_amount = price.get("unit_amount")
+    if isinstance(unit_amount, bool) or not isinstance(unit_amount, int):
+        return None
+    currency = price.get("currency")
+    if not isinstance(currency, str) or not currency:
+        # Without the currency the minor-unit exponent would be a
+        # guess; let the caller fall back to the Plan row.
+        return None
+    # annotation: mypy resolves cross-package imports as Any in this
+    # layout (see the disabled django plugin note in pyproject).
+    amount: Decimal = from_minor_units(unit_amount, currency)
+    return amount
 
 
 @login_required
@@ -493,20 +545,19 @@ def checkout(
         if guard_redirect is not None:
             return guard_redirect
 
-        price_id = _resolve_checkout_price_id(stripe_api, plan, plan_name, interval)
+        # A customer must never hold two live checkout sessions at once:
+        # the idempotency key is per (plan, interval), so switching plan
+        # or interval would otherwise leave a stale session that can
+        # still be completed after the new one is paid (double-billing).
+        # Best-effort — a brand-new customer has nothing to expire.
+        if had_stripe_customer:
+            stripe_api.expire_open_checkout_sessions(customer["id"])
+
+        price_id, checkout_amount = _resolve_checkout_price(
+            stripe_api, plan, plan_name, interval
+        )
         if not price_id:
-            logger.error(f"No Stripe {interval} price configured for plan: {plan_name}")
-            if interval == "yearly":
-                messages.error(
-                    request,
-                    "Annual billing isn't set up for this plan yet. "
-                    "Please choose monthly billing, or contact support.",
-                )
-            else:
-                messages.error(
-                    request, "Plan configuration error. Please contact support."
-                )
-            return redirect("core:upgrade_plan")
+            return _missing_price_redirect(request, plan_name, interval)
 
         # Create Stripe Checkout Session.
         # Idempotency key collapses duplicate checkout-initiation requests
@@ -538,18 +589,16 @@ def checkout(
             )
             return redirect("core:upgrade_plan")
 
-        # price_yearly is nullable: when the yearly price lives only in
-        # Stripe, report 0 rather than a guessed amount.
-        checkout_value = (
-            (plan.price_yearly or 0) if interval == "yearly" else plan.price_monthly
-        )
+        # checkout_amount comes from the resolved Stripe price when
+        # known, else the Plan row; report 0 only when neither proves
+        # an amount rather than guessing one.
         analytics.track_event(
             request,
             "begin_checkout",
             {
                 "plan": plan.name,
                 "currency": "USD",
-                "value": float(checkout_value),
+                "value": float(checkout_amount or 0),
                 "interval": interval,
                 "items": [{"item_id": plan.name, "item_name": plan.display_name}],
             },

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -777,7 +777,11 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
             ):
                 session_metadata = checkout_session.get("metadata", {})
                 plan_name = session_metadata.get("plan_name")
+                # Normalize: metadata is caller-supplied at retrieval
+                # time, and analytics cardinality must stay bounded.
                 purchased_interval = session_metadata.get("interval")
+                if purchased_interval not in ("monthly", "yearly"):
+                    purchased_interval = None
                 purchased_amount = _parse_metadata_amount(
                     session_metadata.get("amount")
                 )

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -214,7 +214,7 @@ def _annotate_yearly_pricing(plans: list[dict[str, Any]]) -> None:
             or not row.stripe_price_id_yearly
         ):
             continue
-        plan["price_yearly"] = f"{row.price_yearly:.0f}"
+        plan["price_yearly"] = _format_dollars(row.price_yearly)
         plan["price_yearly_per_month"] = f"{row.price_yearly / 12:.2f}"
         try:
             displayed_monthly = Decimal(str(plan.get("price", 0)))
@@ -222,7 +222,7 @@ def _annotate_yearly_pricing(plans: list[dict[str, Any]]) -> None:
             continue
         savings = displayed_monthly * 12 - row.price_yearly
         if savings > 0:
-            plan["yearly_savings"] = f"{savings:.0f}"
+            plan["yearly_savings"] = _format_dollars(savings)
 
 
 @login_required
@@ -429,11 +429,36 @@ def _resolve_checkout_price(
 
     if interval == "yearly":
         price_id = plan.stripe_price_id_yearly or None
-        return price_id, plan.price_yearly
+        amount = plan.price_yearly
+        if price_id and amount is None:
+            # The stored price id proves an amount even when the local
+            # row was never backfilled — best effort, one extra call
+            # only on this narrow path.
+            fetched = stripe_api.get_price(price_id)
+            if fetched:
+                amount = _price_amount_major(fetched)
+        return price_id, amount
     price_id = plan.stripe_price_id_monthly or django_settings.STRIPE_PLANS.get(
         plan_name
     )
     return price_id, plan.price_monthly
+
+
+def _format_dollars(amount: Any) -> str:
+    """Format a dollar amount without inventing or rounding away cents.
+
+    Args:
+        amount: Decimal-compatible dollar amount.
+
+    Returns:
+        Whole-dollar amounts without a fractional part ("990"),
+        anything else with its two decimal places ("299.50") — rounding
+        to whole dollars would misstate a real price.
+    """
+    dec = Decimal(str(amount))
+    if dec == dec.to_integral_value():
+        return f"{dec:.0f}"
+    return f"{dec:.2f}"
 
 
 def _checkout_session_metadata(

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -187,11 +187,13 @@ def _annotate_yearly_pricing(plans: list[dict[str, Any]]) -> None:
 
     A card is only annotated when its Plan row proves the option is
     billable: a positive price_yearly AND a stored yearly Stripe price
-    id (checkout refuses without one, so advertising would dead-end
-    the default Yearly toggle). Savings are computed against the
-    monthly price the card actually displays, so the numbers shown
-    together can never contradict each other even if the local Plan
-    row drifts from Stripe.
+    id. Checkout can also resolve a yearly price via its Stripe lookup
+    key, but verifying a lookup key costs a Stripe call per render —
+    the stored id is the only render-time proof, so lookup-key-only
+    setups must also backfill the id to advertise yearly. Savings are
+    computed against the monthly price the card actually displays, so
+    the numbers shown together can never contradict each other even if
+    the local Plan row drifts from Stripe.
 
     Args:
         plans: Plan card dicts carrying an "id" of the internal plan

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -67,16 +67,22 @@ def select_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
         price_display = (
             "Free" if plan.price_monthly == 0 else f"${plan.price_monthly:.0f}"
         )
+        # price_yearly is nullable — guard before comparing, and show the
+        # computed dollar savings instead of asserting a discount ratio.
+        price_yearly = None
+        yearly_savings = None
+        if plan.price_monthly > 0 and plan.price_yearly and plan.price_yearly > 0:
+            price_yearly = f"${plan.price_yearly:.0f}"
+            savings = plan.price_monthly * 12 - plan.price_yearly
+            if savings > 0:
+                yearly_savings = f"${savings:.0f}"
         plans.append(
             {
                 "name": plan.name,
                 "display_name": plan.display_name,
                 "price": price_display,
-                "price_yearly": (
-                    f"${plan.price_yearly:.0f}"
-                    if plan.price_monthly > 0 and plan.price_yearly > 0
-                    else None
-                ),
+                "price_yearly": price_yearly,
+                "yearly_savings": yearly_savings,
                 "features": plan.features,
                 "description": plan.description,
             }
@@ -180,6 +186,9 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
         "workspace": workspace,
         "plans": available_plans,
         "current_plan": workspace.subscription_plan,
+        # The interval toggle only renders when at least one card can
+        # actually be billed yearly — no dead controls.
+        "has_yearly_plans": any("price_yearly" in plan for plan in available_plans),
     }
     return render(request, "core/upgrade_plan.html.j2", context)
 
@@ -487,7 +496,16 @@ def checkout(
         price_id = _resolve_checkout_price_id(stripe_api, plan, plan_name, interval)
         if not price_id:
             logger.error(f"No Stripe {interval} price configured for plan: {plan_name}")
-            messages.error(request, "Plan configuration error. Please contact support.")
+            if interval == "yearly":
+                messages.error(
+                    request,
+                    "Annual billing isn't set up for this plan yet. "
+                    "Please choose monthly billing, or contact support.",
+                )
+            else:
+                messages.error(
+                    request, "Plan configuration error. Please contact support."
+                )
             return redirect("core:upgrade_plan")
 
         # Create Stripe Checkout Session.
@@ -500,6 +518,9 @@ def checkout(
             metadata={
                 "workspace_id": str(workspace.pk),
                 "plan_name": plan_name,
+                # checkout_success reads this back to report the value
+                # actually purchased instead of assuming monthly.
+                "interval": interval,
             },
             # No time-based component: any date bucket (local or UTC)
             # has a midnight edge where retries minutes apart fall on
@@ -517,8 +538,10 @@ def checkout(
             )
             return redirect("core:upgrade_plan")
 
+        # price_yearly is nullable: when the yearly price lives only in
+        # Stripe, report 0 rather than a guessed amount.
         checkout_value = (
-            plan.price_yearly if interval == "yearly" else plan.price_monthly
+            (plan.price_yearly or 0) if interval == "yearly" else plan.price_monthly
         )
         analytics.track_event(
             request,
@@ -612,6 +635,7 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
     session_id = request.GET.get("session_id")
 
     plan_name = None
+    purchased_interval = None
 
     if session_id:
         # Retrieve plan name from Stripe Checkout Session metadata,
@@ -628,7 +652,9 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
                 and workspace.stripe_customer_id
                 and checkout_session.get("customer") == workspace.stripe_customer_id
             ):
-                plan_name = checkout_session.get("metadata", {}).get("plan_name")
+                session_metadata = checkout_session.get("metadata", {})
+                plan_name = session_metadata.get("plan_name")
+                purchased_interval = session_metadata.get("interval")
         except Exception as e:
             logger.warning(f"Error retrieving Stripe session: {e}")
 
@@ -644,6 +670,15 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
     if not request.session.get(purchase_tracked_key):
         request.session[purchase_tracked_key] = True
         plan = Plan.objects.filter(name=plan_name, is_active=True).first()
+        # Report the interval that was actually purchased — a $990/year
+        # checkout must not be counted as $99. price_yearly is nullable,
+        # so an unknown yearly amount reports 0 rather than a guess.
+        purchase_value = 0.0
+        if plan:
+            if purchased_interval == "yearly":
+                purchase_value = float(plan.price_yearly or 0)
+            else:
+                purchase_value = float(plan.price_monthly)
         analytics.track_event(
             request,
             "purchase",
@@ -651,7 +686,8 @@ def checkout_success(request: HttpRequest) -> HttpResponse | HttpResponseRedirec
                 "plan": plan_name,
                 "transaction_id": session_id,
                 "currency": "USD",
-                "value": float(plan.price_monthly) if plan else 0.0,
+                "value": purchase_value,
+                "interval": purchased_interval or "monthly",
                 "items": [{"item_id": plan_name}],
             },
         )

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -6,7 +6,7 @@ and checkout flows.
 
 import logging
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, cast
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -72,6 +72,11 @@ def select_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
                 "name": plan.name,
                 "display_name": plan.display_name,
                 "price": price_display,
+                "price_yearly": (
+                    f"${plan.price_yearly:.0f}"
+                    if plan.price_monthly > 0 and plan.price_yearly > 0
+                    else None
+                ),
                 "features": plan.features,
                 "description": plan.description,
             }
@@ -169,12 +174,45 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
             except (InvalidOperation, TypeError, ValueError):
                 plan["is_downgrade"] = False
 
+    _annotate_yearly_pricing(available_plans)
+
     context: dict[str, Any] = {
         "workspace": workspace,
         "plans": available_plans,
         "current_plan": workspace.subscription_plan,
     }
     return render(request, "core/upgrade_plan.html.j2", context)
+
+
+def _annotate_yearly_pricing(plans: list[dict[str, Any]]) -> None:
+    """Attach yearly pricing display fields to plan card dicts.
+
+    Values come from the local Plan table (the canonical yearly prices)
+    so the annotation works for both the Stripe and database card
+    sources. Cards for plans without a positive yearly price are left
+    untouched — the template keeps them monthly-only rather than
+    advertising a billing option that cannot be charged.
+
+    Args:
+        plans: Plan card dicts carrying an "id" of the internal plan
+            name; mutated in place with price_yearly,
+            price_yearly_per_month, and yearly_savings strings.
+    """
+    rows = {
+        row.name: row
+        for row in Plan.objects.filter(is_active=True).only(
+            "name", "price_monthly", "price_yearly"
+        )
+    }
+    for plan in plans:
+        row = rows.get(str(plan.get("id", "")))
+        if row is None or not row.price_yearly or row.price_yearly <= 0:
+            continue
+        plan["price_yearly"] = f"{row.price_yearly:.0f}"
+        plan["price_yearly_per_month"] = f"{row.price_yearly / 12:.2f}"
+        savings = row.price_monthly * 12 - row.price_yearly
+        if savings > 0:
+            plan["yearly_savings"] = f"{savings:.0f}"
 
 
 @login_required
@@ -348,6 +386,38 @@ def _duplicate_subscription_guard(
     return None
 
 
+def _resolve_checkout_price_id(
+    stripe_api: Any, plan: Plan, plan_name: str, interval: str
+) -> str | None:
+    """Resolve the Stripe price id for a plan and billing interval.
+
+    Prefers the Stripe lookup key, then falls back to the Plan row's
+    stored price id, then (monthly only) to the environment mapping.
+
+    Args:
+        stripe_api: StripeAPI instance.
+        plan: The Plan row being purchased.
+        plan_name: Internal plan name.
+        interval: "monthly" or "yearly" (already validated).
+
+    Returns:
+        A Stripe price id, or None when the interval has no configured
+        price — the caller must error rather than bill a different
+        interval than the user picked.
+    """
+    from django.conf import settings as django_settings
+
+    price = stripe_api.get_price_by_lookup_key(f"{plan_name}_{interval}")
+    if price:
+        return cast(str, price["id"])
+    if interval == "yearly":
+        return cast(str, plan.stripe_price_id_yearly) or None
+    return cast(
+        "str | None",
+        plan.stripe_price_id_monthly or django_settings.STRIPE_PLANS.get(plan_name),
+    )
+
+
 @login_required
 def checkout(
     request: HttpRequest, plan_name: str
@@ -355,7 +425,9 @@ def checkout(
     """Create Stripe Checkout Session and redirect to Stripe-hosted checkout.
 
     Args:
-        request: The HTTP request object.
+        request: The HTTP request object. An optional ``interval`` query
+            parameter of "yearly" bills annually; anything else falls
+            back to monthly.
         plan_name: Name of the plan to checkout (basic, pro, enterprise).
 
     Returns:
@@ -364,12 +436,15 @@ def checkout(
         user is not an owner/admin (permission denied).
     """
     from core.services.stripe import StripeAPI
-    from django.conf import settings as django_settings
 
     workspace, redirect_response = require_admin_role(request)
     if redirect_response:
         return redirect_response
     assert workspace is not None
+
+    interval = request.GET.get("interval", "monthly")
+    if interval not in ("monthly", "yearly"):
+        interval = "monthly"
 
     try:
         # Validate against the Plan model (single source of truth for
@@ -409,24 +484,11 @@ def checkout(
         if guard_redirect is not None:
             return guard_redirect
 
-        # Try to get price from Stripe using lookup key (preferred method)
-        lookup_key = f"{plan_name}_monthly"
-        price = stripe_api.get_price_by_lookup_key(lookup_key)
-
-        if price:
-            price_id = price["id"]
-        else:
-            # Fall back to the Plan model's stored price ID, then to the
-            # environment variable mapping.
-            price_id = plan.stripe_price_id_monthly or django_settings.STRIPE_PLANS.get(
-                plan_name
-            )
-            if not price_id:
-                logger.error(f"No Stripe price configured for plan: {plan_name}")
-                messages.error(
-                    request, "Plan configuration error. Please contact support."
-                )
-                return redirect("core:upgrade_plan")
+        price_id = _resolve_checkout_price_id(stripe_api, plan, plan_name, interval)
+        if not price_id:
+            logger.error(f"No Stripe {interval} price configured for plan: {plan_name}")
+            messages.error(request, "Plan configuration error. Please contact support.")
+            return redirect("core:upgrade_plan")
 
         # Create Stripe Checkout Session.
         # Idempotency key collapses duplicate checkout-initiation requests
@@ -443,10 +505,10 @@ def checkout(
             # has a midnight edge where retries minutes apart fall on
             # different sides and stop deduping. Stripe's idempotency
             # keys already expire 24h after first use, so the same
-            # (workspace, plan) within 24h collapses to one session and
-            # a deliberate next-day retry creates a new one — exactly
-            # the desired behavior, without a midnight glitch.
-            idempotency_key=f"checkout-{workspace.uuid}-{plan_name}",
+            # (workspace, plan, interval) within 24h collapses to one
+            # session and a deliberate next-day retry creates a new one —
+            # exactly the desired behavior, without a midnight glitch.
+            idempotency_key=f"checkout-{workspace.uuid}-{plan_name}-{interval}",
         )
 
         if not checkout_session or not checkout_session.get("url"):
@@ -455,13 +517,17 @@ def checkout(
             )
             return redirect("core:upgrade_plan")
 
+        checkout_value = (
+            plan.price_yearly if interval == "yearly" else plan.price_monthly
+        )
         analytics.track_event(
             request,
             "begin_checkout",
             {
                 "plan": plan.name,
                 "currency": "USD",
-                "value": float(plan.price_monthly),
+                "value": float(checkout_value),
+                "interval": interval,
                 "items": [{"item_id": plan.name, "item_name": plan.display_name}],
             },
         )

--- a/tests/test_ga4_analytics.py
+++ b/tests/test_ga4_analytics.py
@@ -364,6 +364,35 @@ class TestFunnelEvents:
         assert event["params"]["value"] == 990.0
         assert event["params"]["interval"] == "yearly"
 
+    def test_corrupted_interval_metadata_reports_monthly(
+        self, ga4: MagicMock, logged_in_client: Client, user: User, db: None
+    ) -> None:
+        """An unexpected interval value is normalized, keeping analytics
+        cardinality bounded and the fallback on the monthly price."""
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "is_active": True,
+            },
+        )
+        workspace = Workspace.objects.create(name="Acme", stripe_customer_id="cus_123")
+        WorkspaceMember.objects.create(user=user, workspace=workspace, role="owner")
+
+        with patch("core.services.stripe.StripeAPI") as mock_api_cls:
+            mock_api_cls.return_value.retrieve_checkout_session.return_value = {
+                "customer": "cus_123",
+                "metadata": {"plan_name": "pro", "interval": "weekly"},
+            }
+            logged_in_client.get(
+                reverse("core:checkout_success"), {"session_id": "cs_test_w"}
+            )
+
+        (event,) = _events_named(ga4, "purchase")
+        assert event["params"]["interval"] == "monthly"
+        assert event["params"]["value"] == 99.0
+
     def test_purchase_prefers_amount_resolved_at_checkout(
         self, ga4: MagicMock, logged_in_client: Client, user: User, db: None
     ) -> None:

--- a/tests/test_ga4_analytics.py
+++ b/tests/test_ga4_analytics.py
@@ -364,6 +364,44 @@ class TestFunnelEvents:
         assert event["params"]["value"] == 990.0
         assert event["params"]["interval"] == "yearly"
 
+    def test_purchase_prefers_amount_resolved_at_checkout(
+        self, ga4: MagicMock, logged_in_client: Client, user: User, db: None
+    ) -> None:
+        """The amount stored in session metadata at checkout time wins.
+
+        A yearly price that lives only in Stripe leaves the Plan row's
+        price_yearly NULL — the metadata amount still reports the real
+        purchased value instead of 0.
+        """
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "price_yearly": None,
+                "is_active": True,
+            },
+        )
+        workspace = Workspace.objects.create(name="Acme", stripe_customer_id="cus_123")
+        WorkspaceMember.objects.create(user=user, workspace=workspace, role="owner")
+
+        with patch("core.services.stripe.StripeAPI") as mock_api_cls:
+            mock_api_cls.return_value.retrieve_checkout_session.return_value = {
+                "customer": "cus_123",
+                "metadata": {
+                    "plan_name": "pro",
+                    "interval": "yearly",
+                    "amount": "990.00",
+                },
+            }
+            response = logged_in_client.get(
+                reverse("core:checkout_success"), {"session_id": "cs_test_amt"}
+            )
+
+        assert response.status_code == 200
+        (event,) = _events_named(ga4, "purchase")
+        assert event["params"]["value"] == 990.0
+
 
 class TestBillingSyncEvents:
     """Server-side events from the Stripe webhook sync path."""

--- a/tests/test_ga4_analytics.py
+++ b/tests/test_ga4_analytics.py
@@ -332,6 +332,37 @@ class TestFunnelEvents:
         assert event["params"]["value"] == 29.0
         assert event["params"]["currency"] == "USD"
         assert event["params"]["plan"] == "pro"
+        assert event["params"]["interval"] == "monthly"
+
+    def test_yearly_purchase_reports_yearly_value(
+        self, ga4: MagicMock, logged_in_client: Client, user: User, db: None
+    ) -> None:
+        """A yearly checkout session reports the yearly price, not 12x less."""
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "price_yearly": 990,
+                "is_active": True,
+            },
+        )
+        workspace = Workspace.objects.create(name="Acme", stripe_customer_id="cus_123")
+        WorkspaceMember.objects.create(user=user, workspace=workspace, role="owner")
+
+        with patch("core.services.stripe.StripeAPI") as mock_api_cls:
+            mock_api_cls.return_value.retrieve_checkout_session.return_value = {
+                "customer": "cus_123",
+                "metadata": {"plan_name": "pro", "interval": "yearly"},
+            }
+            response = logged_in_client.get(
+                reverse("core:checkout_success"), {"session_id": "cs_test_y"}
+            )
+
+        assert response.status_code == 200
+        (event,) = _events_named(ga4, "purchase")
+        assert event["params"]["value"] == 990.0
+        assert event["params"]["interval"] == "yearly"
 
 
 class TestBillingSyncEvents:

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -1539,6 +1539,47 @@ class TestStripeAPIArchive:
         assert result == []
 
 
+def _checkout_owner_client(
+    username: str,
+    plan_defaults: dict[str, Any],
+    **workspace_kwargs: Any,
+) -> tuple[Any, Any]:
+    """Create a logged-in workspace owner and a pro Plan for checkout tests.
+
+    Shared scaffolding for the checkout-view test classes: one user who
+    owns one free workspace, plus the "pro" Plan row configured per
+    test class (the Plan may already exist via migrations, so it is
+    update_or_create'd).
+
+    Args:
+        username: Username for the owner (also names the workspace).
+        plan_defaults: Field defaults for the "pro" Plan row.
+        **workspace_kwargs: Extra Workspace fields (e.g.
+            stripe_customer_id).
+
+    Returns:
+        (client, workspace) with the owner already logged in.
+    """
+    from core.models import Plan, Workspace, WorkspaceMember
+    from django.contrib.auth.models import User
+    from django.test import Client
+
+    user = User.objects.create_user(username=username, password="x")
+    workspace = Workspace.objects.create(
+        name=f"{username} Workspace",
+        subscription_plan="free",
+        subscription_status="active",
+        **workspace_kwargs,
+    )
+    WorkspaceMember.objects.create(
+        user=user, workspace=workspace, role="owner", is_active=True
+    )
+    Plan.objects.update_or_create(name="pro", defaults=plan_defaults)
+    client = Client()
+    client.force_login(user)
+    return client, workspace
+
+
 @pytest.mark.django_db
 class TestCheckoutBillingInterval:
     """The checkout() view charges the interval the user picked.
@@ -1552,22 +1593,9 @@ class TestCheckoutBillingInterval:
     @pytest.fixture
     def interval_setup(self) -> Any:
         """Logged-in owner + pro plan with both billing intervals."""
-        from core.models import Plan, Workspace, WorkspaceMember
-        from django.contrib.auth.models import User
-        from django.test import Client
-
-        user = User.objects.create_user(username="ann", password="x")
-        workspace = Workspace.objects.create(
-            name="Ann Workspace",
-            subscription_plan="free",
-            subscription_status="active",
-        )
-        WorkspaceMember.objects.create(
-            user=user, workspace=workspace, role="owner", is_active=True
-        )
-        Plan.objects.update_or_create(
-            name="pro",
-            defaults={
+        client, _workspace = _checkout_owner_client(
+            "ann",
+            {
                 "display_name": "Pro",
                 "price_monthly": 99,
                 "price_yearly": 990,
@@ -1576,8 +1604,6 @@ class TestCheckoutBillingInterval:
                 "stripe_price_id_yearly": "price_pro_yearly",
             },
         )
-        client = Client()
-        client.force_login(user)
         return client
 
     @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
@@ -1759,6 +1785,83 @@ class TestCheckoutBillingInterval:
 
 
 @pytest.mark.django_db
+class TestCheckoutSessionExpiry:
+    """A customer never holds two live checkout sessions at once."""
+
+    @patch("core.services.stripe.StripeAPI.expire_open_checkout_sessions")
+    @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
+    @patch("core.services.stripe.StripeAPI.create_checkout_session")
+    @patch("core.services.stripe.StripeAPI.has_live_subscription")
+    @patch("core.services.stripe.StripeAPI.get_or_create_customer")
+    def test_existing_customer_open_sessions_expired(
+        self,
+        mock_get_or_create: MagicMock,
+        mock_has_live: MagicMock,
+        mock_create_session: MagicMock,
+        mock_get_price: MagicMock,
+        mock_expire: MagicMock,
+    ) -> None:
+        """Opening checkout expires the customer's stale open sessions,
+        so flipping plan or interval can't set up double-billing."""
+        from django.urls import reverse
+
+        client, _workspace = _checkout_owner_client(
+            "bob",
+            {
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "price_yearly": 990,
+                "is_active": True,
+                "stripe_price_id_monthly": "price_pro_monthly",
+                "stripe_price_id_yearly": "price_pro_yearly",
+            },
+            stripe_customer_id="cus_existing",
+        )
+        mock_get_or_create.return_value = {"id": "cus_existing"}
+        mock_has_live.return_value = False
+        mock_get_price.return_value = {"id": "price_pro_yearly"}
+        mock_create_session.return_value = {
+            "id": "cs_new",
+            "url": "https://checkout.stripe.com/x",
+        }
+
+        response = client.get(
+            reverse("core:checkout", args=["pro"]), {"interval": "yearly"}
+        )
+
+        assert response.status_code == 302
+        mock_expire.assert_called_once_with("cus_existing")
+
+    @patch("core.services.stripe.stripe.checkout.Session")
+    def test_expire_open_checkout_sessions_expires_each(
+        self, mock_session_cls: MagicMock
+    ) -> None:
+        """Every open session is expired and counted."""
+        mock_session_cls.list.return_value = Mock(
+            data=[Mock(id="cs_1"), Mock(id="cs_2")]
+        )
+        api = StripeAPI()
+
+        assert api.expire_open_checkout_sessions("cus_x") == 2
+
+        mock_session_cls.list.assert_called_once_with(
+            customer="cus_x", status="open", limit=10, api_key=api.api_key
+        )
+        assert mock_session_cls.expire.call_count == 2
+
+    @patch("core.services.stripe.stripe.checkout.Session")
+    def test_expire_failure_never_raises(self, mock_session_cls: MagicMock) -> None:
+        """A Stripe failure logs and returns 0 — it must not block the
+        new checkout from being created."""
+        import stripe as stripe_lib
+
+        mock_session_cls.list.side_effect = stripe_lib.StripeError("boom")
+        api = StripeAPI()
+
+        assert api.expire_open_checkout_sessions("cus_x") == 0
+
+
+@pytest.mark.django_db
 class TestYearlyPricingAnnotation:
     """Plan cards gain yearly display fields from the Plan table."""
 
@@ -1774,6 +1877,7 @@ class TestYearlyPricingAnnotation:
                 "price_monthly": 99,
                 "price_yearly": 990,
                 "is_active": True,
+                "stripe_price_id_yearly": "price_pro_yearly",
             },
         )
         plans: list[dict[str, Any]] = [{"id": "pro", "price": "99"}]
@@ -1783,6 +1887,58 @@ class TestYearlyPricingAnnotation:
         assert plans[0]["price_yearly"] == "990"
         assert plans[0]["price_yearly_per_month"] == "82.50"
         assert plans[0]["yearly_savings"] == "198"
+
+    def test_savings_use_the_displayed_monthly_price(self) -> None:
+        """Savings are consistent with the price shown on the card.
+
+        When the card's monthly price came from Stripe and drifted from
+        the local Plan row, the advertised savings must match the
+        numbers actually rendered next to them.
+        """
+        from core.models import Plan
+        from core.views.billing import _annotate_yearly_pricing
+
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "price_yearly": 990,
+                "is_active": True,
+                "stripe_price_id_yearly": "price_pro_yearly",
+            },
+        )
+        plans: list[dict[str, Any]] = [{"id": "pro", "price": "119"}]
+
+        _annotate_yearly_pricing(plans)
+
+        # 12 x $119 - $990, not 12 x $99 - $990
+        assert plans[0]["yearly_savings"] == "438"
+
+    def test_skips_plans_without_stripe_yearly_price_id(self) -> None:
+        """A display-only yearly price is not advertised.
+
+        checkout refuses an interval with no Stripe price, so a card
+        must not send users into a checkout that always bounces.
+        """
+        from core.models import Plan
+        from core.views.billing import _annotate_yearly_pricing
+
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "price_yearly": 990,
+                "is_active": True,
+                "stripe_price_id_yearly": "",
+            },
+        )
+        plans: list[dict[str, Any]] = [{"id": "pro", "price": "99"}]
+
+        _annotate_yearly_pricing(plans)
+
+        assert "price_yearly" not in plans[0]
 
     def test_skips_plans_with_null_yearly_price(self) -> None:
         """A NULL price_yearly (pre-feature rows) must not raise."""
@@ -1861,34 +2017,16 @@ class TestCheckoutViewActiveSubscriptionGuard:
     @pytest.fixture
     def setup(self) -> Any:
         """Build a logged-in user + workspace + plan, return them."""
-        from core.models import Plan, Workspace, WorkspaceMember
-        from django.contrib.auth.models import User
-        from django.test import Client
-
-        user = User.objects.create_user(username="vik", password="x")
-        workspace = Workspace.objects.create(
-            name="Vik Workspace",
-            subscription_plan="free",
-            subscription_status="active",
-            stripe_customer_id="cus_existing",
-        )
-        WorkspaceMember.objects.create(
-            user=user, workspace=workspace, role="owner", is_active=True
-        )
-        # The "pro" Plan may already exist via migrations; ensure it has a
-        # Stripe price id so the view doesn't bail before the guard.
-        Plan.objects.update_or_create(
-            name="pro",
-            defaults={
+        return _checkout_owner_client(
+            "vik",
+            {
                 "display_name": "Pro",
                 "price_monthly": 99,
                 "is_active": True,
                 "stripe_price_id_monthly": "price_pro_monthly",
             },
+            stripe_customer_id="cus_existing",
         )
-        client = Client()
-        client.force_login(user)
-        return client, workspace
 
     @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
     @patch("core.services.stripe.StripeAPI.create_checkout_session")

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -1836,16 +1836,17 @@ class TestCheckoutSessionExpiry:
     def test_expire_open_checkout_sessions_expires_each(
         self, mock_session_cls: MagicMock
     ) -> None:
-        """Every open session is expired and counted."""
-        mock_session_cls.list.return_value = Mock(
-            data=[Mock(id="cs_1"), Mock(id="cs_2")]
-        )
+        """Every open session is expired and counted, across pages."""
+        mock_session_cls.list.return_value.auto_paging_iter.return_value = [
+            Mock(id="cs_1"),
+            Mock(id="cs_2"),
+        ]
         api = StripeAPI()
 
         assert api.expire_open_checkout_sessions("cus_x") == 2
 
         mock_session_cls.list.assert_called_once_with(
-            customer="cus_x", status="open", limit=10, api_key=api.api_key
+            customer="cus_x", status="open", limit=100, api_key=api.api_key
         )
         assert mock_session_cls.expire.call_count == 2
 

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -1540,6 +1540,214 @@ class TestStripeAPIArchive:
 
 
 @pytest.mark.django_db
+class TestCheckoutBillingInterval:
+    """The checkout() view charges the interval the user picked.
+
+    The interval query parameter selects the Stripe price (yearly or
+    monthly); anything unrecognized falls back to monthly, and a plan
+    with no configured yearly price errors instead of silently billing
+    monthly.
+    """
+
+    @pytest.fixture
+    def interval_setup(self) -> Any:
+        """Logged-in owner + pro plan with both billing intervals."""
+        from core.models import Plan, Workspace, WorkspaceMember
+        from django.contrib.auth.models import User
+        from django.test import Client
+
+        user = User.objects.create_user(username="ann", password="x")
+        workspace = Workspace.objects.create(
+            name="Ann Workspace",
+            subscription_plan="free",
+            subscription_status="active",
+        )
+        WorkspaceMember.objects.create(
+            user=user, workspace=workspace, role="owner", is_active=True
+        )
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "price_yearly": 990,
+                "is_active": True,
+                "stripe_price_id_monthly": "price_pro_monthly",
+                "stripe_price_id_yearly": "price_pro_yearly",
+            },
+        )
+        client = Client()
+        client.force_login(user)
+        return client
+
+    @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
+    @patch("core.services.stripe.StripeAPI.create_checkout_session")
+    @patch("core.services.stripe.StripeAPI.get_or_create_customer")
+    def test_yearly_interval_uses_yearly_price(
+        self,
+        mock_get_or_create: MagicMock,
+        mock_create_session: MagicMock,
+        mock_get_price: MagicMock,
+        interval_setup: Any,
+    ) -> None:
+        """?interval=yearly looks up the yearly price and keys the
+        idempotency window per interval."""
+        from django.urls import reverse
+
+        client = interval_setup
+        mock_get_or_create.return_value = {"id": "cus_new"}
+        mock_get_price.return_value = {"id": "price_pro_yearly"}
+        mock_create_session.return_value = {
+            "id": "cs_x",
+            "url": "https://checkout.stripe.com/x",
+        }
+
+        response = client.get(
+            reverse("core:checkout", args=["pro"]), {"interval": "yearly"}
+        )
+
+        assert response.status_code == 302
+        mock_get_price.assert_called_once_with("pro_yearly")
+        kwargs = mock_create_session.call_args.kwargs
+        assert kwargs["price_id"] == "price_pro_yearly"
+        assert kwargs["idempotency_key"].endswith("-pro-yearly")
+
+    @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
+    @patch("core.services.stripe.StripeAPI.create_checkout_session")
+    @patch("core.services.stripe.StripeAPI.get_or_create_customer")
+    def test_invalid_interval_falls_back_to_monthly(
+        self,
+        mock_get_or_create: MagicMock,
+        mock_create_session: MagicMock,
+        mock_get_price: MagicMock,
+        interval_setup: Any,
+    ) -> None:
+        """An unrecognized interval value bills monthly, never errors."""
+        from django.urls import reverse
+
+        client = interval_setup
+        mock_get_or_create.return_value = {"id": "cus_new"}
+        mock_get_price.return_value = {"id": "price_pro_monthly"}
+        mock_create_session.return_value = {
+            "id": "cs_x",
+            "url": "https://checkout.stripe.com/x",
+        }
+
+        response = client.get(
+            reverse("core:checkout", args=["pro"]), {"interval": "weekly"}
+        )
+
+        assert response.status_code == 302
+        mock_get_price.assert_called_once_with("pro_monthly")
+        kwargs = mock_create_session.call_args.kwargs
+        assert kwargs["idempotency_key"].endswith("-pro-monthly")
+
+    @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
+    @patch("core.services.stripe.StripeAPI.create_checkout_session")
+    @patch("core.services.stripe.StripeAPI.get_or_create_customer")
+    def test_yearly_lookup_miss_falls_back_to_plan_price_id(
+        self,
+        mock_get_or_create: MagicMock,
+        mock_create_session: MagicMock,
+        mock_get_price: MagicMock,
+        interval_setup: Any,
+    ) -> None:
+        """Without a Stripe lookup key, the Plan row's yearly price id
+        is used — never the monthly one or the env mapping."""
+        from django.urls import reverse
+
+        client = interval_setup
+        mock_get_or_create.return_value = {"id": "cus_new"}
+        mock_get_price.return_value = None
+        mock_create_session.return_value = {
+            "id": "cs_x",
+            "url": "https://checkout.stripe.com/x",
+        }
+
+        response = client.get(
+            reverse("core:checkout", args=["pro"]), {"interval": "yearly"}
+        )
+
+        assert response.status_code == 302
+        assert mock_create_session.call_args.kwargs["price_id"] == "price_pro_yearly"
+
+    @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
+    @patch("core.services.stripe.StripeAPI.create_checkout_session")
+    @patch("core.services.stripe.StripeAPI.get_or_create_customer")
+    def test_yearly_without_configured_price_errors_cleanly(
+        self,
+        mock_get_or_create: MagicMock,
+        mock_create_session: MagicMock,
+        mock_get_price: MagicMock,
+        interval_setup: Any,
+    ) -> None:
+        """A plan with no yearly price anywhere redirects with an error
+        instead of silently charging monthly."""
+        from core.models import Plan
+        from django.urls import reverse
+
+        Plan.objects.filter(name="pro").update(stripe_price_id_yearly="")
+        client = interval_setup
+        mock_get_or_create.return_value = {"id": "cus_new"}
+        mock_get_price.return_value = None
+
+        response = client.get(
+            reverse("core:checkout", args=["pro"]), {"interval": "yearly"}
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:upgrade_plan")
+        mock_create_session.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestYearlyPricingAnnotation:
+    """Plan cards gain yearly display fields from the Plan table."""
+
+    def test_annotates_yearly_price_and_savings(self) -> None:
+        """$990/yr on a $99/mo plan shows $82.50/mo and $198 saved."""
+        from core.models import Plan
+        from core.views.billing import _annotate_yearly_pricing
+
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "price_yearly": 990,
+                "is_active": True,
+            },
+        )
+        plans: list[dict[str, Any]] = [{"id": "pro", "price": "99"}]
+
+        _annotate_yearly_pricing(plans)
+
+        assert plans[0]["price_yearly"] == "990"
+        assert plans[0]["price_yearly_per_month"] == "82.50"
+        assert plans[0]["yearly_savings"] == "198"
+
+    def test_skips_plans_without_yearly_price(self) -> None:
+        """No yearly price -> card stays monthly-only, no fake option."""
+        from core.models import Plan
+        from core.views.billing import _annotate_yearly_pricing
+
+        Plan.objects.update_or_create(
+            name="basic",
+            defaults={
+                "display_name": "Basic",
+                "price_monthly": 29,
+                "price_yearly": 0,
+                "is_active": True,
+            },
+        )
+        plans: list[dict[str, Any]] = [{"id": "basic", "price": "29"}]
+
+        _annotate_yearly_pricing(plans)
+
+        assert "price_yearly" not in plans[0]
+
+
+@pytest.mark.django_db
 class TestCheckoutViewActiveSubscriptionGuard:
     """The checkout() view must refuse to create a second subscription for
     a workspace that already has a live one in Stripe. The previous absence

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -1674,6 +1674,64 @@ class TestCheckoutBillingInterval:
     @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
     @patch("core.services.stripe.StripeAPI.create_checkout_session")
     @patch("core.services.stripe.StripeAPI.get_or_create_customer")
+    def test_yearly_checkout_survives_null_price_yearly(
+        self,
+        mock_get_or_create: MagicMock,
+        mock_create_session: MagicMock,
+        mock_get_price: MagicMock,
+        interval_setup: Any,
+    ) -> None:
+        """A yearly price configured only in Stripe (Plan.price_yearly
+        NULL) must complete checkout, not crash after session creation."""
+        from core.models import Plan
+        from django.urls import reverse
+
+        Plan.objects.filter(name="pro").update(price_yearly=None)
+        client = interval_setup
+        mock_get_or_create.return_value = {"id": "cus_new"}
+        mock_get_price.return_value = {"id": "price_pro_yearly"}
+        mock_create_session.return_value = {
+            "id": "cs_x",
+            "url": "https://checkout.stripe.com/x",
+        }
+
+        response = client.get(
+            reverse("core:checkout", args=["pro"]), {"interval": "yearly"}
+        )
+
+        assert response.status_code == 302
+        assert response.url == "https://checkout.stripe.com/x"
+
+    @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
+    @patch("core.services.stripe.StripeAPI.create_checkout_session")
+    @patch("core.services.stripe.StripeAPI.get_or_create_customer")
+    def test_checkout_metadata_carries_interval(
+        self,
+        mock_get_or_create: MagicMock,
+        mock_create_session: MagicMock,
+        mock_get_price: MagicMock,
+        interval_setup: Any,
+    ) -> None:
+        """Session metadata records the interval so checkout_success can
+        report the value actually purchased."""
+        from django.urls import reverse
+
+        client = interval_setup
+        mock_get_or_create.return_value = {"id": "cus_new"}
+        mock_get_price.return_value = {"id": "price_pro_yearly"}
+        mock_create_session.return_value = {
+            "id": "cs_x",
+            "url": "https://checkout.stripe.com/x",
+        }
+
+        client.get(reverse("core:checkout", args=["pro"]), {"interval": "yearly"})
+
+        metadata = mock_create_session.call_args.kwargs["metadata"]
+        assert metadata["interval"] == "yearly"
+
+    @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
+    @patch("core.services.stripe.StripeAPI.create_checkout_session")
+    @patch("core.services.stripe.StripeAPI.get_or_create_customer")
     def test_yearly_without_configured_price_errors_cleanly(
         self,
         mock_get_or_create: MagicMock,
@@ -1725,6 +1783,51 @@ class TestYearlyPricingAnnotation:
         assert plans[0]["price_yearly"] == "990"
         assert plans[0]["price_yearly_per_month"] == "82.50"
         assert plans[0]["yearly_savings"] == "198"
+
+    def test_skips_plans_with_null_yearly_price(self) -> None:
+        """A NULL price_yearly (pre-feature rows) must not raise."""
+        from core.models import Plan
+        from core.views.billing import _annotate_yearly_pricing
+
+        Plan.objects.update_or_create(
+            name="legacy",
+            defaults={
+                "display_name": "Legacy",
+                "price_monthly": 49,
+                "price_yearly": None,
+                "is_active": True,
+            },
+        )
+        plans: list[dict[str, Any]] = [{"id": "legacy", "price": "49"}]
+
+        _annotate_yearly_pricing(plans)
+
+        assert "price_yearly" not in plans[0]
+
+    def test_select_plan_renders_with_null_yearly_price(self) -> None:
+        """The plans page must not 500 on a paid plan with NULL
+        price_yearly — the nullable field predates annual pricing."""
+        from core.models import Plan
+        from django.contrib.auth.models import User
+        from django.test import Client
+        from django.urls import reverse
+
+        Plan.objects.update_or_create(
+            name="legacy",
+            defaults={
+                "display_name": "Legacy",
+                "price_monthly": 49,
+                "price_yearly": None,
+                "is_active": True,
+            },
+        )
+        user = User.objects.create_user(username="planless", password="x")
+        client = Client()
+        client.force_login(user)
+
+        response = client.get(reverse("core:select_plan"))
+
+        assert response.status_code == 200
 
     def test_skips_plans_without_yearly_price(self) -> None:
         """No yearly price -> card stays monthly-only, no fake option."""

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -7,6 +7,7 @@ This module contains tests for the Stripe billing features including:
 - Webhook handlers for checkout and billing events
 """
 
+from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1728,6 +1729,46 @@ class TestCheckoutBillingInterval:
         assert response.status_code == 302
         assert response.url == "https://checkout.stripe.com/x"
 
+    @patch("core.services.stripe.StripeAPI.get_price")
+    @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
+    @patch("core.services.stripe.StripeAPI.create_checkout_session")
+    @patch("core.services.stripe.StripeAPI.get_or_create_customer")
+    def test_lookup_miss_with_null_db_price_fetches_amount(
+        self,
+        mock_get_or_create: MagicMock,
+        mock_create_session: MagicMock,
+        mock_get_price_by_key: MagicMock,
+        mock_get_price: MagicMock,
+        interval_setup: Any,
+    ) -> None:
+        """When the yearly amount lives only behind the stored price id,
+        it is fetched so analytics and metadata carry the real value."""
+        from core.models import Plan
+        from django.urls import reverse
+
+        Plan.objects.filter(name="pro").update(price_yearly=None)
+        client = interval_setup
+        mock_get_or_create.return_value = {"id": "cus_new"}
+        mock_get_price_by_key.return_value = None
+        mock_get_price.return_value = {
+            "id": "price_pro_yearly",
+            "unit_amount": 99000,
+            "currency": "usd",
+        }
+        mock_create_session.return_value = {
+            "id": "cs_x",
+            "url": "https://checkout.stripe.com/x",
+        }
+
+        response = client.get(
+            reverse("core:checkout", args=["pro"]), {"interval": "yearly"}
+        )
+
+        assert response.status_code == 302
+        mock_get_price.assert_called_once_with("price_pro_yearly")
+        metadata = mock_create_session.call_args.kwargs["metadata"]
+        assert metadata["amount"] == "990.00"
+
     @patch("core.services.stripe.StripeAPI.get_price_by_lookup_key")
     @patch("core.services.stripe.StripeAPI.create_checkout_session")
     @patch("core.services.stripe.StripeAPI.get_or_create_customer")
@@ -1888,6 +1929,29 @@ class TestYearlyPricingAnnotation:
         assert plans[0]["price_yearly"] == "990"
         assert plans[0]["price_yearly_per_month"] == "82.50"
         assert plans[0]["yearly_savings"] == "198"
+
+    def test_prices_with_cents_keep_their_cents(self) -> None:
+        """Non-whole-dollar prices must not be rounded to whole dollars."""
+        from core.models import Plan
+        from core.views.billing import _annotate_yearly_pricing
+
+        Plan.objects.update_or_create(
+            name="pro",
+            defaults={
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "price_yearly": Decimal("989.50"),
+                "is_active": True,
+                "stripe_price_id_yearly": "price_pro_yearly",
+            },
+        )
+        plans: list[dict[str, Any]] = [{"id": "pro", "price": "99"}]
+
+        _annotate_yearly_pricing(plans)
+
+        assert plans[0]["price_yearly"] == "989.50"
+        # 12 x 99 - 989.50
+        assert plans[0]["yearly_savings"] == "198.50"
 
     def test_savings_use_the_displayed_monthly_price(self) -> None:
         """Savings are consistent with the price shown on the card.


### PR DESCRIPTION
## Summary

UX psychology item #4 (anchoring, with honest numbers): annual pricing existed in the `Plan` table and on the marketing site (notipus.com PR #15), but in-app it was invisible — cards rendered monthly only, checkout was hardwired to monthly price IDs, and the FAQ claimed **"Save 20%"** when the seeded yearly prices are 2 months free (**~17%**).

## Changes

**Checkout can actually charge yearly** (the prerequisite for any honest toggle):
- `checkout` accepts `?interval=yearly`: resolves the `{plan}_yearly` Stripe lookup key, falls back to `Plan.stripe_price_id_yearly` (fetching the amount by price ID when the local row was never backfilled), and **errors with interval-specific messaging instead of silently billing monthly** when no yearly price is configured
- idempotency key includes the interval; before creating a session, the customer's **open checkout sessions are expired** (`StripeAPI.expire_open_checkout_sessions`, paginated) so flipping plan or interval can never leave a stale completable session (double-billing)
- `begin_checkout` and `purchase` report the amount resolved at checkout time — it travels in session metadata so the two events can never disagree

**upgrade_plan**: Yearly/Monthly radiogroup toggle (arrow-key navigation, `aria-checked`) defaulting to **Yearly**, rendered only when at least one plan is actually billable yearly (positive `price_yearly` + stored yearly Stripe price ID). Cards show the per-month equivalent with "$990 billed annually · Save $198" sublines — savings computed against the monthly price the card displays, cents preserved, and no hardcoded discount-ratio claims anywhere.

**select_plan**: shows monthly prices only — a deeper review found its signup funnel is hardwired to monthly price IDs, so this page must not advertise a yearly deal it cannot bill. The FAQ now points to the Billing page (where yearly checkout actually works) instead of claiming "Save 20%" / "all paid plans".

**Cleanup**: removed the dead hidden `workspace_name` input; deduplicated price markup, checkout test scaffolding, and cast ceremony.

## Review provenance

Hardened by 5 Copilot passes + a 24-agent workflow code review (10 verified findings, all fixed): NULL `price_yearly` crashes, 10× under-reported yearly GA4 purchases, dual-session double-billing, advertise-only-when-billable, cross-source savings drift, cents rounding.

## Testing

- `TestCheckoutBillingInterval`, `TestCheckoutSessionExpiry`, `TestYearlyPricingAnnotation` + GA4 purchase-value tests
- Full suite: **1997 passed**; ruff, mypy, djlint clean; screenshot-verified both toggle states and select_plan via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)