### PR TITLE
feat(billing): state real usage and the actual pause point in upgrade prompts

### DIFF
--- a/app/core/services/dashboard.py
+++ b/app/core/services/dashboard.py
@@ -70,7 +70,7 @@ class DashboardService:
             "member": member,
             "integrations": self._get_integration_data(workspace),
             "recent_activity": self._get_recent_activity(workspace),
-            "usage_data": self._get_usage_data(workspace),
+            "usage_data": self.get_usage_data(workspace),
             "trial_info": self._get_trial_info(workspace),
         }
 
@@ -314,15 +314,21 @@ class DashboardService:
 
         return deduplicated
 
-    def _get_usage_data(self, workspace: Workspace) -> dict[str, Any]:
+    def get_usage_data(self, workspace: Workspace) -> dict[str, Any]:
         """Get rate limiting and usage statistics for the workspace.
 
         Args:
             workspace: Workspace model instance.
 
         Returns:
-            Dictionary with usage data and rate limit info.
+            Dictionary with usage data and rate limit info, including
+            pause_at — the event count at which delivery actually stops
+            (the plan limit times its grace multiplier), so upgrade
+            prompts can state the real consequence instead of a vague
+            warning.
         """
+        from core.services.usage_alerts import hard_limit
+
         try:
             # Get rate limit info and usage stats
             is_allowed, rate_limit_info = rate_limiter.check_rate_limit(workspace)
@@ -338,6 +344,7 @@ class DashboardService:
                 "rate_limit_info": rate_limit_info,
                 "usage_stats": usage_stats,
                 "usage_percentage": min(usage_percentage, 100),  # Cap at 100%
+                "pause_at": hard_limit(limit, workspace.subscription_plan),
             }
         except Exception as e:
             logger.error(f"Error getting usage data: {e!s}")
@@ -346,6 +353,7 @@ class DashboardService:
                 "rate_limit_info": {},
                 "usage_stats": {},
                 "usage_percentage": 0,
+                "pause_at": None,
             }
 
     def _get_trial_info(self, workspace: Workspace) -> dict[str, Any]:
@@ -590,7 +598,7 @@ class BillingService:
             Dictionary with billing dashboard information.
         """
         dashboard_service = DashboardService()
-        usage_data = dashboard_service._get_usage_data(workspace)
+        usage_data = dashboard_service.get_usage_data(workspace)
         trial_info = dashboard_service._get_trial_info(workspace)
 
         # Get Stripe subscription info if available

--- a/app/core/templates/core/dashboard.html.j2
+++ b/app/core/templates/core/dashboard.html.j2
@@ -226,7 +226,12 @@
                                     <div class="ml-3">
                                         <h4 class="text-sm font-medium text-red-800">Action Required</h4>
                                         <p class="text-sm text-red-700 mt-1">
-                                            You've used {{ usage_percentage|floatformat:0 }}% of your monthly quota. Upgrade now to avoid service interruption.
+                                            You've used {{ rate_limit_info.current_usage|floatformat:0|intcomma }} of the {{ rate_limit_info.limit|floatformat:0|intcomma }} events in your plan this month.
+                                            {% if pause_at %}
+                                                Delivery stops at {{ pause_at|intcomma }} events until your count resets{% if rate_limit_info.reset_time %} on {{ rate_limit_info.reset_time|date:"M j" }}{% endif %} — upgrade to keep notifications flowing.
+                                            {% else %}
+                                                Upgrade now to keep notifications flowing.
+                                            {% endif %}
                                         </p>
                                     </div>
                                 </div>
@@ -243,7 +248,8 @@
                                     <div class="ml-3">
                                         <h4 class="text-sm font-medium text-yellow-800">Consider Upgrading</h4>
                                         <p class="text-sm text-yellow-700 mt-1">
-                                            You're at {{ usage_percentage|floatformat:0 }}% usage. Consider upgrading for peace of mind.
+                                            You've used {{ rate_limit_info.current_usage|floatformat:0|intcomma }} of the {{ rate_limit_info.limit|floatformat:0|intcomma }} events in your plan this month.
+                                            If you expect more{% if rate_limit_info.reset_time %} before your count resets on {{ rate_limit_info.reset_time|date:"M j" }}{% endif %}, upgrading now avoids any interruption.
                                         </p>
                                     </div>
                                 </div>

--- a/app/core/templates/core/upgrade_plan.html.j2
+++ b/app/core/templates/core/upgrade_plan.html.j2
@@ -1,4 +1,5 @@
 {% extends "core/base.html.j2" %}
+{% load humanize %}
 
 {% block title %}
     Upgrade Plan - Notipus
@@ -32,7 +33,13 @@
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
                     <div class="flex-1 min-w-0">
                         <h3 class="text-lg font-semibold truncate">Current Plan: {{ current_plan|title }}</h3>
-                        <p class="text-primary-100 mt-1 text-sm sm:text-base">Ready to unlock more features and higher limits?</p>
+                        {% if events_used %}
+                            <p class="text-primary-100 mt-1 text-sm sm:text-base">
+                                You've used {{ events_used|intcomma }} of the {{ events_limit|intcomma }} events in your plan this month{% if usage_percentage >= 80 and pause_at %} — delivery stops at {{ pause_at|intcomma }}{% endif %}.
+                            </p>
+                        {% else %}
+                            <p class="text-primary-100 mt-1 text-sm sm:text-base">Ready to unlock more features and higher limits?</p>
+                        {% endif %}
                     </div>
                     <div class="flex items-center mt-4 sm:mt-0 sm:ml-4">
                         <svg class="h-6 w-6 sm:h-8 sm:w-8 text-primary-200"

--- a/app/core/views/billing.py
+++ b/app/core/views/billing.py
@@ -145,7 +145,7 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
         no workspace, or redirect to the dashboard if the user is not an
         owner/admin (permission denied).
     """
