### PR TITLE
fix(stripe): carry guest-checkout identity from customer_details

### DIFF
--- a/app/plugins/sources/stripe.py
+++ b/app/plugins/sources/stripe.py
@@ -1170,6 +1170,12 @@ class StripeSourcePlugin(BaseSourcePlugin):
             else:
                 data_dict = dict(data)
 
+            # Checkout sessions carry buyer identity in customer_details —
+            # even guest checkouts with no Customer object. Hoist it to the
+            # flat fields get_customer_data reads, so those notifications
+            # and dashboard records are not anonymous.
+            self._hoist_checkout_customer_details(data_dict)
+
             # Get customer ID - some events may not require one
             # (checkout sessions use metadata for organization lookup)
             customer_id = str(data_dict.get("customer", "") or "")
@@ -1207,6 +1213,34 @@ class StripeSourcePlugin(BaseSourcePlugin):
 
         except (KeyError, ValueError, AttributeError) as e:
             raise InvalidDataError("Missing required fields") from e
+
+    def _hoist_checkout_customer_details(self, data_dict: dict[str, Any]) -> None:
+        """Copy checkout-session customer_details into the flat fields.
+
+        checkout.session.completed payloads put the buyer's email and name
+        in a nested ``customer_details`` object, and for guest checkouts
+        (payment mode, no Customer created) that nested object is the ONLY
+        identity in the payload. get_customer_data reads the flat
+        ``customer_email``/``customer_name`` keys, so without this hoist a
+        guest checkout produces an anonymous notification.
+
+        Existing flat values win: they are set explicitly at session
+        creation and customer_details merely echoes them.
+
+        Args:
+            data_dict: The event object dict, mutated in place.
+        """
+        details = data_dict.get("customer_details")
+        if not isinstance(details, dict):
+            return
+
+        email = details.get("email")
+        if not data_dict.get("customer_email") and isinstance(email, str):
+            data_dict["customer_email"] = email
+
+        name = details.get("name")
+        if not data_dict.get("customer_name") and isinstance(name, str):
+            data_dict["customer_name"] = name
 
     def get_customer_data(self, customer_id: str) -> dict[str, Any]:
         """Get customer data from stored webhook payload.

--- a/app/webhooks/services/database_lookup.py
+++ b/app/webhooks/services/database_lookup.py
@@ -390,6 +390,31 @@ class DatabaseLookupService:
 
         cache.set(activity_key, json.dumps(current_activity), timeout=self.ttl_seconds)
 
+    def _customer_display_key(
+        self, event_data: dict[str, Any], notification: RichNotification
+    ) -> str:
+        """Customer identifier for the dashboard record.
+
+        Guest checkouts (checkout.session.completed in payment mode) have
+        no Stripe Customer object; fall back to the payload-proven email
+        from the notification instead of dropping the event from the
+        activity feed.
+
+        Args:
+            event_data: The event data dictionary.
+            notification: The built RichNotification.
+
+        Returns:
+            The customer id, the customer email, or empty string if the
+            event carries no identity at all.
+        """
+        customer_id = event_data.get("customer_id")
+        if customer_id:
+            return str(customer_id)
+        if notification.customer and notification.customer.email:
+            return str(notification.customer.email)
+        return ""
+
     def store_enriched_record(
         self,
         event_data: dict[str, Any],
@@ -421,7 +446,7 @@ class DatabaseLookupService:
                 or event_data.get("transaction_id")
                 or event_data.get("id")
             )
-            customer_id = event_data.get("customer_id")
+            customer_id = self._customer_display_key(event_data, notification)
             if not customer_id:
                 logger.warning(
                     f"Missing customer_id in event: {event_data.get('type')}"

--- a/app/webhooks/services/database_lookup.py
+++ b/app/webhooks/services/database_lookup.py
@@ -449,7 +449,8 @@ class DatabaseLookupService:
             customer_id = self._customer_display_key(event_data, notification)
             if not customer_id:
                 logger.warning(
-                    f"Missing customer_id in event: {event_data.get('type')}"
+                    f"No customer identity (id or email) in event: "
+                    f"{event_data.get('type')}"
                 )
                 return False
 

--- a/tests/test_enriched_storage.py
+++ b/tests/test_enriched_storage.py
@@ -191,15 +191,41 @@ class TestStoreEnrichedRecord:
         mock_cache.set.assert_not_called()
 
     @patch("webhooks.services.database_lookup.cache")
-    def test_store_enriched_record_missing_customer_id(
+    def test_store_enriched_record_missing_customer_id_uses_email(
         self,
         mock_cache: MagicMock,
         db_service: DatabaseLookupService,
         workspace_id: str,
         sample_notification: RichNotification,
     ) -> None:
-        """Test storage fails gracefully when customer_id is missing."""
+        """Missing customer_id falls back to the notification's email.
+
+        Guest checkouts (checkout.session.completed in payment mode) have
+        no Stripe Customer object; the payload-proven email keys the
+        dashboard record instead of the event being dropped.
+        """
+        mock_cache.get.return_value = []
+        event_data = {"type": "checkout_completed", "provider": "stripe"}
+
+        result = db_service.store_enriched_record(
+            event_data, sample_notification, workspace_id=workspace_id
+        )
+
+        assert result is True
+        stored = decrypt_cache_value(mock_cache.set.call_args_list[0][0][1])
+        assert stored["customer_id"] == "billing@acme.com"
+
+    @patch("webhooks.services.database_lookup.cache")
+    def test_store_enriched_record_no_identity_at_all(
+        self,
+        mock_cache: MagicMock,
+        db_service: DatabaseLookupService,
+        workspace_id: str,
+        sample_notification: RichNotification,
+    ) -> None:
+        """Test storage fails gracefully when there is no identity at all."""
         event_data = {"type": "payment_success", "provider": "stripe"}
+        sample_notification.customer = None
 
         result = db_service.store_enriched_record(
             event_data, sample_notification, workspace_id=workspace_id

--- a/tests/test_stripe_realistic_scenarios.py
+++ b/tests/test_stripe_realistic_scenarios.py
@@ -1652,3 +1652,86 @@ class TestPaymentFailureNotFiltered:
         # Headlines are event-focused (no company name)
         assert "failed" in notification.headline.lower()
         assert "$99.00" in notification.headline
+
+
+class TestGuestCheckoutIdentity:
+    """Integration test: guest checkout (payment mode, no Customer object).
+
+    checkout.session.completed for a guest checkout has customer=None and
+    the buyer's identity only in the nested customer_details object. Seen
+    in prod: these events produced anonymous notifications and were
+    dropped from the dashboard activity feed entirely.
+    """
+
+    @pytest.fixture
+    def stripe_plugin(self) -> StripeSourcePlugin:
+        """Create a Stripe plugin instance."""
+        return StripeSourcePlugin()
+
+    @pytest.fixture
+    def guest_checkout_session(self) -> dict[str, Any]:
+        """checkout.session.completed object for a guest checkout."""
+        return {
+            "id": "cs_test_a1b2c3",
+            "object": "checkout.session",
+            "customer": None,
+            "customer_email": None,
+            "customer_details": {
+                "email": "guest@example.com",
+                "name": "Guest Buyer",
+            },
+            "amount_total": 4900,
+            "currency": "usd",
+            "mode": "payment",
+            "status": "complete",
+            "created": 1769327717,
+        }
+
+    def test_customer_details_hoisted_to_flat_fields(
+        self,
+        stripe_plugin: StripeSourcePlugin,
+        guest_checkout_session: dict[str, Any],
+    ) -> None:
+        """The nested customer_details identity lands in the flat fields."""
+        stripe_plugin._hoist_checkout_customer_details(guest_checkout_session)
+
+        assert guest_checkout_session["customer_email"] == "guest@example.com"
+        assert guest_checkout_session["customer_name"] == "Guest Buyer"
+
+    def test_explicit_flat_fields_are_not_overwritten(
+        self, stripe_plugin: StripeSourcePlugin
+    ) -> None:
+        """A customer_email set at session creation wins over the echo."""
+        data = {
+            "customer_email": "explicit@example.com",
+            "customer_details": {"email": "details@example.com", "name": "N"},
+        }
+
+        stripe_plugin._hoist_checkout_customer_details(data)
+
+        assert data["customer_email"] == "explicit@example.com"
+
+    def test_non_dict_and_null_customer_details_are_ignored(
+        self, stripe_plugin: StripeSourcePlugin
+    ) -> None:
+        """Events without a usable customer_details object are untouched."""
+        for details in (None, "str", 42, ["list"]):
+            data = {"customer_details": details}
+            stripe_plugin._hoist_checkout_customer_details(data)
+            assert "customer_email" not in data
+            assert "customer_name" not in data
+
+    def test_get_customer_data_returns_guest_identity(
+        self,
+        stripe_plugin: StripeSourcePlugin,
+        guest_checkout_session: dict[str, Any],
+    ) -> None:
+        """After the hoist, the customer lookup yields the buyer identity."""
+        stripe_plugin._hoist_checkout_customer_details(guest_checkout_session)
+        stripe_plugin._current_webhook_data = guest_checkout_session
+
+        customer_data = stripe_plugin.get_customer_data("")
+
+        assert customer_data["email"] == "guest@example.com"
+        assert customer_data["first_name"] == "Guest"
+        assert customer_data["last_name"] == "Buyer"


### PR DESCRIPTION
## Problem

The new tenant (`794365fc`) sends `checkout.session.completed` events from **guest checkouts** (payment mode, no Stripe Customer object). Seen twice in prod logs (July 25, 07:19 and 10:34 UTC):

```
Missing customer_id in event: checkout_completed
```

For these events the buyer's identity lives only in the nested `customer_details` object, which the parser never read. Result: the Slack notification goes out **anonymous**, and the event is **dropped from the dashboard activity feed** entirely.

## Fix

Both changes use only payload-proven data (no guessing):

- `stripe.py`: new `_hoist_checkout_customer_details` copies `customer_details.email`/`.name` into the flat `customer_email`/`customer_name` fields that `get_customer_data` reads. Explicit flat values win (they're set at session creation; `customer_details` merely echoes them). Mirrors nothing new architecturally — it feeds the existing lookup.
- `database_lookup.py`: `store_enriched_record` keys the dashboard record by the notification's email when `customer_id` is absent (extracted into `_customer_display_key`), instead of dropping the event. Events with no identity at all are still skipped.

## Testing

- New `TestGuestCheckoutIdentity` covering the hoist (guest session, explicit-fields-win, malformed `customer_details`) and end-to-end `get_customer_data` identity.
- Updated enriched-storage tests: email fallback stores the record; no-identity events still skip.
- Full suite: 2018 passed. mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3k1yqkAbEm2A5nFvE4p4m