-    from core.services.dashboard import BillingService
+    from core.services.dashboard import BillingService, DashboardService
 
     workspace, redirect_response = require_admin_role(request)
     if redirect_response:
@@ -171,6 +171,11 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
 
     _annotate_yearly_pricing(available_plans)
 
+    # Real usage numbers make the banner state actual stakes ("used X of
+    # Y events, delivery stops at Z") instead of a generic pitch.
+    usage_data = DashboardService().get_usage_data(workspace)
+    rate_limit_info = usage_data.get("rate_limit_info") or {}
+
     context: dict[str, Any] = {
         "workspace": workspace,
         "plans": available_plans,
@@ -178,6 +183,10 @@ def upgrade_plan(request: HttpRequest) -> HttpResponse | HttpResponseRedirect:
         # The interval toggle only renders when at least one card can
         # actually be billed yearly — no dead controls.
         "has_yearly_plans": any("price_yearly" in plan for plan in available_plans),
+        "events_used": rate_limit_info.get("current_usage"),
+        "events_limit": rate_limit_info.get("limit"),
+        "usage_percentage": usage_data.get("usage_percentage", 0),
+        "pause_at": usage_data.get("pause_at"),
     }
     return render(request, "core/upgrade_plan.html.j2", context)
 

--- a/tests/core/tests_services.py
+++ b/tests/core/tests_services.py
@@ -832,10 +832,31 @@ class DashboardServiceTest(TestCase):
         mock_rate_limiter.get_usage_stats.return_value = {"monthly": []}
 
         service = DashboardService()
-        result = service._get_usage_data(self.workspace)
+        result = service.get_usage_data(self.workspace)
 
         self.assertTrue(result["is_allowed"])
         self.assertEqual(result["usage_percentage"], 50.0)
+
+    @patch("core.services.dashboard.rate_limiter")
+    def test_get_usage_data_includes_pause_point(self, mock_rate_limiter) -> None:
+        """Usage data carries the count at which delivery actually stops.
+
+        The default grace multiplier is 2x the plan limit, so upgrade
+        prompts can state the real consequence instead of a vague
+        warning.
+        """
+        from core.services.dashboard import DashboardService
+
+        mock_rate_limiter.check_rate_limit.return_value = (
+            True,
+            {"current_usage": 18, "limit": 20, "remaining": 2},
+        )
+        mock_rate_limiter.get_usage_stats.return_value = {"monthly": []}
+
+        service = DashboardService()
+        result = service.get_usage_data(self.workspace)
+
+        self.assertEqual(result["pause_at"], 40)
 
     @patch("core.services.dashboard.rate_limiter")
     def test_get_usage_data_error_handling(self, mock_rate_limiter):
@@ -845,11 +866,12 @@ class DashboardServiceTest(TestCase):
         mock_rate_limiter.check_rate_limit.side_effect = Exception("Redis error")
 
         service = DashboardService()
-        result = service._get_usage_data(self.workspace)
+        result = service.get_usage_data(self.workspace)
 
         # Should return default values on error
         self.assertTrue(result["is_allowed"])
         self.assertEqual(result["usage_percentage"], 0)
+        self.assertIsNone(result["pause_at"])
 
     @patch("core.services.dashboard.DatabaseLookupService")
     def test_transform_activity_data(self, mock_db_service):

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -1904,6 +1904,69 @@ class TestCheckoutSessionExpiry:
 
 
 @pytest.mark.django_db
+class TestUpgradePlanUsageContext:
+    """The upgrade banner states real usage, not a generic pitch."""
+
+    @patch("core.services.dashboard.rate_limiter")
+    def test_upgrade_page_carries_real_usage(
+        self, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Context and copy carry the workspace's actual event counts
+        and the count at which delivery stops."""
+        from django.urls import reverse
+
+        client, _workspace = _checkout_owner_client(
+            "uma",
+            {
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "is_active": True,
+                "stripe_price_id_monthly": "price_pro_monthly",
+            },
+        )
+        mock_rate_limiter.check_rate_limit.return_value = (
+            True,
+            {"current_usage": 16, "limit": 20},
+        )
+        mock_rate_limiter.get_usage_stats.return_value = {}
+
+        response = client.get(reverse("core:upgrade_plan"))
+
+        assert response.status_code == 200
+        assert response.context["events_used"] == 16
+        assert response.context["events_limit"] == 20
+        assert response.context["pause_at"] == 40
+        assert b"used 16 of the 20 events" in response.content
+
+    @patch("core.services.dashboard.rate_limiter")
+    def test_zero_usage_keeps_generic_banner(
+        self, mock_rate_limiter: MagicMock
+    ) -> None:
+        """With no events yet there are no numbers to state."""
+        from django.urls import reverse
+
+        client, _workspace = _checkout_owner_client(
+            "uma",
+            {
+                "display_name": "Pro",
+                "price_monthly": 99,
+                "is_active": True,
+                "stripe_price_id_monthly": "price_pro_monthly",
+            },
+        )
+        mock_rate_limiter.check_rate_limit.return_value = (
+            True,
+            {"current_usage": 0, "limit": 20},
+        )
+        mock_rate_limiter.get_usage_stats.return_value = {}
+
+        response = client.get(reverse("core:upgrade_plan"))
+
+        assert response.status_code == 200
+        assert b"Ready to unlock more features" in response.content
+
+
+@pytest.mark.django_db
 class TestYearlyPricingAnnotation:
     """Plan cards gain yearly display fields from the Plan table."""
 


### PR DESCRIPTION
## Summary

UX psychology item #5 (loss aversion with provable stakes) — the **last item** on the list. Upgrade prompts were generic gain-framing ("Ready to unlock more features and higher limits?", "Consider upgrading for peace of mind") while the real stakes were provable from data already at hand.

## Changes

- `DashboardService.get_usage_data` (promoted from `_get_usage_data`, which `BillingService` was already reaching into cross-class) now includes **`pause_at`** — the count at which delivery actually stops (plan limit × grace multiplier), the same number the shipped soft-limit emails state.
- **Dashboard ≥95% banner**: "You've used 19 of the 20 events in your plan this month. Delivery stops at 40 events until your count resets on Jul 31 — upgrade to keep notifications flowing."
- **Dashboard ≥80% banner**: names the counts and reset date; "peace of mind" filler removed.
- **Upgrade page banner**: shows the workspace's own numbers ("used 19 of the 20 events — delivery stops at 40" once usage ≥80%); the generic aspirational line remains only when there is no usage to report.

Every number comes from the rate limiter and Plan rows — nothing is shown that the data doesn't prove, consistent with the project's no-guessed-data rule and the usage-alert emails' language.

## Testing

- `pause_at` computation + error-path tests; `TestUpgradePlanUsageContext` (real numbers in context and copy, generic banner at zero usage)
- Full suite: **2001 passed**; ruff, mypy, djlint clean; both surfaces screenshot-verified via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)